### PR TITLE
Fix crash when switching from NPU to GPU delegate

### DIFF
--- a/compiled_model_api/image_segmentation/kotlin_npu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/ImageSegmentationHelper.kt
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/ImageSegmentationHelper.kt
@@ -105,9 +105,11 @@ class ImageSegmentationHelper(private val context: Context) {
 
       withContext(singleThreadDispatcher) {
         val options = CompiledModel.Options(aiPackModelProvider.getCompatibleAccelerators()).apply {
-          qualcommOptions = CompiledModel.QualcommOptions(
-            htpPerformanceMode = CompiledModel.QualcommOptions.HtpPerformanceMode.HIGH_PERFORMANCE
-          )
+          if (acceleratorEnum == AcceleratorEnum.NPU) {
+            qualcommOptions = CompiledModel.QualcommOptions(
+              htpPerformanceMode = CompiledModel.QualcommOptions.HtpPerformanceMode.HIGH_PERFORMANCE
+            )
+          }
         }
         val model =
           if (aiPackModelProvider.getType() == ModelProvider.Type.ASSET) {
@@ -115,13 +117,13 @@ class ImageSegmentationHelper(private val context: Context) {
               context.assets,
               aiPackModelProvider.getPath(),
               options,
-              env,
+              if (acceleratorEnum == AcceleratorEnum.NPU) env else null,
             )
           } else {
             CompiledModel.create(
               aiPackModelProvider.getPath(),
               options,
-              env,
+              if (acceleratorEnum == AcceleratorEnum.NPU) env else null,
             )
           }
         segmenter = Segmenter(model, coloredLabels)


### PR DESCRIPTION
Ensure NPU-specific configurations in `ImageSegmentationHelper.kt` are only applied when the NPU accelerator is selected, preventing initialization failures on GPU.