### PR TITLE
fix run issue on image_segmentation_gpu

### DIFF
--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/build.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/build.gradle.kts
@@ -29,12 +29,12 @@ plugins {
 
 android {
   namespace = "com.google.ai.edge.examples.image_segmentation"
-  compileSdk = 34
+  compileSdk = 36
 
   defaultConfig {
     applicationId = "com.google.ai.edge.examples.image_segmentation"
     minSdk = 23
-    targetSdk = 33
+    targetSdk = 36
     versionCode = 1
     versionName = "1.0"
 

--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/view/GalleryScreen.kt
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/view/GalleryScreen.kt
@@ -103,7 +103,7 @@ fun GalleryScreen(
                     // Use the imageLoader extension property on Context
                     imageLoader = LocalContext.current.imageLoader,
                     onSuccess = { result ->
-                        val coilImage = (result as SuccessResult).image
+                        val coilImage = (result.result).image
                         val drawable = coilImage.asDrawable(context.resources)
                         val bitmap = (drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
 


### PR DESCRIPTION
- Class force cast error 

`java.lang.ClassCastException: coil3.compose.AsyncImagePainter$State$Success cannot be cast to coil3.request.SuccessResult`

- compile sdk error 

```
29 issues were found when checking AAR metadata:

  1.  Dependency 'androidx.navigationevent:navigationevent-android:1.0.1' requires libraries and applications that
      depend on it to compile against version 36 or later of the
      Android APIs.

      :app is currently compiled against android-34.

      Recommended action: Update this project to use a newer compileSdk
      of at least 36, for example 36.

      Note that updating a library or application's compileSdk (which
      allows newer APIs to be used) can be done separately from updating
      targetSdk (which opts the app in to new runtime behavior) and
      minSdk (which determines which devices the app can be installed
      on).
```