### PR TITLE
text_classification: fix google storage URLs

### DIFF
--- a/examples/text_classification/android/app/download_model.gradle
+++ b/examples/text_classification/android/app/download_model.gradle
@@ -1,11 +1,11 @@
 tasks.register('downloadMobileBertModel', Download) {
-    src 'https://storage.googleapis.com/ai-edge/interpreter-samples/textclassification/android/bert_classifier.tflite'
+    src 'https://storage.googleapis.com/ai-edge/interpreter-samples/text_classification/android/bert_classifier.tflite'
     dest project.ext.ASSET_DIR + '/mobile_bert.tflite'
     overwrite false
 }
 
 tasks.register('downloadWordVecModel', Download) {
-    src 'https://storage.googleapis.com/ai-edge/interpreter-samples/textclassification/android/average_word_classifier.tflite'
+    src 'https://storage.googleapis.com/ai-edge/interpreter-samples/text_classification/android/average_word_classifier.tflite'
     dest project.ext.ASSET_DIR + '/word_vec.tflite'
     overwrite false
 }


### PR DESCRIPTION
Current URLs were throwing a 404, seems like there was a missing underscore. 