### PR TITLE
Revise README title for iOS image segmentation

### DIFF
--- a/compiled_model_api/image_segmentation/ios/README.md
+++ b/compiled_model_api/image_segmentation/ios/README.md
@@ -1,4 +1,4 @@
-# LiteRT Image Segmentation - iOS (Clean App)
+# LiteRT Image Segmentation - iOS
 
 An iOS application demonstrating real-time and static image segmentation using LiteRT's Compiled Model API. The app performs multi-class segmentation on a bundled test image, allowing easy verification of CPU (Builtin Kernels) and GPU (Metal) execution.
 


### PR DESCRIPTION
Updated the README to remove 'Clean App' from the title.