### PR TITLE
Add Google Tensor G5 NPU support to LiteRT samples

### DIFF
--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/BUILD
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/BUILD
@@ -50,6 +50,7 @@ filegroup(
     srcs = [
         "models/selfie_multiclass_256x256.tflite",
         "models/selfie_multiclass_256x256_SM8750.tflite",
+        "models/selfie_multiclass_256x256_Tensor_G5.tflite",
     ],
 )
 
@@ -130,6 +131,34 @@ cc_binary(
         "@qairt//:lib/aarch64-android/libQnnSystem.so",
         "@qairt//:lib/hexagon-v75/unsigned/libQnnHtpV75Skel.so",
         "@qairt//:lib/hexagon-v79/unsigned/libQnnHtpV79Skel.so",
+    ],
+    linkopts = gles_linkopts(),
+    deps = [
+        ":image_processor",
+        ":image_utils",
+        ":timing_utils",
+        "@litert_archive//litert/cc:litert_api_with_dynamic_runtime",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+    ] + gles_deps() + gl_native_deps(),
+)
+
+cc_binary(
+    name = "cpp_segmentation_npu_google_tensor",
+    srcs = [
+        "main_npu.cc",
+    ],
+    copts = [
+        "-I.",
+    ],
+    data = [
+        ":model_files",
+        ":shader_files",
+        ":test_images",
+        "@litert_archive//litert/c:litert_runtime_c_api_shared_lib",  # buildcleaner: keep
+        "@litert_archive//litert/vendors/google_tensor/compiler:libLiteRtCompilerPlugin_google_tensor.so",
+        "@litert_archive//litert/vendors/google_tensor/dispatch:dispatch_api_so",
     ],
     linkopts = gles_linkopts(),
     deps = [

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/README.md
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/README.md
@@ -110,6 +110,11 @@ bazel build //compiled_model_api/image_segmentation/c++_segmentation/build_from_
 bazel build //compiled_model_api/image_segmentation/c++_segmentation/build_from_source:cpp_segmentation_npu_mtk \
   --config=android_arm64 \
   --nocheck_visibility
+
+# 5. Google Tensor NPU (No extra SDK required)
+bazel build //compiled_model_api/image_segmentation/c++_segmentation/build_from_source:cpp_segmentation_npu_google_tensor \
+  --config=android_arm64 \
+  --nocheck_visibility
 ```
 
 > [!NOTE]
@@ -131,6 +136,9 @@ After building, use the `deploy_and_run_on_android.sh` script to deploy and run 
 
 # For MediaTek APU (dim9400)
 ./compiled_model_api/image_segmentation/c++_segmentation/build_from_source/deploy_and_run_on_android.sh --accelerator=npu --phone=dim9400 --jit bazel-bin/
+
+# For Google Tensor G5 (pixel10)
+./compiled_model_api/image_segmentation/c++_segmentation/build_from_source/deploy_and_run_on_android.sh --accelerator=npu --phone=pixel10 bazel-bin/
 ```
 The output image `output_segmented.png` will be pulled from the device and saved in the current directory.
 

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/deploy_and_run_on_android.sh
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/deploy_and_run_on_android.sh
@@ -24,9 +24,9 @@ BINARY_BUILD_PATH=""
 
 # --- Usage ---
 usage() {
-    echo "Usage: $0 --accelerator=[gpu|npu|cpu] --phone=[s24|s25|dim9400] <binary_build_path>"
+    echo "Usage: $0 --accelerator=[gpu|npu|cpu] --phone=[s24|s25|pixel10|dim9400] <binary_build_path>"
     echo "  --accelerator : Specify the accelerator to use (gpu, npu, or cpu)."
-    echo "  --phone       : Specify the phone model (s24/s25 for Qualcomm, dim9400 for MediaTek)."
+    echo "  --phone       : Specify the phone model (s24/s25 for Qualcomm, pixel10 for Google Tensor, dim9400 for MediaTek)."
     echo "  --backend     : For GPU, specify backend (opengl or opencl). Defaults to opencl."
     echo "  --jit         : Use JIT compilation (true). Defaults to false (Qualcomm AOT)."
     echo "  <binary_build_path> : Path to bazel-bin/."
@@ -128,10 +128,44 @@ ROOT_DIR="compiled_model_api/image_segmentation/c++_segmentation"
 PACKAGE_LOCATION="${ROOT_DIR}/build_from_source"
 C_LIBRARY_LOCATION="${BINARY_BUILD_PATH}/external/litert_archive/litert/c"
 
-# For MediaTek phones, use the dedicated MTK binary (no QAIRT SDK dependency).
-# The PHONE-to-IS_MTK mapping is re-derived here early so PACKAGE_NAME is set
-# correctly before the runfiles paths are computed.
-if [[ "$ACCELERATOR" == "npu" && "$PHONE" == "dim9400" ]]; then
+# --- NPU Configuration ---
+QNN_STUB_LIB=""
+QNN_SKEL_LIB=""
+QNN_SKEL_PATH_ARCH=""
+IS_QUALCOMM=false
+IS_GOOGLE_TENSOR=false
+GOOGLE_TENSOR_MODEL=""
+IS_MTK=false
+case "$PHONE" in
+    's24')
+        QNN_STUB_LIB="libQnnHtpV75Stub.so"
+        QNN_SKEL_LIB="libQnnHtpV75Skel.so"
+        QNN_SKEL_PATH_ARCH="hexagon-v75"
+        IS_QUALCOMM=true
+        ;;
+    's25')
+        QNN_STUB_LIB="libQnnHtpV79Stub.so"
+        QNN_SKEL_LIB="libQnnHtpV79Skel.so"
+        QNN_SKEL_PATH_ARCH="hexagon-v79"
+        IS_QUALCOMM=true
+        ;;
+    'pixel10')
+        IS_GOOGLE_TENSOR=true
+        GOOGLE_TENSOR_MODEL="Tensor_G5"
+        ;;
+    'dim9400')
+        # MediaTek Dimensity 9400 (MT6991) — NeuroPilot v8
+        IS_MTK=true
+        ;;
+    *)
+        echo "Error: Unsupported phone model '$PHONE'. Supported models are 's24', 's25', 'pixel10', 'dim9400'." >&2
+        exit 1
+        ;;
+esac
+
+if [[ "$ACCELERATOR" == "npu" ]] && [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+    PACKAGE_NAME="cpp_segmentation_npu_google_tensor"
+elif [[ "$ACCELERATOR" == "npu" ]] && [[ "$IS_MTK" == "true" ]]; then
     PACKAGE_NAME="cpp_segmentation_npu_mtk"
 else
     PACKAGE_NAME="cpp_segmentation_${ACCELERATOR}"
@@ -154,18 +188,23 @@ HOST_MODEL_DIR="${PACKAGE_LOCATION}/models"
 HOST_GPU_LIBRARY_DIR="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/${PACKAGE_NAME}.runfiles/litert_prebuilts/android_arm64/"
 
 # Set NPU library path based on the --npu_dispatch_lib_path flag
-if [[ -z "$HOST_NPU_LIB" ]]; then
+if [[ "$IS_QUALCOMM" == "true" ]] && [[ -z "$HOST_NPU_LIB" ]]; then
     echo "Defaulting to QNN libraries path."
     HOST_NPU_LIB="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/${PACKAGE_NAME}.runfiles/qairt/lib/"
 fi
-if [[ -z "$HOST_NPU_DISPATCH_LIB" ]]; then
+if [[ "$IS_QUALCOMM" == "true" ]] && [[ -z "$HOST_NPU_DISPATCH_LIB" ]]; then
     echo "Defaulting to internal dispatch library path."
     HOST_NPU_DISPATCH_LIB="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/${PACKAGE_NAME}.runfiles/litert_archive/litert/vendors/qualcomm/dispatch"
+elif [[ "$IS_GOOGLE_TENSOR" == "true" ]] && [[ -z "$HOST_NPU_DISPATCH_LIB" ]]; then
+    echo "Defaulting to Google Tensor dispatch library path."
+    HOST_NPU_DISPATCH_LIB="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/${PACKAGE_NAME}.runfiles/litert_archive/litert/vendors/google_tensor/dispatch"
 fi
 if [[ "$USE_JIT" == "true" ]]; then
     echo "Using NPU JIT compilation."
-    if [[ -z "$HOST_NPU_COMPILER_LIB" ]]; then
+    if [[ "$IS_QUALCOMM" == "true" ]] && [[ -z "$HOST_NPU_COMPILER_LIB" ]]; then
         HOST_NPU_COMPILER_LIB="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/${PACKAGE_NAME}.runfiles/litert_archive/litert/vendors/qualcomm/compiler"
+    elif [[ "$IS_GOOGLE_TENSOR" == "true" ]] && [[ -z "$HOST_NPU_COMPILER_LIB" ]]; then
+        HOST_NPU_COMPILER_LIB="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/${PACKAGE_NAME}.runfiles/litert_archive/litert/vendors/google_tensor/compiler"
     fi
 fi
 
@@ -180,40 +219,12 @@ HOST_MTK_COMPILER_LIB="${BINARY_BUILD_PATH}/${PACKAGE_LOCATION}/cpp_segmentation
 LD_LIBRARY_PATH="${DEVICE_NPU_LIBRARY_DIR}/"
 ADSP_LIBRARY_PATH="${DEVICE_NPU_LIBRARY_DIR}/"
 
-# --- NPU / MTK phone configuration ---
-# Determine if this is a MediaTek phone by the --phone value.
-IS_MTK=false
-QNN_STUB_LIB=""
-QNN_SKEL_LIB=""
-QNN_SKEL_PATH_ARCH=""
-if [[ "$ACCELERATOR" == "npu" ]]; then
-    case "$PHONE" in
-        's24')
-            QNN_STUB_LIB="libQnnHtpV75Stub.so"
-            QNN_SKEL_LIB="libQnnHtpV75Skel.so"
-            QNN_SKEL_PATH_ARCH="hexagon-v75"
-            ;;
-        's25')
-            QNN_STUB_LIB="libQnnHtpV79Stub.so"
-            QNN_SKEL_LIB="libQnnHtpV79Skel.so"
-            QNN_SKEL_PATH_ARCH="hexagon-v79"
-            ;;
-        'dim9400')
-            # MediaTek Dimensity 9400 (MT6991) — NeuroPilot v8
-            IS_MTK=true
-            ;;
-        *)
-            echo "Error: Unsupported phone model '$PHONE'. Supported: s24, s25 (Qualcomm), dim9400 (MediaTek)." >&2
-            exit 1
-            ;;
-    esac
-fi
-
-
 # --- Model Selection ---
 MODEL_FILENAME="selfie_multiclass_256x256.tflite"
