### PR TITLE
integrate litert-support ImageProcessor for input preprocessing for v2 image segmentation sample app

### DIFF
--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/build.gradle.kts
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/build.gradle.kts
@@ -86,7 +86,13 @@ dependencies {
   implementation(libs.androidx.material.icons.core)
   implementation(libs.androidx.material.icons.extended)
   implementation(libs.androidx.material2)
-  implementation(libs.litert)
+  implementation(libs.litert) {
+    exclude(group = "com.google.ai.edge.litert", module = "litert-support")
+    exclude(group = "com.google.ai.edge.litert", module = "litert-support-api")
+  }
+  implementation(libs.litert.support) {
+    exclude(group = "com.google.ai.edge.litert", module = "litert-api")
+  }
   implementation(libs.androidx.camera.core)
   implementation(libs.androidx.camera.lifecycle)
   implementation(libs.androidx.camera.view)

--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/ImageSegmentationHelper.kt
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/app/src/main/java/com/google/ai/edge/examples/image_segmentation/ImageSegmentationHelper.kt
@@ -36,6 +36,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 
+import org.tensorflow.lite.support.common.ops.NormalizeOp
+import org.tensorflow.lite.support.image.ImageProcessor
+import org.tensorflow.lite.support.image.TensorImage
+import org.tensorflow.lite.support.image.ops.ResizeOp
+import org.tensorflow.lite.support.image.ops.Rot90Op
+
 class ImageSegmentationHelper(private val context: Context) {
   /** As the result of image segmentation, this value emits map of probabilities */
   val segmentation: SharedFlow<SegmentationResult>
@@ -122,13 +128,19 @@ class ImageSegmentationHelper(private val context: Context) {
       val rotation = -rotationDegrees / 90
       val (h, w) = Pair(256, 256)
 
-      // Preprocessing timing
+      // Preprocessing timing using litert-support ImageProcessor
       val preprocessStartTime = SystemClock.uptimeMillis()
-      var image = bitmap.scale(w, h, true)
-      image = rot90Clockwise(image, rotation)
-      val inputFloatArray = normalize(image, 127.5f, 127.5f)
+      val imageProcessor =
+        ImageProcessor.Builder()
+          .add(ResizeOp(h, w, ResizeOp.ResizeMethod.BILINEAR))
+          .add(Rot90Op(rotation))
+          .add(NormalizeOp(127.5f, 127.5f))
+          .build()
+
+      val tensorImage = imageProcessor.process(TensorImage.fromBitmap(bitmap))
+      val inputFloatArray = tensorImage.tensorBuffer.floatArray
       val preprocessTime = SystemClock.uptimeMillis() - preprocessStartTime
-      Log.d(TAG, "Preprocessing time: $preprocessTime ms")
+      Log.d(TAG, "Preprocessing time (via litert-support ImageProcessor): $preprocessTime ms")
 
       // Inference timing (includes both model execution and mask processing)
       val inferenceStartTime = SystemClock.uptimeMillis()

--- a/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/gradle/libs.versions.toml
+++ b/compiled_model_api/image_segmentation/kotlin_cpu_gpu/android/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ activityCompose = "1.12.1"
 composeBom = "2025.12.00"
 undercouchDownload = "5.6.0"
 litert = "2.1.6"
+litertSupport = "1.0.0"
 cameraCore = "1.5.2"
 compose = "1.5.0"
 composeLivedata = "1.9.4"
@@ -54,6 +55,7 @@ androidx-material2 = { group = "androidx.compose.material", name = "material", v
 androidx-camera-core = { group = "androidx.camera", name = "camera-core", version.ref = "cameraCore" }
 
 litert = { group = "com.google.ai.edge.litert", name = "litert", version.ref = "litert" }
+litert-support = { group = "com.google.ai.edge.litert", name = "litert-support", version.ref = "litertSupport" }
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraCore" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraCore" }
 androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "cameraCore" }


### PR DESCRIPTION
Summary of changes:
- changes done in: compiled_model_api/image_segmentation/kotlin_cpu_gpu
- Add `litertSupport = "1.0.0"` and `litert-support` library entry in `libs.versions.toml`.
- Declare `libs.litert.support` in `app/build.gradle.kts` with proper dependency exclusions.
- Update `ImageSegmentationHelper.kt` to build an `ImageProcessor` pipeline (Bilinear Resize, Rot90, Normalize).
- Convert input Bitmap to `TensorImage` and write preprocessed float array directly to `CompiledModel` input buffers.