### PR TITLE
colab: on-device-rag litert-lm

### DIFF
--- a/compiled_model_api/colab/On_Device_RAG.ipynb
+++ b/compiled_model_api/colab/On_Device_RAG.ipynb
@@ -1,0 +1,516 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c617cd8726e4"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/google-ai-edge/litert-samples/blob/main/compiled_model_api/colab/On_Device_RAG.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "62f5797ad760"
+      },
+      "source": [
+        "##### Copyright 2026 The AI Edge Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "906e07f6e562"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1f7c44d5c6c4"
+      },
+      "source": [
+        "# On Device RAG using Lite-RT Gemma-4 and Qdrant Edge\n",
+        "\n",
+        "### Overview\n",
+        "\n",
+        "Build a fully on-device RAG pipeline that runs entirely without any cloud API calls. It combines three local components: a Qdrant edge vector store for retrieval, a Google Embedding Gemma model for semantic search, and Gemma 4 via LiteRT-LM for answer generation with all running locally on CPU. \n",
+        "\n",
+        "- Vector store setup: Uses qdrant-edge-py to create a local EdgeShard with cosine similarity, then index 10 sample documents encoded ``via google/embeddinggemma-300m``\n",
+        "- Semantic retrieval: Encodes the user query with the same embedding model and runs a nearest-neighbor search on the shard to pull the top-2 most relevant document chunks as context.\n",
+        "- On-device LLM inference: Feeds the retrieved context into Gemma-4-E2B running locally via litert_lm.Engine on CPU backend, with a strict RAG system prompt instructing the model to only answer from the provided context."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d87dfa8c6c3b"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the Python dependencies and the Vulkan library needed by LiteRT-LM's backend. Since we will be running on CPU no need to switch to the hardware accelerator. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "vxcC-XHy10sQ"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\u001b[2mUsing Python 3.12.13 environment at: /usr\u001b[0m\n",
+            "\u001b[2K\u001b[2mResolved \u001b[1m41 packages\u001b[0m \u001b[2min 681ms\u001b[0m\u001b[0m                                        \u001b[0m\n",
+            "\u001b[2K\u001b[2mPrepared \u001b[1m2 packages\u001b[0m \u001b[2min 889ms\u001b[0m\u001b[0m                                             \n",
+            "\u001b[2K\u001b[2mInstalled \u001b[1m2 packages\u001b[0m \u001b[2min 1ms\u001b[0m\u001b[0m1                                \u001b[0m\n",
+            " \u001b[32m+\u001b[39m \u001b[1mlitert-lm-api\u001b[0m\u001b[2m==0.13.1\u001b[0m\n",
+            " \u001b[32m+\u001b[39m \u001b[1mqdrant-edge-py\u001b[0m\u001b[2m==0.7.2\u001b[0m\n"
+          ]
+        }
+      ],
+      "source": [
+        "!uv pip install litert-lm-api qdrant-edge-py sentence-transformers"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "pjqXBCEWFOKF"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Reading package lists... Done\n",
+            "Building dependency tree... Done\n",
+            "Reading state information... Done\n",
+            "The following additional packages will be installed:\n",
+            "  mesa-vulkan-drivers\n",
+            "The following NEW packages will be installed:\n",
+            "  libvulkan1 mesa-vulkan-drivers\n",
+            "0 upgraded, 2 newly installed, 0 to remove and 3 not upgraded.\n",
+            "Need to get 10.9 MB of archives.\n",
+            "After this operation, 51.3 MB of additional disk space will be used.\n",
+            "Get:1 http://archive.ubuntu.com/ubuntu jammy/main amd64 libvulkan1 amd64 1.3.204.1-2 [128 kB]\n",
+            "Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 mesa-vulkan-drivers amd64 23.2.1-1ubuntu3.1~22.04.3 [10.7 MB]\n",
+            "Fetched 10.9 MB in 0s (58.3 MB/s)             \n",
+            "Selecting previously unselected package libvulkan1:amd64.\n",
+            "(Reading database ... 118243 files and directories currently installed.)\n",
+            "Preparing to unpack .../libvulkan1_1.3.204.1-2_amd64.deb ...\n",
+            "Unpacking libvulkan1:amd64 (1.3.204.1-2) ...\n",
+            "Selecting previously unselected package mesa-vulkan-drivers:amd64.\n",
+            "Preparing to unpack .../mesa-vulkan-drivers_23.2.1-1ubuntu3.1~22.04.3_amd64.deb ...\n",
+            "Unpacking mesa-vulkan-drivers:amd64 (23.2.1-1ubuntu3.1~22.04.3) ...\n",
+            "Setting up libvulkan1:amd64 (1.3.204.1-2) ...\n",
+            "Setting up mesa-vulkan-drivers:amd64 (23.2.1-1ubuntu3.1~22.04.3) ...\n",
+            "Processing triggers for libc-bin (2.35-0ubuntu3.13) ...\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libur_adapter_opencl.so.0 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtbbmalloc_proxy.so.2 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtcm_debug.so.1 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libur_adapter_level_zero.so.0 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtcm.so.1 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libumf.so.1 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtbbbind_2_5.so.3 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtbbbind.so.3 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtbb.so.12 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libur_loader.so.0 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtbbmalloc.so.2 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libhwloc.so.15 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libur_adapter_level_zero_v2.so.0 is not a symbolic link\n",
+            "\n",
+            "/sbin/ldconfig.real: /usr/local/lib/libtbbbind_2_0.so.3 is not a symbolic link\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "!apt-get install -y libvulkan1"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "98cddeba532e"
+      },
+      "source": [
+        "## Initial Setup\n",
+        "\n",
+        "To use [google/embeddinggemma-300m](https://huggingface.co/google/embeddinggemma-300m), you first need to accept the model terms on its Hugging Face page and then generate a token from [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) and paste it below.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "MXIsNkB73862"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import shutil\n",
+        "\n",
+        "from sentence_transformers import SentenceTransformer\n",
+        "from qdrant_edge import (\n",
+        "    Distance,EdgeConfig,EdgeShard,EdgeVectorParams,\n",
+        "    Point,Query,QueryRequest,UpdateOperation,\n",
+        ")\n",
+        "\n",
+        "import litert_lm"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SJLRvzpA4DpB"
+      },
+      "outputs": [],
+      "source": [
+        "os.environ[\"HF_TOKEN\"] = \"<replace-with-hf-token>\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "lndQ_qtd4FGz"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_DIM = 768\n",
+        "MODEL_NAME = \"google/embeddinggemma-300m\"\n",
+        "\n",
+        "path = \"./tmp/qdrant_edge_eg\"\n",
+        "shutil.rmtree(path, ignore_errors=True)\n",
+        "os.makedirs(path)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HCaIDh9_4CkV"
+      },
+      "outputs": [],
+      "source": [
+        "model = SentenceTransformer(MODEL_NAME)\n",
+        "shard = EdgeShard.create(\n",
+        "    path,\n",
+        "    EdgeConfig(vectors=EdgeVectorParams(size=MODEL_DIM, distance=Distance.Cosine)),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d60e9394b7f0"
+      },
+      "source": [
+        "## Index your document\n",
+        "\n",
+        "Encode all documents into 768-dim vectors using the embedding model, then upsert them into the Qdrant edge shard as points with their text as payload. shard.optimize() finalizes the index for faster query performance."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "xjtqKCkk7bRV"
+      },
+      "outputs": [],
+      "source": [
+        "documents = [\n",
+        "    (1, \"The bakery opens just before dawn, when the streets are still quiet and the first customers begin walking in for fresh bread. The smell of warm sourdough fills the small shop as the bakers arrange loaves, croissants, and pastries behind the counter. Many people stop there every morning before work because the bakery has become a familiar part of the neighborhood.\"),\n",
+        "    (2, \"A golden retriever ran happily across the park after its owner threw a bright tennis ball into the grass. Children nearby stopped to watch as the dog jumped, rolled, and carried the ball back with excitement. The park was full of people enjoying the sunny afternoon, but the playful dog easily became the center of attention.\"),\n",
+        "    (3, \"Python decorators are a powerful feature used to wrap functions and extend their behavior without changing the original function code. Developers often use decorators for logging, caching, authentication, and performance tracking. They make the code cleaner by separating repeated logic from the main business logic.\"),\n",
+        "    (4, \"Heavy rain continued through the night and caused several streets to flood by early morning. Commuters had to wait longer than usual because buses were delayed and traffic moved slowly across the city. Many people arrived late to work, while others decided to stay home until the weather improved.\"),\n",
+        "    (5, \"She booked a window seat on the overnight train to Vienna because she wanted to watch the quiet towns pass by during the journey. Her dog rested beside her in a small travel carrier, occasionally waking up whenever the train stopped at a station. The trip felt peaceful, and she enjoyed the comfort of traveling slowly through the night.\"),\n",
+        "    (6, \"The old library stood at the corner of the main road, surrounded by tall trees and a quiet garden. Students often came there after school to study, read novels, or prepare for exams in the large reading hall. Even though the building was old, it remained one of the most loved places in the town.\"),\n",
+        "    (7, \"The startup team worked late into the evening to finish the first version of their product before the investor demo. Everyone had a different responsibility, from fixing bugs to improving the user interface and preparing the final presentation. By midnight, they were tired but excited because the product finally started to feel real.\"),\n",
+        "    (8, \"The mountain village was covered in mist when the travelers arrived early in the morning. Small houses with wooden balconies stood along narrow paths, and smoke rose slowly from kitchen chimneys. The place felt calm and untouched, making it perfect for people who wanted to escape the noise of the city.\"),\n",
+        "    (9, \"The school science fair attracted students, parents, and teachers from across the district. Each team presented a different project, including simple robots, water filtration models, and solar powered devices. The event encouraged students to explain their ideas clearly and learn from what others had built.\"),\n",
+        "    (10, \"The restaurant near the beach became popular because of its simple food, friendly staff, and beautiful sunset view. Tourists usually visited in the evening, while locals preferred coming during quiet afternoons. The owner personally greeted regular customers and made sure every table felt comfortable and welcome.\"),\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "ODNtFuCx8Oxp"
+      },
+      "outputs": [],
+      "source": [
+        "texts = [text for _, text in documents]\n",
+        "embeddings = model.encode_document(texts)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "i6Zp-oMj8PQ4"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "False"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "shard.update(UpdateOperation.upsert_points([\n",
+        "    Point(\n",
+        "        point_id,\n",
+        "        embeddings[i].tolist(),\n",
+        "        {\"text\": text},\n",
+        "    )\n",
+        "    for i, (point_id, text) in enumerate(documents)\n",
+        "]))\n",
+        "shard.optimize()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "510c24e6c14c"
+      },
+      "source": [
+        "### Test your retrieval\n",
+        "\n",
+        "Ask a user query and retrieve the top_k = 2 relevant documents from the Qdrant-Edge knowledge store. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "Pkv7ueRE72K_"
+      },
+      "outputs": [],
+      "source": [
+        "user_query = \"Which animal chased the tennis ball?\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "65qLnKwT8WW2"
+      },
+      "outputs": [],
+      "source": [
+        "query_vector = model.encode_query(user_query).tolist()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "fO6iBiZs8AOt"
+      },
+      "outputs": [],
+      "source": [
+        "results = shard.query(QueryRequest(\n",
+        "    query=Query.Nearest(query_vector),\n",
+        "    limit=2,\n",
+        "    with_payload=True,\n",
+        "))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "id": "HR6f6dVl8nTs"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "A golden retriever ran happily across the park after its owner threw a bright tennis ball into the grass. Children nearby stopped to watch as the dog jumped, rolled, and carried the ball back with excitement. The park was full of people enjoying the sunny afternoon, but the playful dog easily became the center of attention.She booked a window seat on the overnight train to Vienna because she wanted to watch the quiet towns pass by during the journey. Her dog rested beside her in a small travel carrier, occasionally waking up whenever the train stopped at a station. The trip felt peaceful, and she enjoyed the comfort of traveling slowly through the night.\n"
+          ]
+        }
+      ],
+      "source": [
+        "context = \"\"\n",
+        "for point in results:\n",
+        "  context+= point.payload['text']\n",
+        "\n",
+        "print(context)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5107ecf62ca9"
+      },
+      "source": [
+        "## Define System Prompt\n",
+        "\n",
+        "Set up the system message that instructs Gemma to act as a RAG assistant answering strictly from the retrieved context and keeping responses concise. This is passed into the conversation at engine initialization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "i55uShYQDcTS"
+      },
+      "outputs": [],
+      "source": [
+        "messages = [\n",
+        "    litert_lm.Message.system(\n",
+        "        \"You are a helpful RAG assistant. \"\n",
+        "        \"Answer the user question using only the provided context. \"\n",
+        "        \"If the answer is not in the context, say: I don't know based on the provided context. \"\n",
+        "        \"Keep the answer short.\"\n",
+        "    )\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "415e95ba7759"
+      },
+      "source": [
+        "## On-Device LLM Inference using Lite-RT LM\n",
+        "\n",
+        "- Download only the base gemma-4-E2B-it.litertlm file (~2.6GB) from HuggingFace instead of the full repo. \n",
+        "- Initialize the LiteRT-LM engine on CPU backend with the system prompt. \n",
+        "- Answer Generation: The conversation sends the retrieved context and user query to Gemma 4, which generates an answer strictly grounded in the provided context. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "DhsA_1MN-wG-"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\u001b[90mHint: A new version of huggingface_hub (1.19.0) is available! You are using version 1.18.0.\n",
+            "To update, run: hf update\u001b[0m\n",
+            "gemma-4-E2B-it.litertlm: 100% 2.59G/2.59G [00:21<00:00, 122MB/s] \n",
+            "\u001b[32m✓ Downloaded\u001b[0m\n",
+            "  path: /root/gemma4/gemma-4-E2B-it.litertlm\n"
+          ]
+        }
+      ],
+      "source": [
+        "!hf download litert-community/gemma-4-E2B-it-litert-lm gemma-4-E2B-it.litertlm --local-dir ~/gemma4"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "g6Kw-NDEBdLm"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "gemma-4-E2B-it.litertlm\n"
+          ]
+        }
+      ],
+      "source": [
+        "!ls /root/gemma4"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "id": "XEhIYJQS9Dtt"
+      },
+      "outputs": [],
+      "source": [
+        "GEMMA4_LITELLM = \"/root/gemma4/gemma-4-E2B-it.litertlm\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "id": "KhpU30EL3hf_"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "A golden retriever chased the tennis ball.\n"
+          ]
+        }
+      ],
+      "source": [
+        "with litert_lm.Engine(\n",
+        "    GEMMA4_LITELLM,\n",
+        "    backend=litert_lm.Backend.CPU(),\n",
+        ") as engine:\n",
+        "    with engine.create_conversation(messages=messages) as conversation:\n",
+        "        response = conversation.send_message(f\"Context:\\n{context}\\n\\nQuestion:\\n{user_query}\")\n",
+        "        print(response[\"content\"][0][\"text\"])"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "On_Device_RAG.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
tl;dr: On Device RAG using Lite-RT Gemma-4 and Qdrant Edge

> Overview

Build a fully on-device RAG pipeline that runs entirely without any cloud API calls. It combines three local components: a Qdrant edge vector store for retrieval, a Google Embedding Gemma model for semantic search, and Gemma 4 via LiteRT-LM for answer generation with all running locally on CPU. 

- Vector store setup: Uses qdrant-edge-py to create a local EdgeShard with cosine similarity, then index 10 sample documents encoded ``via google/embeddinggemma-300m``
- Semantic retrieval: Encodes the user query with the same embedding model and runs a nearest-neighbor search on the shard to pull the top-2 most relevant document chunks as context.
- On-device LLM inference: Feeds the retrieved context into Gemma-4-E2B running locally via litert_lm.Engine on CPU backend, with a strict RAG system prompt instructing the model to only answer from the provided context.