-if [[ "$ACCELERATOR" == "npu" && "$USE_JIT" == "false" ]]; then
-    if [[ "$PHONE" == "s24" ]]; then
+if [[ "$ACCELERATOR" == "npu" ]] && [[ "$USE_JIT" == "false" ]]; then
+    if [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+        MODEL_FILENAME="selfie_multiclass_256x256_${GOOGLE_TENSOR_MODEL}.tflite"
+    elif [[ "$PHONE" == "s24" ]]; then
         MODEL_FILENAME="selfie_multiclass_256x256_SM8650.tflite"
     elif [[ "$PHONE" == "s25" ]]; then
         MODEL_FILENAME="selfie_multiclass_256x256_SM8750.tflite"
@@ -282,39 +293,48 @@ echo "Pushed gpu accelerator shared library."
 
 # Push NPU libraries (Qualcomm or MediaTek depending on phone)
 if [[ "$ACCELERATOR" == "npu" ]]; then
-    if [[ "$IS_MTK" == "true" ]]; then
-        # ---- MediaTek path ----
-        # Push the pre-built dispatch library from litert_npu_runtime_libraries.
-        adb push --sync "${HOST_MTK_DISPATCH_LIB}/libLiteRtDispatch_MediaTek.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        echo "Pushed MediaTek dispatch library."
-        # NeuroPilot runtime (libneuronusdk_adapter.mtk.so etc.) lives in
-        # /system_ext/lib64/ on the device -- nothing extra to push.
-        echo "Note: NeuroPilot runtime libs are system libs on the device."
-        if [[ "$USE_JIT" == "true" ]]; then
-            MTK_COMPILER="${HOST_MTK_COMPILER_LIB}/libLiteRtCompilerPlugin_MediaTek.so"
-            if [[ -f "$MTK_COMPILER" ]]; then
-                adb push --sync "$MTK_COMPILER" "${DEVICE_NPU_LIBRARY_DIR}/"
-                echo "Pushed MediaTek compiler plugin."
-            else
-                echo "Warning: libLiteRtCompilerPlugin_MediaTek.so not found."
-                echo "  Build it from LiteRT source and set HOST_MTK_COMPILER_LIB."
-            fi
-        fi
-    else
-        # ---- Qualcomm path ----
-        adb push --sync "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        echo "Pushed Qualcomm dispatch library."
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtp.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/${QNN_STUB_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnSystem.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtpPrepare.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/${QNN_SKEL_PATH_ARCH}/unsigned/${QNN_SKEL_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
-        echo "Pushed Qualcomm NPU libraries."
-        if [[ "$USE_JIT" == "true" ]]; then
-            adb push --sync "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-            echo "Pushed Qualcomm compiler plugin library."
+  if [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+    # ---- Google Tensor path ----
+    adb push --sync "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_GoogleTensor.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    echo "Pushed Google Tensor NPU dispatch library."
+    # If JIT, push compiler plugin.
+    if [[ "$USE_JIT" == "true" ]]; then
+        adb push --sync "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_google_tensor.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+        echo "Pushed Google Tensor NPU compiler library."
+    fi
+  elif [[ "$IS_MTK" == "true" ]]; then
+    # ---- MediaTek path ----
+    # Push the pre-built dispatch library from litert_npu_runtime_libraries.
+    adb push --sync "${HOST_MTK_DISPATCH_LIB}/libLiteRtDispatch_MediaTek.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    echo "Pushed MediaTek dispatch library."
+    # NeuroPilot runtime (libneuronusdk_adapter.mtk.so etc.) lives in
+    # /system_ext/lib64/ on the device -- nothing extra to push.
+    echo "Note: NeuroPilot runtime libs are system libs on the device."
+    if [[ "$USE_JIT" == "true" ]]; then
+        MTK_COMPILER="${HOST_MTK_COMPILER_LIB}/libLiteRtCompilerPlugin_MediaTek.so"
+        if [[ -f "$MTK_COMPILER" ]]; then
+            adb push --sync "$MTK_COMPILER" "${DEVICE_NPU_LIBRARY_DIR}/"
+            echo "Pushed MediaTek compiler plugin."
+        else
+            echo "Warning: libLiteRtCompilerPlugin_MediaTek.so not found."
+            echo "  Build it from LiteRT source and set HOST_MTK_COMPILER_LIB."
         fi
     fi
+  elif [[ "$IS_QUALCOMM" == "true" ]]; then
+    # ---- Qualcomm path ----
+    adb push --sync "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    echo "Pushed Qualcomm dispatch library."
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtp.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/${QNN_STUB_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnSystem.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtpPrepare.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/${QNN_SKEL_PATH_ARCH}/unsigned/${QNN_SKEL_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
+    echo "Pushed Qualcomm NPU libraries."
+    if [[ "$USE_JIT" == "true" ]]; then
+        adb push --sync "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+        echo "Pushed Qualcomm compiler plugin library."
+    fi
+  fi
 fi
 
 
@@ -337,7 +357,14 @@ if [[ "$ACCELERATOR" == "gpu" ]]; then
 fi
 
 if [[ "$ACCELERATOR" == "npu" ]]; then
-    if [[ "$IS_MTK" == "true" ]]; then
+    if [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+        FULL_COMMAND="cd ${DEVICE_BASE_DIR} && LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}\" ${RUN_COMMAND}"
+        if [[ "$USE_JIT" == "true" ]]; then
+            FULL_COMMAND="${FULL_COMMAND} true google_tensor"
+        else
+            FULL_COMMAND="${FULL_COMMAND} false google_tensor"
+        fi
+    elif [[ "$IS_MTK" == "true" ]]; then
         # MTK: dispatch dir is /npu/, also include /system_ext/lib64/ for NeuroPilot.
         MTK_LD_PATH="${DEVICE_NPU_LIBRARY_DIR}/:${DEVICE_BASE_DIR}/:/system_ext/lib64/"
         FULL_COMMAND="cd ${DEVICE_BASE_DIR} && LD_LIBRARY_PATH=\"${MTK_LD_PATH}\" ${RUN_COMMAND}"
@@ -351,7 +378,9 @@ if [[ "$ACCELERATOR" == "npu" ]]; then
         # Qualcomm: standard LD_LIBRARY_PATH + ADSP path.
         FULL_COMMAND="cd ${DEVICE_BASE_DIR} && LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}\" ADSP_LIBRARY_PATH=\"${ADSP_LIBRARY_PATH}\" ${RUN_COMMAND}"
         if [[ "$USE_JIT" == "true" ]]; then
-            FULL_COMMAND="${FULL_COMMAND} true"
+            FULL_COMMAND="${FULL_COMMAND} true qualcomm"
+        else
+            FULL_COMMAND="${FULL_COMMAND} false qualcomm"
         fi
     fi
 else

--- a/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/main_npu.cc
+++ b/compiled_model_api/image_segmentation/c++_segmentation/build_from_source/main_npu.cc
@@ -35,17 +35,15 @@
 #include "compiled_model_api/image_segmentation/c++_segmentation/build_from_source/image_utils.h"
 #include "compiled_model_api/image_segmentation/c++_segmentation/build_from_source/timing_utils.h"
 
-// Device paths where NPU libraries are deployed by the deploy script.
-static constexpr absl::string_view kQualcommDispatchDir =
-    "/data/local/tmp/cpp_segmentation_android/npu/";
-static constexpr absl::string_view kMediatekDispatchDir =
+// Device path where NPU libraries are deployed by the deploy script.
+static constexpr absl::string_view kNpuDispatchDir =
     "/data/local/tmp/cpp_segmentation_android/npu/";
 
 int main(int argc, char* argv[]) {
   if (argc < 4) {
     std::cerr << "Usage: " << argv[0]
               << " <model_path> <input_image_path> <output_image_path> "
-                 "[use_jit (true|false)] [npu_vendor (qualcomm|mediatek)]"
+                 "[use_jit (true|false)] [npu_vendor (qualcomm|mediatek|google_tensor)]"
               << std::endl;
     return 1;
   }
@@ -65,9 +63,10 @@ int main(int argc, char* argv[]) {
   }
 
   const bool use_mediatek = (npu_vendor == "mediatek");
-  if (npu_vendor != "qualcomm" && npu_vendor != "mediatek") {
+  const bool use_google_tensor = (npu_vendor == "google_tensor");
+  if (npu_vendor != "qualcomm" && npu_vendor != "mediatek" && npu_vendor != "google_tensor") {
     std::cerr << "Warning: Unknown npu_vendor '" << npu_vendor
-              << "'. Must be 'qualcomm' or 'mediatek'. Defaulting to qualcomm."
+              << "'. Must be 'qualcomm', 'mediatek', or 'google_tensor'. Defaulting to qualcomm."
               << std::endl;
   }
 
@@ -86,8 +85,7 @@ int main(int argc, char* argv[]) {
 
   // Initialize LiteRT environment, pointing at the directory where the
   // dispatch (and optionally compiler) plugin .so files are deployed.
-  const absl::string_view dispatch_dir =
-      use_mediatek ? kMediatekDispatchDir : kQualcommDispatchDir;
+  const absl::string_view dispatch_dir = kNpuDispatchDir;
 
   std::vector<litert::Environment::Option> environment_options;
   environment_options.push_back(litert::Environment::Option{
@@ -122,6 +120,10 @@ int main(int argc, char* argv[]) {
         kLiteRtMediatekOptionsNeronSDKVersionTypeVersion8);
     std::cout << "Enabled MediaTek APU: FastSingleAnswer + LowLatency hint."
               << std::endl;
+  } else if (use_google_tensor) {
+    // ---- Google Tensor options ----
+    // TODO: Add performance mode once new LiteRT SDK releases.
+    std::cout << "Enabled Google Tensor NPU." << std::endl;
   } else {
     // ---- Qualcomm HTP options ----
     LITERT_ASSIGN_OR_ABORT(auto& qnn_opts, options.GetQualcommOptions());

--- a/compiled_model_api/image_segmentation/c++_segmentation/use_prebuilt_litert/README.md
+++ b/compiled_model_api/image_segmentation/c++_segmentation/use_prebuilt_litert/README.md
@@ -103,9 +103,15 @@ runs inference, and pulls `output_segmented.png` back automatically.
     --accelerator=npu --phone=dim9400 --jit \
     --host_npu_dispatch_lib=/path/to/dir/with/libLiteRtDispatch_MediaTek.so \
     build/
+
+# Google Tensor G5 (pixel10)
+./deploy_and_run_on_android.sh \
+    --accelerator=npu --phone=pixel10 \
+    --host_npu_dispatch_lib=/path/to/dir/with/libLiteRtDispatch_GoogleTensor.so \
+    build/
 ```
 
-**`--phone` values**: `s24` (Snapdragon 8 Gen 3), `s25` (Snapdragon 8 Elite), `dim9400` (MediaTek Dimensity 9400)
+**`--phone` values**: `s24` (Snapdragon 8 Gen 3), `s25` (Snapdragon 8 Elite), `pixel10` (Google Tensor G5), `dim9400` (MediaTek Dimensity 9400)
 
 The Qualcomm NPU requires:
 - `libLiteRtDispatch_Qualcomm.so` from the [LiteRT NPU runtime libraries](https://github.com/google-ai-edge/LiteRT/releases/tag/v2.1.1) zip

--- a/compiled_model_api/image_segmentation/c++_segmentation/use_prebuilt_litert/deploy_and_run_on_android.sh
+++ b/compiled_model_api/image_segmentation/c++_segmentation/use_prebuilt_litert/deploy_and_run_on_android.sh
@@ -20,7 +20,7 @@
 # Usage:
 #   ./deploy_and_run_on_android.sh \
 #       --accelerator=[gpu|npu|cpu] \
-#       --phone=[s24|s25|dim9400] \
+#       --phone=[s24|s25|pixel10|dim9400] \
 #       [--use_gl_buffers] \
 #       [--jit] \
 #       [--host_npu_lib=<path>] \
@@ -35,9 +35,9 @@ PHONE="s25"
 BINARY_BUILD_PATH=""
 
 usage() {
-    echo "Usage: $0 --accelerator=[gpu|npu|cpu] --phone=[s24|s25|dim9400] <cmake_build_dir>"
+    echo "Usage: $0 --accelerator=[gpu|npu|cpu] --phone=[s24|s25|pixel10|dim9400] <cmake_build_dir>"
     echo "  --accelerator : Specify the accelerator to use (gpu, npu, or cpu)."
-    echo "  --phone       : Specify the phone model (s24/s25 for Qualcomm, dim9400 for MediaTek)."
+    echo "  --phone       : Specify the phone model (s24/s25 for Qualcomm, pixel10 for Google Tensor, dim9400 for MediaTek)."
     echo "  --jit         : Use JIT compilation (true). Defaults to false (Qualcomm AOT)."
     echo "  <cmake_build_dir> : Path to cmake build output directory (e.g. build/)."
     exit 1
@@ -179,23 +179,32 @@ IS_MTK=false
 QNN_STUB_LIB=""
 QNN_SKEL_LIB=""
 QNN_SKEL_PATH_ARCH=""
+IS_QUALCOMM=false
+IS_GOOGLE_TENSOR=false
+GOOGLE_TENSOR_MODEL=""
 if [[ "$ACCELERATOR" == "npu" ]]; then
     case "$PHONE" in
         's24')
             QNN_STUB_LIB="libQnnHtpV75Stub.so"
             QNN_SKEL_LIB="libQnnHtpV75Skel.so"
             QNN_SKEL_PATH_ARCH="hexagon-v75"
+            IS_QUALCOMM=true
             ;;
         's25')
             QNN_STUB_LIB="libQnnHtpV79Stub.so"
             QNN_SKEL_LIB="libQnnHtpV79Skel.so"
             QNN_SKEL_PATH_ARCH="hexagon-v79"
+            IS_QUALCOMM=true
+            ;;
+        'pixel10')
+            IS_GOOGLE_TENSOR=true
+            GOOGLE_TENSOR_MODEL="Tensor_G5"
             ;;
         'dim9400')
             IS_MTK=true
             ;;
         *)
-            echo "Error: Unsupported phone model '$PHONE'. Supported: s24, s25 (Qualcomm), dim9400 (MediaTek)." >&2
+            echo "Error: Unsupported phone model '$PHONE'. Supported: s24, s25 (Qualcomm), pixel10 (Google Tensor), dim9400 (MediaTek)." >&2
             exit 1
             ;;
     esac
@@ -203,8 +212,10 @@ fi
 
 # --- Model Selection ---
 MODEL_FILENAME="selfie_multiclass_256x256.tflite"
-if [[ "$ACCELERATOR" == "npu" && "$USE_JIT" == "false" ]]; then
-    if [[ "$PHONE" == "s24" ]]; then
+if [[ "$ACCELERATOR" == "npu" ]] && [[ "$USE_JIT" == "false" ]]; then
+    if [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+        MODEL_FILENAME="selfie_multiclass_256x256_${GOOGLE_TENSOR_MODEL}.tflite"
+    elif [[ "$PHONE" == "s24" ]]; then
         MODEL_FILENAME="selfie_multiclass_256x256_SM8650.tflite"
     elif [[ "$PHONE" == "s25" ]]; then
         MODEL_FILENAME="selfie_multiclass_256x256_SM8750.tflite"
@@ -280,39 +291,55 @@ fi
 
 # Push NPU libraries
 if [[ "$ACCELERATOR" == "npu" ]]; then
-    if [[ "$IS_MTK" == "true" ]]; then
-        # ---- MediaTek path ----
-        if [[ -f "${HOST_MTK_DISPATCH_LIB}/libLiteRtDispatch_MediaTek.so" ]]; then
-            adb push --sync "${HOST_MTK_DISPATCH_LIB}/libLiteRtDispatch_MediaTek.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-            echo "Pushed MediaTek dispatch library."
-        else
-            echo "Warning: libLiteRtDispatch_MediaTek.so not found at ${HOST_MTK_DISPATCH_LIB}."
-        fi
-        echo "Note: NeuroPilot runtime libs are system libs on the device."
-        if [[ "$USE_JIT" == "true" ]]; then
-            MTK_COMPILER="${HOST_MTK_COMPILER_LIB}/libLiteRtCompilerPlugin_MediaTek.so"
-            if [[ -f "$MTK_COMPILER" ]]; then
-                adb push --sync "$MTK_COMPILER" "${DEVICE_NPU_LIBRARY_DIR}/"
-                echo "Pushed MediaTek compiler plugin."
-            else
-                echo "Warning: libLiteRtCompilerPlugin_MediaTek.so not found."
-            fi
-        fi
+  if [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+    # ---- Google Tensor path ----
+    if [[ -f "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_GoogleTensor.so" ]]; then
+        adb push --sync "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_GoogleTensor.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+        echo "Pushed Google Tensor NPU dispatch library."
     else
-        # ---- Qualcomm path ----
-        adb push --sync "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        echo "Pushed Qualcomm dispatch library."
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtp.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/${QNN_STUB_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnSystem.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtpPrepare.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-        adb push --sync "${HOST_NPU_LIB}/${QNN_SKEL_PATH_ARCH}/unsigned/${QNN_SKEL_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
-        echo "Pushed Qualcomm NPU libraries."
-        if [[ "$USE_JIT" == "true" ]]; then
-            adb push --sync "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
-            echo "Pushed Qualcomm compiler plugin library."
+        echo "Warning: libLiteRtDispatch_GoogleTensor.so not found at ${HOST_NPU_DISPATCH_LIB}."
+    fi
+    if [[ "$USE_JIT" == "true" ]]; then
+        if [[ -f "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_google_tensor.so" ]]; then
+            adb push --sync "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_google_tensor.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+            echo "Pushed Google Tensor NPU compiler library."
+        else
+            echo "Warning: libLiteRtCompilerPlugin_google_tensor.so not found."
         fi
     fi
+  elif [[ "$IS_MTK" == "true" ]]; then
+    # ---- MediaTek path ----
+    if [[ -f "${HOST_MTK_DISPATCH_LIB}/libLiteRtDispatch_MediaTek.so" ]]; then
+        adb push --sync "${HOST_MTK_DISPATCH_LIB}/libLiteRtDispatch_MediaTek.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+        echo "Pushed MediaTek dispatch library."
+    else
+        echo "Warning: libLiteRtDispatch_MediaTek.so not found at ${HOST_MTK_DISPATCH_LIB}."
+    fi
+    echo "Note: NeuroPilot runtime libs are system libs on the device."
+    if [[ "$USE_JIT" == "true" ]]; then
+        MTK_COMPILER="${HOST_MTK_COMPILER_LIB}/libLiteRtCompilerPlugin_MediaTek.so"
+        if [[ -f "$MTK_COMPILER" ]]; then
+            adb push --sync "$MTK_COMPILER" "${DEVICE_NPU_LIBRARY_DIR}/"
+            echo "Pushed MediaTek compiler plugin."
+        else
+            echo "Warning: libLiteRtCompilerPlugin_MediaTek.so not found."
+        fi
+    fi
+  elif [[ "$IS_QUALCOMM" == "true" ]]; then
+    # ---- Qualcomm path ----
+    adb push --sync "${HOST_NPU_DISPATCH_LIB}/libLiteRtDispatch_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    echo "Pushed Qualcomm dispatch library."
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtp.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/${QNN_STUB_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnSystem.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/aarch64-android/libQnnHtpPrepare.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+    adb push --sync "${HOST_NPU_LIB}/${QNN_SKEL_PATH_ARCH}/unsigned/${QNN_SKEL_LIB}" "${DEVICE_NPU_LIBRARY_DIR}/"
+    echo "Pushed Qualcomm NPU libraries."
+    if [[ "$USE_JIT" == "true" ]]; then
+        adb push --sync "${HOST_NPU_COMPILER_LIB}/libLiteRtCompilerPlugin_Qualcomm.so" "${DEVICE_NPU_LIBRARY_DIR}/"
+        echo "Pushed Qualcomm compiler plugin library."
+    fi
+  fi
 fi
 
 # Set execute permissions
@@ -332,7 +359,14 @@ if [[ "$ACCELERATOR" == "gpu" ]] && $USE_GL_BUFFERS; then
 fi
 
 if [[ "$ACCELERATOR" == "npu" ]]; then
-    if [[ "$IS_MTK" == "true" ]]; then
+    if [[ "$IS_GOOGLE_TENSOR" == "true" ]]; then
+        FULL_COMMAND="cd ${DEVICE_BASE_DIR} && LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}\" ${RUN_COMMAND}"
+        if [[ "$USE_JIT" == "true" ]]; then
+            FULL_COMMAND="${FULL_COMMAND} true google_tensor"
+        else
+            FULL_COMMAND="${FULL_COMMAND} false google_tensor"
+        fi
+    elif [[ "$IS_MTK" == "true" ]]; then
         MTK_LD_PATH="${DEVICE_NPU_LIBRARY_DIR}/:${DEVICE_BASE_DIR}/:/system_ext/lib64/"
         FULL_COMMAND="cd ${DEVICE_BASE_DIR} && LD_LIBRARY_PATH=\"${MTK_LD_PATH}\" ${RUN_COMMAND}"
         if [[ "$USE_JIT" == "true" ]]; then
@@ -343,7 +377,9 @@ if [[ "$ACCELERATOR" == "npu" ]]; then
     else
         FULL_COMMAND="cd ${DEVICE_BASE_DIR} && LD_LIBRARY_PATH=\"${LD_LIBRARY_PATH}\" ADSP_LIBRARY_PATH=\"${ADSP_LIBRARY_PATH}\" ${RUN_COMMAND}"
         if [[ "$USE_JIT" == "true" ]]; then
-            FULL_COMMAND="${FULL_COMMAND} true"
+            FULL_COMMAND="${FULL_COMMAND} true qualcomm"
+        else
+            FULL_COMMAND="${FULL_COMMAND} false qualcomm"
         fi
     fi
 else

--- a/compiled_model_api/image_segmentation/c++_segmentation/use_prebuilt_litert/main_npu.cc
+++ b/compiled_model_api/image_segmentation/c++_segmentation/use_prebuilt_litert/main_npu.cc
@@ -35,17 +35,15 @@
 #include "image_utils.h"
 #include "timing_utils.h"
 
-// Device paths where NPU libraries are deployed by the deploy script.
-static constexpr absl::string_view kQualcommDispatchDir =
-    "/data/local/tmp/cpp_segmentation_android/npu/";
-static constexpr absl::string_view kMediatekDispatchDir =
+// Device path where NPU libraries are deployed by the deploy script.
+static constexpr absl::string_view kNpuDispatchDir =
     "/data/local/tmp/cpp_segmentation_android/npu/";
 
 int main(int argc, char* argv[]) {
   if (argc < 4) {
     std::cerr << "Usage: " << argv[0]
               << " <model_path> <input_image_path> <output_image_path> "
-                 "[use_jit (true|false)] [npu_vendor (qualcomm|mediatek)]"
+                 "[use_jit (true|false)] [npu_vendor (qualcomm|mediatek|google_tensor)]"
               << std::endl;
     return 1;
   }
@@ -65,9 +63,10 @@ int main(int argc, char* argv[]) {
   }
 
   const bool use_mediatek = (npu_vendor == "mediatek");
-  if (npu_vendor != "qualcomm" && npu_vendor != "mediatek") {
+  const bool use_google_tensor = (npu_vendor == "google_tensor");
+  if (npu_vendor != "qualcomm" && npu_vendor != "mediatek" && npu_vendor != "google_tensor") {
     std::cerr << "Warning: Unknown npu_vendor '" << npu_vendor
-              << "'. Must be 'qualcomm' or 'mediatek'. Defaulting to qualcomm."
+              << "'. Must be 'qualcomm', 'mediatek', or 'google_tensor'. Defaulting to qualcomm."
               << std::endl;
   }
 
@@ -86,8 +85,7 @@ int main(int argc, char* argv[]) {
 
   // Initialize LiteRT environment, pointing at the directory where the
   // dispatch (and optionally compiler) plugin .so files are deployed.
-  const absl::string_view dispatch_dir =
-      use_mediatek ? kMediatekDispatchDir : kQualcommDispatchDir;
+  const absl::string_view dispatch_dir = kNpuDispatchDir;
 
   std::vector<litert::Environment::Option> environment_options;
   environment_options.push_back(litert::Environment::Option{
@@ -122,6 +120,10 @@ int main(int argc, char* argv[]) {
         kLiteRtMediatekOptionsNeronSDKVersionTypeVersion8);
     std::cout << "Enabled MediaTek APU: FastSingleAnswer + LowLatency hint."
               << std::endl;
+  } else if (use_google_tensor) {
+    // ---- Google Tensor options ----
+    // TODO: Add performance mode once new LiteRT SDK releases.
+    std::cout << "Enabled Google Tensor NPU." << std::endl;
   } else {
     // ---- Qualcomm HTP options ----
     LITERT_ASSIGN_OR_ABORT(auto& qnn_opts, options.GetQualcommOptions());

--- a/compiled_model_api/image_segmentation/kotlin_npu/android/README.md
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android/README.md
@@ -68,3 +68,4 @@ Currently, the following devices are supported:
 | Mediatek | MT6985    |  15             | Mediatek_MT6985_ANDROID_15 |
 | Mediatek | MT6989    |  15             | Mediatek_MT6989_ANDROID_15 |
 | Mediatek | MT6991    |  15             | Mediatek_MT6991_ANDROID_15 |
+| Google   | Tensor G5 |  16             | Google_Tensor_G5           |

--- a/compiled_model_api/image_segmentation/kotlin_npu/android/app/build.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android/app/build.gradle.kts
@@ -61,6 +61,7 @@ android {
 
   // NPU runtime libraries
   dynamicFeatures.add(":litert_npu_runtime_libraries:mediatek_runtime")
+  dynamicFeatures.add(":litert_npu_runtime_libraries:google_tensor_runtime")
   dynamicFeatures.add(":litert_npu_runtime_libraries:qualcomm_runtime_v69")
   dynamicFeatures.add(":litert_npu_runtime_libraries:qualcomm_runtime_v73")
   dynamicFeatures.add(":litert_npu_runtime_libraries:qualcomm_runtime_v75")

--- a/compiled_model_api/image_segmentation/kotlin_npu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/ImageSegmentationHelper.kt
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/ImageSegmentationHelper.kt
@@ -90,18 +90,19 @@ class ImageSegmentationHelper(private val context: Context) {
               add(Accelerator.NPU)
           }
         }
-      val qualcommNpuModelProvider =
+      val npuModelProvider =
         AiPackModelProvider(context, "selfie_multiclass", "model/segmentation_multiclass.tflite") {
           buildSet {
             if (
-              accelerator == Accelerator.NPU && NpuCompatibilityChecker.Qualcomm.isDeviceSupported()
+              accelerator == Accelerator.NPU &&
+                (NpuCompatibilityChecker.Qualcomm.isDeviceSupported() ||
+                  NpuCompatibilityChecker.GoogleTensor.isDeviceSupported())
             )
               add(Accelerator.NPU)
           }
         }
       val aiPackModelProvider =
-        ModelSelector(cpuGpuModelProvider, mtkNpuModelProvider, qualcommNpuModelProvider)
-          .selectModel(env)
+        ModelSelector(cpuGpuModelProvider, mtkNpuModelProvider, npuModelProvider).selectModel(env)
 
       withContext(singleThreadDispatcher) {
         val options = CompiledModel.Options(aiPackModelProvider.getCompatibleAccelerators()).apply {

--- a/compiled_model_api/image_segmentation/kotlin_npu/android/settings.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android/settings.gradle.kts
@@ -50,6 +50,8 @@ include(":litert_npu_runtime_libraries:runtime_strings")
 
 include(":litert_npu_runtime_libraries:mediatek_runtime")
 
+include(":litert_npu_runtime_libraries:google_tensor_runtime")
+
 include(":litert_npu_runtime_libraries:qualcomm_runtime_v69")
 
 include(":litert_npu_runtime_libraries:qualcomm_runtime_v73")

--- a/compiled_model_api/image_segmentation/kotlin_npu/android_jit/app/build.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android_jit/app/build.gradle.kts
@@ -57,6 +57,7 @@ android {
 
   // NPU runtime libraries
   dynamicFeatures.add(":litert_npu_runtime_libraries:mediatek_runtime")
+  dynamicFeatures.add(":litert_npu_runtime_libraries:google_tensor_runtime")
   dynamicFeatures.add(":litert_npu_runtime_libraries:qualcomm_runtime_v69")
   dynamicFeatures.add(":litert_npu_runtime_libraries:qualcomm_runtime_v73")
   dynamicFeatures.add(":litert_npu_runtime_libraries:qualcomm_runtime_v75")

--- a/compiled_model_api/image_segmentation/kotlin_npu/android_jit/app/device_targeting_configuration.xml
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android_jit/app/device_targeting_configuration.xml
@@ -70,4 +70,19 @@
       <config:system-on-chip manufacturer="QTI" model="SM8850"/>
     </config:device-selector>
   </config:device-group>
+  <config:device-group name="Google_Tensor_G5">
+    <config:device-selector>
+      <config:system-on-chip manufacturer="Google" model="Tensor G5"/>
+    </config:device-selector>
+  </config:device-group>
+  <config:device-group name="Google_Tensor_G4">
+    <config:device-selector>
+      <config:system-on-chip manufacturer="Google" model="Tensor G4"/>
+    </config:device-selector>
+  </config:device-group>
+  <config:device-group name="Google_Tensor_G3">
+    <config:device-selector>
+      <config:system-on-chip manufacturer="Google" model="Tensor G3"/>
+    </config:device-selector>
+  </config:device-group>
 </config:device-targeting-config>

--- a/compiled_model_api/image_segmentation/kotlin_npu/android_jit/settings.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_npu/android_jit/settings.gradle.kts
@@ -45,6 +45,8 @@ include(":litert_npu_runtime_libraries:runtime_strings")
 
 include(":litert_npu_runtime_libraries:mediatek_runtime")
 
+include(":litert_npu_runtime_libraries:google_tensor_runtime")
+
 include(":litert_npu_runtime_libraries:qualcomm_runtime_v69")
 
 include(":litert_npu_runtime_libraries:qualcomm_runtime_v73")


### PR DESCRIPTION
Key changes include:
- Kotlin Image Segmentation (kotlin_npu): Updated ImageSegmentationHelper.kt to use NpuCompatibilityChecker.
- C++ Async Segmentation (c++_segmentation): Added cpp_segmentation_npu_google_tensor cc_binary target in Bazel build, updated main_npu.cc to support google_tensor vendor argument, updated deploy_and_run_on_android.sh to support Google Tensor G5 Pixel devices using precompiled model.