### PR TITLE
Add Intel NPU support for C++ image segmentation sample on Windows

### DIFF
--- a/.bazelrc.user
+++ b/.bazelrc.user
@@ -1,6 +1,9 @@
-build --incompatible_enable_apple_toolchain_resolution
-build --apple_crosstool_top=@build_bazel_apple_support//crosstool:toolchain
-build --crosstool_top=@build_bazel_apple_support//crosstool:toolchain
-build --host_crosstool_top=@build_bazel_apple_support//crosstool:toolchain
-build --action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
-build --action_env=SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
+# macOS-specific Apple toolchain settings.
+# These are scoped to build:macos so they only apply on macOS
+# (via --enable_platform_specific_config in .bazelrc).
+build:macos --incompatible_enable_apple_toolchain_resolution
+build:macos --apple_crosstool_top=@build_bazel_apple_support//crosstool:toolchain
+build:macos --crosstool_top=@build_bazel_apple_support//crosstool:toolchain
+build:macos --host_crosstool_top=@build_bazel_apple_support//crosstool:toolchain
+build:macos --action_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+build:macos --action_env=SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk

--- a/.litert_configure.bazelrc
+++ b/.litert_configure.bazelrc
@@ -1,0 +1,2 @@
+# Auto-generated LiteRT configure file for Windows build.
+# This file is imported by .bazelrc and must exist.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,10 @@ http_archive(
     patch_cmds = [
         "sed 's|//litert|@litert_archive//litert|g' litert/build_common/special_rule.bzl > litert/build_common/special_rule.bzl.tmp && mv litert/build_common/special_rule.bzl.tmp litert/build_common/special_rule.bzl",
         "sed 's|@//third_party|@litert_archive//third_party|g' third_party/litert_prebuilts/workspace.bzl > third_party/litert_prebuilts/workspace.bzl.tmp && mv third_party/litert_prebuilts/workspace.bzl.tmp third_party/litert_prebuilts/workspace.bzl",
+        # Windows: inject windows_export_all_symbols feature into cc_shared_library for DLL builds.
+        "sed -i 's/cc_shared_library(/cc_shared_library(\\n    features = [\"windows_export_all_symbols\"],/g' litert/c/BUILD",
+        # Windows: define the missing static constant kValueNotSet needed by MSVC linker.
+        "echo 'namespace tflite { namespace profiling { namespace memory { constexpr size_t MemoryUsage::kValueNotSet; } } }' >> tflite/profiling/memory_info.cc",
     ],
 )
 

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/BUILD
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/BUILD
@@ -103,6 +103,38 @@ cc_binary(
     ],
 )
 
