### PR TITLE
Android - super_resolution : Correct image orientation for portrait images on selection

### DIFF
--- a/examples/super_resolution/android/app/build.gradle.kts
+++ b/examples/super_resolution/android/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.litert.api)
     implementation(libs.google.litert)
+    implementation(libs.androidx.exifinterface)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/examples/super_resolution/android/app/src/main/java/com/google/aiedge/examples/super_resolution/gallery/ImagePickerHelper.kt
+++ b/examples/super_resolution/android/app/src/main/java/com/google/aiedge/examples/super_resolution/gallery/ImagePickerHelper.kt
@@ -1,0 +1,131 @@
+package com.google.aiedge.examples.super_resolution.gallery
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import androidx.exifinterface.media.ExifInterface
+import android.net.Uri
+import android.util.Log
+import java.io.IOException
+
+/*
+ * Represents the result of an image orientation correction operation.
+ */
+sealed class OrientationResult {
+    /**
+     * Indicates that the orientation correction was successful.
+     *
+     * @param bitmap The corrected bitmap.
+     */
+    data class Success(val bitmap: Bitmap) : OrientationResult()
+
+    /**
+     * Indicates that an error occurred during orientation correction.
+     *
+     * @param exception The exception that was thrown.
+     */
+    data class Error(val exception: Exception) : OrientationResult()
+}
+
+/**
+ * Utility class for handling image orientation correction.
+ */
+object ImagePickerHelper {
+
+    /**
+     * Modifies the orientation of a bitmap based on the Exif information in the input stream.
+     *
+     * @param bitmap The bitmap to modify.
+     * @param inputStream The input stream containing the image data.
+     * @return The corrected bitmap.
+     */
+    fun modifyOrientation(
+        bitmap: Bitmap,
+        contentResolver: ContentResolver,
+        uri: Uri
+    ): OrientationResult {
+        try {
+            contentResolver.openInputStream(uri).use { inputStream ->
+                if (inputStream == null) {
+                    throw IOException(NullPointerException("Input stream is null"))
+                }
+                val exif: ExifInterface = ExifInterface(inputStream)
+                val orientation = exif.getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL
+                )
+                return when (orientation) {
+                    ExifInterface.ORIENTATION_ROTATE_90 -> OrientationResult.Success(
+                        rotateImage(
+                            bitmap,
+                            90f
+                        )
+                    )
+
+                    ExifInterface.ORIENTATION_ROTATE_180 -> OrientationResult.Success(
+                        rotateImage(
+                            bitmap,
+                            180f
+                        )
+                    )
+
+                    ExifInterface.ORIENTATION_ROTATE_270 -> OrientationResult.Success(
+                        rotateImage(
+                            bitmap,
+                            270f
+                        )
+                    )
+
+                    ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> OrientationResult.Success(
+                        flipImage(
+                            bitmap,
+                            true,
+                            false
+                        )
+                    )
+
+                    ExifInterface.ORIENTATION_FLIP_VERTICAL -> OrientationResult.Success(
+                        flipImage(
+                            bitmap,
+                            false,
+                            true
+                        )
+                    )
+
+                    else -> OrientationResult.Success(bitmap)
+                }
+            }
+        } catch (e: IOException) {
+            Log.e("ImagePickerHelper", "Error in modifyOrientation: ${e.message}", e)
+            return OrientationResult.Error(e)
+        }
+    }
+
+    /**
+     * Rotates a bitmap by the specified degrees.
+     *
+     * @param bitmap The bitmap to rotate.
+     * @param degrees The angle in degrees to rotate the bitmap.
+     * @return The rotated bitmap.
+     */
+    fun rotateImage(bitmap: Bitmap, degrees: Float): Bitmap {
+        val matrix = Matrix()
+        matrix.postRotate(degrees)
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    }
+
+    /**
+     * Flips a bitmap horizontally or vertically.
+     *
+     * @param bitmap The bitmap to flip.
+     * @param horizontal Whether to flip the bitmap horizontally.
+     * @param vertical Whether to flip the bitmap vertically.
+     * @return The flipped bitmap.
+     */
+    fun flipImage(bitmap: Bitmap, horizontal: Boolean, vertical: Boolean): Bitmap {
+        val matrix = Matrix()
+        matrix.preScale((if (horizontal) -1 else 1).toFloat(), (if (vertical) -1 else 1).toFloat())
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    }
+}
+

--- a/examples/super_resolution/android/app/src/main/java/com/google/aiedge/examples/super_resolution/gallery/ImagePickerScreen.kt
+++ b/examples/super_resolution/android/app/src/main/java/com/google/aiedge/examples/super_resolution/gallery/ImagePickerScreen.kt
@@ -93,7 +93,11 @@ fun ImagePickerScreen(
                 val contentResolver = context.contentResolver
                 val inputStream: InputStream? = contentResolver.openInputStream(uri)
                 val bitmap = BitmapFactory.decodeStream(inputStream)
-                viewModel.selectImage(bitmap)
+                when (val convertedBitmap =
+                    ImagePickerHelper.modifyOrientation(bitmap, contentResolver, uri)) {
+                    is OrientationResult.Success -> viewModel.selectImage(convertedBitmap.bitmap)
+                    is OrientationResult.Error -> viewModel.selectImage(bitmap)
+                }
             }
         }
 

--- a/examples/super_resolution/android/gradle/libs.versions.toml
+++ b/examples/super_resolution/android/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ cameraCore = "1.3.3"
 compose = "1.3.0"
 litertApi = "1.0.1"
 litertVersion = "1.0.1"
+exifinterface = "1.3.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -45,6 +46,7 @@ androidx-camera-view = { group = "androidx.camera", name = "camera-view", versio
 androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "cameraCore" }
 litert-api = { group = "com.google.ai.edge.litert", name = "litert-api", version.ref = "litertApi" }
 google-litert = { group = "com.google.ai.edge.litert", name = "litert", version.ref = "litertVersion" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request fixes an issue where images selected from the Photo Picker, especially portrait-oriented ones, were displayed with incorrect orientation.

**Changes:**

- Implemented orientation correction using `ExifInterface` to read image orientation and apply necessary rotations/flips in `ImagePickerHelper`.
- Added error handling to `modifyOrientation` for potential Exif data issues.
- Updated `ImagePickerScreen` to use `ImagePickerHelper` for orientation correction and handle results.

**Benefits:**

- Images selected from the Photo Picker will now display with the correct orientation.
- Improved robustness and error handling during image loading.
- Images can now be properly tested for super resolution.

**Testing:**

Verified fix by selecting images with different orientations and observing correct display.