### PR TITLE
Upgrade litert to v2.1.4 in image segmentation android starter app

### DIFF
--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android_starter/app/build.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android_starter/app/build.gradle.kts
@@ -29,11 +29,11 @@ plugins {
 
 android {
   namespace = "com.google.ai.edge.examples.image_segmentation"
-  compileSdk = 34
+  compileSdk = 36
 
   defaultConfig {
     applicationId = "com.google.ai.edge.examples.image_segmentation"
-    minSdk = 21
+    minSdk = 23
     targetSdk = 33
     versionCode = 1
     versionName = "1.0"

--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android_starter/app/src/main/java/com/google/ai/edge/examples/image_segmentation/view/GalleryScreen.kt
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android_starter/app/src/main/java/com/google/ai/edge/examples/image_segmentation/view/GalleryScreen.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.graphics.drawable.toBitmap
-import coil.compose.AsyncImage
-import coil.imageLoader
+import coil3.asDrawable
+import coil3.compose.AsyncImage
+import coil3.imageLoader
+import coil3.request.SuccessResult
 import com.google.ai.edge.examples.image_segmentation.UiState
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
@@ -99,9 +101,14 @@ fun GalleryScreen(
           model = uri,
           contentDescription = null,
           imageLoader = LocalContext.current.imageLoader,
-          onSuccess = {
-            val bimap = it.result.drawable.toBitmap()
-            onImageAnalyzed(bimap)
+          onSuccess = { result ->
+            val coilImage = (result as SuccessResult).image
+            val drawable = coilImage.asDrawable(context.resources)
+            val bitmap = (drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
+
+            bitmap?.let {
+              onImageAnalyzed(it)
+            }
           },
           contentScale = ContentScale.Crop,
         )

--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android_starter/gradle/libs.versions.toml
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android_starter/gradle/libs.versions.toml
@@ -14,28 +14,28 @@
 
 
 [versions]
-agp = "8.10.0"
-coilCompose = "2.6.0"
-kotlin = "2.1.0"
-coreKtx = "1.13.0"
+agp = "8.9.1"
+coilCompose = "3.3.0"
+kotlin = "2.2.21"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.1.5"
+junitVersion = "1.2.1"
 espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.7.0"
-activityCompose = "1.9.0"
-composeBom = "2023.08.00"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.12.1"
+composeBom = "2025.12.00"
 undercouchDownload = "5.6.0"
-litert = "2.0.0-alpha"
-cameraCore = "1.3.3"
-compose = "1.3.0"
-composeLivedata = "1.5.4"
+litert = "2.1.4"
+cameraCore = "1.5.2"
+compose = "1.5.0"
+composeLivedata = "1.9.4"
 aiDelivery = "0.1.1-alpha01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Upgrade litert to v2.1.4, dependencies, update SDK versions, and migrate Coil to version 3 in image segmentation android starter app