+# Intel NPU segmentation target with no OpenGL/EGL dependency.
+# Intended for Windows desktop with Intel NPU via OpenVINO.
+cc_binary(
+    name = "cpp_segmentation_npu_intel",
+    srcs = [
+        "main_npu_no_gl.cc",
+    ],
+    copts = [
+        "-I.",
+    ],
+    data = [
+        ":model_files",
+        ":test_images",
+        "@litert_archive//litert/vendors/intel_openvino/compiler:LiteRtCompilerPlugin",
+        "@litert_archive//litert/vendors/intel_openvino/dispatch:LiteRtDispatch",
+        "@intel_openvino//:openvino/runtime/bin/intel64/Release/openvino.dll",
+        "@intel_openvino//:openvino/runtime/bin/intel64/Release/openvino_tensorflow_lite_frontend.dll",
+        "@intel_openvino//:openvino/runtime/bin/intel64/Release/openvino_intel_npu_plugin.dll",
+        "@intel_openvino//:openvino/runtime/bin/intel64/Release/openvino_intel_npu_compiler.dll",
+        "@intel_openvino//:openvino/runtime/bin/intel64/Release/openvino_auto_plugin.dll",
+        "@intel_openvino//:openvino/runtime/3rdparty/tbb/bin/tbb12.dll",
+    ],
+    deps = [
+        ":image_utils",
+        ":timing_utils",
+        "@litert_archive//litert/cc:litert_api_with_dynamic_runtime",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
 cc_binary(
     name = "cpp_segmentation_gpu",
     srcs = [

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/BUILD
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/BUILD
@@ -79,6 +79,30 @@ cc_binary(
     ] + gles_deps() + gl_native_deps(),
 )
 
+# CPU-only segmentation target with no OpenGL/EGL dependency.
+# Intended for platforms where GLES compute shaders are unavailable (e.g. Windows).
+cc_binary(
+    name = "cpp_segmentation_cpu_no_gl",
+    srcs = [
+        "main_cpu_no_gl.cc",
+    ],
+    copts = [
+        "-I.",
+    ],
+    data = [
+        ":model_files",
+        ":test_images",
+    ],
+    deps = [
+        ":image_utils",
+        ":timing_utils",
+        "@litert_archive//litert/cc:litert_api_with_dynamic_runtime",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
 cc_binary(
     name = "cpp_segmentation_gpu",
     srcs = [

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/image_utils.h
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/image_utils.h
@@ -20,6 +20,12 @@
 #include <string>
 #include <vector>
 
+// On Windows, windows.h (pulled in transitively) defines LoadImage as a macro
+// (LoadImageA / LoadImageW). This collides with ImageUtils::LoadImage.
+#ifdef LoadImage
+#undef LoadImage
+#endif
+
 struct RGBAColor {
   float r, g, b, a;
 };

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/main_cpu_no_gl.cc
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/main_cpu_no_gl.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CPU-only version of the image segmentation sample that does not depend on
+// OpenGL/EGL. This is intended for platforms where GLES compute shaders are
+// unavailable (e.g. Windows desktop).
+//
+// All image pre/post-processing is performed using the pure-CPU helpers already
+// provided by ImageUtils.
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/time/clock.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/c/litert_common.h"
+#include "litert/cc/litert_common.h"
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_macros.h"
+#include "litert/cc/litert_model.h"
+#include "compiled_model_api/image_segmentation/c++_segmentation/build_from_source/image_utils.h"
+#include "compiled_model_api/image_segmentation/c++_segmentation/build_from_source/timing_utils.h"
+
+int main(int argc, char* argv[]) {
+  if (argc != 4) {
+    std::cerr << "Usage: " << argv[0]
+              << " <model_path> <input_image_path> <output_image_path>"
+              << std::endl;
+    return 1;
+  }
+
+  const std::string model_path = argv[1];
+  const std::string input_file = argv[2];
+  const std::string output_file = argv[3];
+
+  std::vector<RGBAColor> mask_colors = {
+      {1.0f, 0.0f, 0.0f, 0.1f}, {0.0f, 1.0f, 0.0f, 0.1f},
+      {0.0f, 0.0f, 1.0f, 0.1f}, {1.0f, 1.0f, 0.0f, 0.1f},
+      {1.0f, 0.0f, 1.0f, 0.1f}, {0.0f, 1.0f, 1.0f, 0.1f}};
+
+  // Initialize LiteRT environment
+  LITERT_ASSIGN_OR_ABORT(auto env, litert::Environment::Create({}));
+
+  // Compile the model for the CPU
+  LITERT_ASSIGN_OR_ABORT(auto compiled_model,
+                         litert::CompiledModel::Create(
+                             env, model_path, litert::HwAccelerators::kCpu));
+
+  // Create input and output buffers
+  LITERT_ASSIGN_OR_ABORT(auto input_buffers,
+                         compiled_model.CreateInputBuffers());
+  LITERT_ASSIGN_OR_ABORT(auto output_buffers,
+                         compiled_model.CreateOutputBuffers());
+
+  // ================= PRE-PROCESSING (CPU) =================
+  ProfilingTimestamps profiling_timestamps;
+  profiling_timestamps.load_image_start_time = absl::Now();
+
+  int width_orig = 0, height_orig = 0, channels_file = 0;
+  const int loaded_channels = 3;
+  auto img_data_cpu = ImageUtils::LoadImage(input_file, width_orig, height_orig,
+                                            channels_file, loaded_channels);
+  if (!img_data_cpu) {
+    std::cerr << "Failed to load image file: " << input_file << std::endl;
+    return 1;
+  }
+
+  profiling_timestamps.load_image_end_time =
+      profiling_timestamps.e2e_start_time =
+          profiling_timestamps.pre_process_start_time = absl::Now();
+
+  const int preprocessed_width = 256;
+  const int preprocessed_height = 256;
+
+  std::vector<float> preprocessed_buffer_data =
+      ImageUtils::PreprocessInputForSegmentationCpu(
+          img_data_cpu, width_orig, height_orig, loaded_channels,
+          preprocessed_width, preprocessed_height);
+  ImageUtils::FreeImageData(img_data_cpu);
+
+  // Write preprocessed data to the input tensor buffer
+  LITERT_ABORT_IF_ERROR(
+      input_buffers[0].Write(absl::MakeConstSpan(preprocessed_buffer_data)));
+
+  profiling_timestamps.pre_process_end_time =
+      profiling_timestamps.inference_start_time = absl::Now();
+
+  // ================= INFERENCE =================
+  LITERT_ABORT_IF_ERROR(compiled_model.Run(input_buffers, output_buffers));
+
+  profiling_timestamps.inference_end_time =
+      profiling_timestamps.post_process_start_time = absl::Now();
+
+  // ================= POST-PROCESSING (CPU) =================
+  std::vector<float> raw_output_data(preprocessed_width *
+                                     preprocessed_height * 6);
+  LITERT_ABORT_IF_ERROR(
+      output_buffers[0].Read(absl::MakeSpan(raw_output_data)));
+
+  // Deinterleave the 6 masks
+  std::vector<std::vector<float>> masks = ImageUtils::DeinterleaveMasksCpu(
+      raw_output_data.data(), preprocessed_width, preprocessed_height);
+
+  // Reload the original image at its native resolution for blending.
+  // We load as 3 channels (RGB) which is what ApplyColoredMasksCpu expects.
+  int blend_w = 0, blend_h = 0, blend_ch_file = 0;
+  const int blend_channels = 3;
+  unsigned char* blend_img = ImageUtils::LoadImage(
+      input_file, blend_w, blend_h, blend_ch_file, blend_channels);
+  if (!blend_img) {
+    std::cerr << "Failed to reload image for blending." << std::endl;
+    return 1;
+  }
+
+  // The masks are at 256x256 but the original image may be a different size.
+  // We need to resize the masks to the original image size before blending.
+  // Simple nearest-neighbour resize for each mask.
+  std::vector<std::vector<float>> resized_masks(6);
+  for (int i = 0; i < 6; ++i) {
+    resized_masks[i].resize(blend_w * blend_h);
+    for (int y = 0; y < blend_h; ++y) {
+      for (int x = 0; x < blend_w; ++x) {
+        int src_x = x * preprocessed_width / blend_w;
+        int src_y = y * preprocessed_height / blend_h;
+        src_x = std::min(src_x, preprocessed_width - 1);
+        src_y = std::min(src_y, preprocessed_height - 1);
+        resized_masks[i][y * blend_w + x] =
+            masks[i][src_y * preprocessed_width + src_x];
+      }
+    }
+  }
+
+  std::vector<unsigned char> blended_image = ImageUtils::ApplyColoredMasksCpu(
+      blend_img, blend_w, blend_h, blend_channels, resized_masks, mask_colors);
+  ImageUtils::FreeImageData(blend_img);
+
+  profiling_timestamps.post_process_end_time =
+      profiling_timestamps.e2e_end_time =
+          profiling_timestamps.save_image_start_time = absl::Now();
+
+  // Save the output image
+  if (!ImageUtils::SaveImage(output_file, blend_w, blend_h, blend_channels,
+                             blended_image.data())) {
+    std::cerr << "Failed to save final blended image." << std::endl;
+    return 1;
+  }
+  std::cout << "Successfully saved final blended image to " << output_file
+            << std::endl;
+
+  profiling_timestamps.save_image_end_time = absl::Now();
+  PrintTiming(profiling_timestamps);
+
+  return 0;
+}

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/main_npu_no_gl.cc
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/main_npu_no_gl.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Intel NPU version of the image segmentation sample that does not depend on
+// OpenGL/EGL. This is intended for Windows desktop with Intel NPU via
+// OpenVINO.
+//
+// All image pre/post-processing is performed using the pure-CPU helpers already
+// provided by ImageUtils.
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/time/clock.h"           // from @com_google_absl
+#include "absl/types/span.h"           // from @com_google_absl
+#include "litert/c/litert_common.h"
+#include "litert/cc/litert_common.h"
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_macros.h"
+#include "litert/cc/litert_model.h"
+#include "litert/cc/litert_options.h"
+#include "compiled_model_api/image_segmentation/c++_segmentation/build_from_source/image_utils.h"
+#include "compiled_model_api/image_segmentation/c++_segmentation/build_from_source/timing_utils.h"
+
+int main(int argc, char* argv[]) {
+  if (argc < 4) {
+    std::cerr << "Usage: " << argv[0]
+              << " <model_path> <input_image_path> <output_image_path>"
+                 " [npu_libs_dir]"
+              << std::endl;
+    return 1;
+  }
+
+  const std::string model_path = argv[1];
+  const std::string input_file = argv[2];
+  const std::string output_file = argv[3];
+  // Directory containing the dispatch and compiler plugin libraries.
+  const std::string npu_libs_dir = argc > 4 ? argv[4] : ".";
+
+  std::vector<RGBAColor> mask_colors = {
+      {1.0f, 0.0f, 0.0f, 0.1f}, {0.0f, 1.0f, 0.0f, 0.1f},
+      {0.0f, 0.0f, 1.0f, 0.1f}, {1.0f, 1.0f, 0.0f, 0.1f},
+      {1.0f, 0.0f, 1.0f, 0.1f}, {0.0f, 1.0f, 1.0f, 0.1f}};
+
+  // Initialize LiteRT environment, pointing at the directory where the
+  // dispatch and compiler plugin libraries are located.
+  std::vector<litert::Environment::Option> environment_options;
+  environment_options.push_back(litert::Environment::Option{
+      litert::Environment::OptionTag::DispatchLibraryDir,
+      npu_libs_dir,
+  });
+  environment_options.push_back(litert::Environment::Option{
+      litert::Environment::OptionTag::CompilerPluginLibraryDir,
+      npu_libs_dir,
+  });
+  LITERT_ASSIGN_OR_ABORT(
+      auto env, litert::Environment::Create(std::move(environment_options)));
+
+  // Configure compilation options for NPU with CPU fallback.
+  LITERT_ASSIGN_OR_ABORT(litert::Options options, litert::Options::Create());
+  options.SetHardwareAccelerators(litert::HwAccelerators::kNpu |
+                                  litert::HwAccelerators::kCpu);
+
+  // Set Intel OpenVINO-specific options: target the NPU device.
+  LITERT_ASSIGN_OR_ABORT(auto& ov_opts, options.GetIntelOpenVinoOptions());
+  ov_opts.SetDeviceType(kLiteRtIntelOpenVinoDeviceTypeNPU);
+  std::cout << "Enabled Intel OpenVINO NPU mode." << std::endl;
+
+  LITERT_ASSIGN_OR_ABORT(auto compiled_model, litert::CompiledModel::Create(
+                                                  env, model_path, options));
+
+  // Create input and output buffers
+  LITERT_ASSIGN_OR_ABORT(auto input_buffers,
+                         compiled_model.CreateInputBuffers());
+  LITERT_ASSIGN_OR_ABORT(auto output_buffers,
+                         compiled_model.CreateOutputBuffers());
+
+  // ================= PRE-PROCESSING (CPU) =================
+  ProfilingTimestamps profiling_timestamps;
+  profiling_timestamps.load_image_start_time = absl::Now();
+
+  int width_orig = 0, height_orig = 0, channels_file = 0;
+  const int loaded_channels = 3;
+  auto img_data_cpu = ImageUtils::LoadImage(input_file, width_orig, height_orig,
+                                            channels_file, loaded_channels);
+  if (!img_data_cpu) {
+    std::cerr << "Failed to load image file: " << input_file << std::endl;
+    return 1;
+  }
+
+  profiling_timestamps.load_image_end_time =
+      profiling_timestamps.e2e_start_time =
+          profiling_timestamps.pre_process_start_time = absl::Now();
+
+  const int preprocessed_width = 256;
+  const int preprocessed_height = 256;
+
+  std::vector<float> preprocessed_buffer_data =
+      ImageUtils::PreprocessInputForSegmentationCpu(
+          img_data_cpu, width_orig, height_orig, loaded_channels,
+          preprocessed_width, preprocessed_height);
+  ImageUtils::FreeImageData(img_data_cpu);
+
+  // Write preprocessed data to the input tensor buffer
+  LITERT_ABORT_IF_ERROR(
+      input_buffers[0].Write(absl::MakeConstSpan(preprocessed_buffer_data)));
+
+  profiling_timestamps.pre_process_end_time =
+      profiling_timestamps.inference_start_time = absl::Now();
+
+  // ================= INFERENCE =================
+  LITERT_ABORT_IF_ERROR(compiled_model.Run(input_buffers, output_buffers));
+
+  profiling_timestamps.inference_end_time =
+      profiling_timestamps.post_process_start_time = absl::Now();
+
+  // ================= POST-PROCESSING (CPU) =================
+  std::vector<float> raw_output_data(preprocessed_width *
+                                     preprocessed_height * 6);
+  LITERT_ABORT_IF_ERROR(
+      output_buffers[0].Read(absl::MakeSpan(raw_output_data)));
+
+  // Deinterleave the 6 masks
+  std::vector<std::vector<float>> masks = ImageUtils::DeinterleaveMasksCpu(
+      raw_output_data.data(), preprocessed_width, preprocessed_height);
+
+  // Reload the original image at its native resolution for blending.
+  int blend_w = 0, blend_h = 0, blend_ch_file = 0;
+  const int blend_channels = 3;
+  unsigned char* blend_img = ImageUtils::LoadImage(
+      input_file, blend_w, blend_h, blend_ch_file, blend_channels);
+  if (!blend_img) {
+    std::cerr << "Failed to reload image for blending." << std::endl;
+    return 1;
+  }
+
+  // Resize masks to the original image size (nearest-neighbour).
+  std::vector<std::vector<float>> resized_masks(6);
+  for (int i = 0; i < 6; ++i) {
+    resized_masks[i].resize(blend_w * blend_h);
+    for (int y = 0; y < blend_h; ++y) {
+      for (int x = 0; x < blend_w; ++x) {
+        int src_x = x * preprocessed_width / blend_w;
+        int src_y = y * preprocessed_height / blend_h;
+        src_x = std::min(src_x, preprocessed_width - 1);
+        src_y = std::min(src_y, preprocessed_height - 1);
+        resized_masks[i][y * blend_w + x] =
+            masks[i][src_y * preprocessed_width + src_x];
+      }
+    }
+  }
+
+  std::vector<unsigned char> blended_image = ImageUtils::ApplyColoredMasksCpu(
+      blend_img, blend_w, blend_h, blend_channels, resized_masks, mask_colors);
+  ImageUtils::FreeImageData(blend_img);
+
+  profiling_timestamps.post_process_end_time =
+      profiling_timestamps.e2e_end_time =
+          profiling_timestamps.save_image_start_time = absl::Now();
+
+  // Save the output image
+  if (!ImageUtils::SaveImage(output_file, blend_w, blend_h, blend_channels,
+                             blended_image.data())) {
+    std::cerr << "Failed to save final blended image." << std::endl;
+    return 1;
+  }
+  std::cout << "Successfully saved final blended image to " << output_file
+            << std::endl;
+
+  profiling_timestamps.save_image_end_time = absl::Now();
+  PrintTiming(profiling_timestamps);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Add a new build target (cpp_segmentation_npu_intel) and source file (main_npu_no_gl.cc) that runs the image segmentation model on Intel NPU via OpenVINO on Windows, without OpenGL/EGL dependencies.

## Changes

### New files
- **main_npu_no_gl.cc** — Intel NPU variant based on the CPU-only no-GL implementation. Configures the LiteRT environment with DispatchLibraryDir and CompilerPluginLibraryDir, sets kNpu | kCpu hardware accelerators, and targets kLiteRtIntelOpenVinoDeviceTypeNPU for JIT compilation.
- **third_party/intel_openvino/BUILD** + **openvino.bazel** — Package marker and build file required by the openvino_configure() repository rule to locate the OpenVINO SDK.

### Modified files
- **BUILD** — New cpp_segmentation_npu_intel target with data deps for:
  - Intel OpenVINO compiler plugin and dispatch library
  - OpenVINO SDK runtime DLLs (openvino, TFLite frontend, NPU plugin/compiler, auto plugin, TBB)

## Performance

Tested on Windows with Intel NPU hardware:

| Metric | CPU | Intel NPU | Speedup |
|--------|-----|-----------|---------|
| Inference | ~300ms | ~9ms | **~32x** |
| E2E (pre + inference + post) | ~318ms | ~23ms | **~14x** |

## Build & Run
```Bash
# Build
bazelisk --nowindows_enable_symlinks build --noenable_runfiles --nocheck_visibility \
  //compiled_model_api/image_segmentation/c++_segmentation/build_from_source:cpp_segmentation_npu_intel

# Run (npu_libs_dir should contain LiteRtCompilerPlugin.dll, LiteRtDispatch.dll, and OpenVINO runtime DLLs)
./cpp_segmentation_npu_intel <model_path> <input_image> <output_image> <npu_libs_dir>
```

## Dependencies
- Builds on top of PR #122 (Windows CPU-only support)
- Requires Intel NPU hardware and OpenVINO SDK (fetched automatically via openvino_configure() in WORKSPACE)