### PR TITLE
Add Qwen3-TTS Tensor API implementation (talker step graph, codec decoder, verification suite)

### DIFF
--- a/models/qwen/qwen3_tts/tensor_api/README.md
+++ b/models/qwen/qwen3_tts/tensor_api/README.md
@@ -1,3 +1,125 @@
 # Qwen3-TTS Tensor API Implementation
 
-Qwen3-TTS implementation using the LiteRT Tensor API.
+Qwen3-TTS-12Hz-0.6B-Base implemented by authoring the graphs directly with
+the [LiteRT Tensor API](https://github.com/google-ai-edge/LiteRT/tree/main/tensor)
+(C++, no converter), plus a C++ reference host loop. Companion code to the
+"Audio-LM Loop Design Note (Tensor API)".
+
+## This project demonstrates:
+
+1.  Authoring a full autoregressive TTS decode step as one Tensor API
+    graph: `prefill`/`decode` signatures sharing weights, fixed-size KV
+    caches as signature I/O (DynamicUpdateSlice at a runtime position,
+    zero-copy output→input rebind), codebook-0 pick + 15-group code
+    predictor + next-frame feedback aggregation in-graph — one signature
+    call per 12.5 Hz frame. Both code predictor forms are build-time
+    options (re-forward unroll for GPUs, KV-cached incremental for CPUs;
+    ids bit-identical).
+2.  The full speech_tokenizer decoder (RVQ + transformer + vocoder) as one
+    Tensor API graph, with the causal 64+25 chunk schedule on the host.
+3.  Composite adoption in an authored graph: `odml.runtime_bmm` (talker
+    attention, `--attention=rbmm`) and `odml.rms_norm`
+    (`--norms=composite`); `attn_bench` compares raw ops vs
+    `odml.scaled_dot_product_attention` vs the `odml.runtime_bmm` +
+    `odml.cache_update` pair at identical inputs, including multi-step
+    feedback-loop runs (LiteRT PR #8796).
+4.  Weight quantization paths: fp32, int8 per-channel, int4 blockwise-32,
+    and pre-quantized (GPTQ) companion files.
+5.  Sampling through a host-staged additive bias input: suppression, EOS
+    gating, min-new-tokens, and exact temperature sampling (Gumbel
+    noise-as-input) — no RNG op needed in-graph.
+6.  Bit-exact verification against independent numpy references on the
+    real checkpoint, plus an end-to-end text → wav smoke driver.
+
+## Directory layout
+
+*   `talker_step/` — talker decode-step graph, weights loader, host
+    reference loop (`talker_main.cc`), and the attention micro-benchmark
+    (`attn_bench.cc`).
+*   `codec_decode/` — codec decoder graph, weights loader, and host
+    chunking driver (`codec_main.cc`).
+*   `verify/` — numpy references for both graphs, the GPTQ quantizer
+    (emits the exact blockwise-32 layout the C++ loader consumes), speaker
+    x-vector enrollment, and `audio_smoke.py` (text → wav end to end).
+
+## Prerequisites
+
+1.  **Bazel**: installed via bazelisk (version pinned by `.bazelversion`).
+2.  **Android NDK** 26+ for Android builds (tested with r27) and **ADB**
+    for on-device runs.
+3.  **Python 3 + numpy** for `verify/` (torch additionally for the GPTQ
+    and speaker-enrollment scripts).
+4.  **Weights**: the Qwen3-TTS-12Hz-0.6B-Base checkpoint (safetensors)
+    from Hugging Face — not included in this repository. `talker_main`
+    runs without `--weights` using synthetic weights under the real
+    tensor names (useful for smoke tests); `codec_main` requires the
+    checkpoint.
+
+## Build Instructions
+
+All commands are run from the repository root (the workspace pulls LiteRT
+`main` as `@litert_archive`).
+
+```bash
+# macOS (Apple silicon)
+bazel build --config=macos_arm64 //models/qwen/qwen3_tts/tensor_api/talker_step:talker_main
+bazel build --config=macos_arm64 //models/qwen/qwen3_tts/tensor_api/codec_decode:codec_main
+
+# Android (the two extra flags mirror LiteRT's own android_arm64 config;
+# needed until this repository's .bazelrc carries them)
+ANDROID_NDK_HOME=<ndk> bazel build -c opt --config=android_arm64 \
+  --incompatible_enable_cc_toolchain_resolution \
+  --incompatible_enable_android_toolchain_resolution \
+  //models/qwen/qwen3_tts/tensor_api/talker_step:talker_main
+```
+
+Runtime behavior was validated at LiteRT commit `a19d8fa` plus the
+PR #8796 runner change; against current `main`, all sources compile and
+the Android arm64 binaries build and link from this workspace. Please
+tell us if anything else drifts and we will chase it.
+
+## Run
+
+```bash
+# Talker: one signature call per frame, benchmark + optional dumps
+talker_main --layers=28 --weights=<ckpt>/model.safetensors \
+  --accelerator=gpu --gpu_buffer_storage=buffer
+
+# Codec: codes -> 24 kHz waveform with production-style chunking
+codec_main --weights=<ckpt>/speech_tokenizer/model.safetensors \
+  --frames=128 --accelerator=cpu --dump_wav=/tmp/out.f32
+
+# End to end (text -> wav), driving both binaries:
+python3 verify/audio_smoke.py --help
+```
+
+GPU runs on macOS need `libLiteRtMetalAccelerator.dylib` (shipped in the
+target's runfiles) in the working directory. The Metal delegate's default
+compute precision is fp16; set `--gpu_precision` explicitly when comparing
+against fp32 references. On Metal use `--gpu_buffer_storage=buffer` for
+max_seq ≥ 1024 (texture storage silently falls back to CPU).
+
+## Measured highlights
+
+Frame budget = 80 ms (12.5 Hz).
+
+*   Pixel 8a CPU, GPTQ int4 blockwise-32, KV-cached code predictor:
+    99.6 ms/frame = RTF 1.24 (thermal-controlled).
+*   M4 Max Metal, GPTQ int4 + composite stack (runtime_bmm + rms_norm):
+    17.3 ms/frame = RTF 0.216; fp16 raw→composite 22.3 → 20.4 ms (−8.7%).
+*   Codec on GPU: 17.6 ms (Mali) / 47.4 ms (Metal fp16) per 89-frame
+    window.
+*   KV-cache rebind by buffer handle is zero-copy and
+    in-place-DUS-eligible; naive copy-rebind costs +24%/frame (M4 Max) /
+    +35%/frame (Pixel 8a).
+*   Quantization that survives listening tests: blockwise int4 (GPTQ ≥
+    RTN); per-channel int8 collapses in long rollouts even where
+    short-horizon id checks look healthy — gate quant recipes on full
+    listenable rollouts.
+
+## Findings ledger and evidence notes
+
+The living findings ledger (delegate/composite observations with repro
+commands), the standalone repro tools, and the per-campaign evidence notes
+are maintained at
+[john-rocky/litert-tensor-audio-examples](https://github.com/john-rocky/litert-tensor-audio-examples).

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/BUILD
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/BUILD
@@ -1,0 +1,89 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(
+    "@litert_archive//litert/build_common:special_rule.bzl",
+    "litert_android_linkopts",
+    "litert_gpu_accelerator_prebuilts",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "codec_config",
+    hdrs = ["codec_config.h"],
+)
+
+cc_library(
+    name = "codec_graph",
+    srcs = ["codec_graph.cc"],
+    hdrs = ["codec_graph.h"],
+    deps = [
+        ":codec_config",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "codec_weights",
+    srcs = ["codec_weights.cc"],
+    hdrs = ["codec_weights.h"],
+    deps = [
+        ":codec_config",
+        ":codec_graph",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/examples/gemma3:safetensor_loader",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_binary(
+    name = "codec_main",
+    srcs = ["codec_main.cc"],
+    copts = ["-DGOOGLE_COMMANDLINEFLAGS_FULL_API=1"] + select({
+        "@litert_archive//litert:android": ["-DABSL_FLAGS_STRIP_NAMES=0"],
+        "//conditions:default": [],
+    }),
+    data = litert_gpu_accelerator_prebuilts(),
+    linkopts = litert_android_linkopts(),
+    deps = [
+        ":codec_config",
+        ":codec_graph",
+        ":codec_weights",
+        "@litert_archive//litert/cc:litert_common",
+        "@litert_archive//litert/cc:litert_environment",
+        "@litert_archive//litert/cc:litert_options",
+        "@litert_archive//litert/cc/options:litert_gpu_options",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:tflite_flatbuffer_conversion",
+        "@litert_archive//tensor/runners/litert:litert_dynamic_runner",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+    ],
+)

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_config.h
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_config.h
@@ -1,0 +1,70 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Qwen3-TTS-Tokenizer-12Hz codec DECODER config, from
+// speech_tokenizer/config.json (decoder_config) of
+// Qwen/Qwen3-TTS-12Hz-0.6B-Base.
+
+#ifndef SPEECHLM_STAGE1_CODEC_DECODE_CODEC_CONFIG_H_
+#define SPEECHLM_STAGE1_CODEC_DECODE_CODEC_CONFIG_H_
+
+#include <vector>
+
+namespace litert::tensor::examples::codec {
+
+struct CodecConfig {
+  // RVQ (SplitResidualVectorQuantizer): 1 semantic + 15 acoustic codebooks,
+  // EMA codebooks (embedding = embedding_sum / clamp(cluster_usage, eps)).
+  int num_quantizers = 16;
+  int codebook_size = 2048;
+  int vq_dim = 256;        // internal codebook dim (codebook_dim / 2)
+  int codebook_dim = 512;  // RVQ output dim (after output_proj)
+  float vq_eps = 1e-5f;
+
+  // pre_transformer (8L, MHA, rope, sliding-window causal, LayerScale).
+  int tf_hidden = 512;
+  int tf_layers = 8;
+  int tf_heads = 16;
+  int tf_head_dim = 64;
+  int tf_ffn = 1024;
+  float tf_eps = 1e-5f;
+  float rope_theta = 10000.0f;
+  int sliding_window = 72;
+
+  // Conv stack.
+  int latent_dim = 1024;
+  int decoder_dim = 1536;
+  std::vector<int> upsampling_ratios = {2, 2};   // TransConv k=s + ConvNeXt
+  std::vector<int> upsample_rates = {8, 5, 4, 3};  // decoder blocks
+
+  // Host chunking (production: 64-frame chunks with 25 frames left context).
+  int chunk_frames = 64;
+  int context_frames = 25;
+
+  int total_upsample() const {
+    int p = 1;
+    for (int r : upsample_rates) p *= r;
+    for (int r : upsampling_ratios) p *= r;
+    return p;  // 1920: 12.5 Hz frames -> 24 kHz samples
+  }
+  int block_in_dim(int i) const { return decoder_dim >> i; }
+  int block_out_dim(int i) const { return decoder_dim >> (i + 1); }
+  int output_dim() const {
+    return decoder_dim >> static_cast<int>(upsample_rates.size());  // 96
+  }
+};
+
+}  // namespace litert::tensor::examples::codec
+
+#endif  // SPEECHLM_STAGE1_CODEC_DECODE_CODEC_CONFIG_H_

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.cc
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.cc
@@ -1,0 +1,337 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Codec decoder step-graph. See codec_graph.h.
+
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/log/absl_check.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "tensor/arithmetic.h"
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_config.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::codec {
+
+namespace {
+
+constexpr float kMaskFloor = -30000.0f;  // fp16-safe additive mask floor
+
+TfTensor Const1(float value) {
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>({value})});
+}
+
+const TfTensor& W(const WeightMap& weights, const std::string& name) {
+  auto it = weights.find(name);
+  ABSL_CHECK(it != weights.end()) << "missing weight: " << name;
+  return it->second;
+}
+
+// ---- generic pieces ------------------------------------------------------
+
+TfTensor RmsNorm(const TfTensor& input, const TfTensor& scale, float eps) {
+  TfTensor x2 = Mul(input, input);
+  int last = static_cast<int>(input.GetShape().size()) - 1;
+  TfTensor ms = Mean(x2, {last}, /*keep_dims=*/true);
+  return Mul(Mul(input, Rsqrt(Add(ms, Const1(eps)))), scale);
+}
+
+TfTensor Silu(const TfTensor& x) { return Mul(x, Logistic(x)); }
+
+// LayerNorm over the last axis with gamma+beta (ConvNeXt norm).
+TfTensor LayerNorm(const TfTensor& x, const TfTensor& gamma,
+                   const TfTensor& beta, float eps) {
+  int last = static_cast<int>(x.GetShape().size()) - 1;
+  TfTensor m = Mean(x, {last}, /*keep_dims=*/true);
+  TfTensor d = Sub(x, m);
+  TfTensor v = Mean(Mul(d, d), {last}, /*keep_dims=*/true);
+  return Add(Mul(Mul(d, Rsqrt(Add(v, Const1(eps)))), gamma), beta);
+}
+
+// SnakeBeta on NHWC [1,1,T,C]: x + beta_inv * sin(x * alpha_exp)^2, with
+// alpha_exp = exp(alpha), beta_inv = 1/(exp(beta)+1e-9) precomputed at load.
+TfTensor Snake(const TfTensor& x, const TfTensor& alpha_exp,
+               const TfTensor& beta_inv) {
+  TfTensor s = Sin(Mul(x, alpha_exp));
+  return Add(x, Mul(beta_inv, Mul(s, s)));
+}
+
+// Left-pad the width axis of NHWC [1,1,T,C] by `left` zeros.
+TfTensor PadLeftW(const TfTensor& x, int left) {
+  if (left == 0) return x;
+  TfTensor paddings(
+      {.type = Type::kI32,
+       .shape = {4, 2},
+       .buffer = OwningCpuBuffer::Copy<Type::kI32>(
+           std::vector<int32_t>{0, 0, 0, 0, left, 0, 0, 0})});
+  return Pad(x, paddings);
+}
+
+// Causal Conv1d on NHWC [1,1,T,C]: left-pad (k-1)*dilation, VALID conv.
+// filter [out, 1, k, in] (+bias [out]) already in TFLite layout.
+TfTensor CausalConv(const TfTensor& x, const TfTensor& filter,
+                    const TfTensor& bias, int dilation = 1) {
+  int k = filter.GetShape()[2];
+  TfTensor padded = PadLeftW(x, (k - 1) * dilation);
+  return Conv2D(padded, filter, bias, /*stride_h=*/1, /*stride_w=*/1,
+                kPaddingValid, /*dilation_h=*/1, /*dilation_w=*/dilation);
+}
+
+// Causal depthwise Conv1d k=7 on NHWC; filter [1, 1, k, C].
+TfTensor CausalDwConv(const TfTensor& x, const TfTensor& filter,
+                      const TfTensor& bias) {
+  int k = filter.GetShape()[2];
+  TfTensor padded = PadLeftW(x, k - 1);
+  return DepthwiseConv2D(padded, filter, bias, /*stride_h=*/1, /*stride_w=*/1,
+                         kPaddingValid);
+}
+
+// Causal ConvTranspose1d: VALID transpose-conv (out = (T-1)*s + k), then crop
+// (k - s) from the right. filter [out, 1, k, in], bias [out].
+TfTensor CausalTransConv(const TfTensor& x, const TfTensor& filter,
+                         const TfTensor& bias, int stride) {
+  const auto& s = x.GetShape();  // [1,1,T,in]
+  int T = s[2];
+  int k = filter.GetShape()[2];
+  int out_ch = filter.GetShape()[0];
+  int full = (T - 1) * stride + k;
+  TfTensor y = TransposeConv(filter, x, bias, {1, 1, full, out_ch},
+                             kPaddingValid, /*stride_h=*/1,
+                             /*stride_w=*/stride);
+  int crop = k - stride;
+  if (crop == 0) return y;
+  return Slice(y, {0, 0, 0, 0}, {1, 1, full - crop, out_ch});
+}
+
+// ---- RVQ -----------------------------------------------------------------
+
+// codes [16, T] -> latent [1, 1, T, codebook_dim].
+TfTensor RvqDecode(const CodecConfig& config, const TfTensor& codes, int T,
+                   const WeightMap& weights) {
+  auto gather_q = [&](int q) {
+    TfTensor row = Slice(codes, {q, 0}, {1, T});
+    TfTensor idx = Reshape(row, {T});  // 1-D indices (Metal-safe)
+    return Gather(W(weights, absl::StrCat("codebook_table_", q)), idx,
+                  /*axis=*/0);  // [T, vq_dim]
+  };
+
+  TfTensor semantic = FullyConnected(
+      gather_q(0), W(weights, "decoder.quantizer.rvq_first.output_proj"));
+  TfTensor acoustic_sum = gather_q(1);
+  for (int q = 2; q < config.num_quantizers; ++q) {
+    acoustic_sum = Add(acoustic_sum, gather_q(q));
+  }
+  TfTensor acoustic = FullyConnected(
+      acoustic_sum, W(weights, "decoder.quantizer.rvq_rest.output_proj"));
+  TfTensor latent = Add(semantic, acoustic);  // [T, codebook_dim]
+  return Reshape(latent, {1, 1, T, config.codebook_dim});
+}
+
+// ---- pre_transformer -----------------------------------------------------
+
+std::pair<TfTensor, TfTensor> ConstRope(int seq, int head_dim, float base) {
+  std::vector<float> cos_v(static_cast<size_t>(seq) * head_dim);
+  std::vector<float> sin_v(static_cast<size_t>(seq) * head_dim);
+  int half = head_dim / 2;
+  for (int t = 0; t < seq; ++t) {
+    for (int i = 0; i < half; ++i) {
+      float freq = std::pow(base, -2.0f * static_cast<float>(i) / head_dim);
+      float angle = static_cast<float>(t) * freq;
+      cos_v[t * head_dim + i] = std::cos(angle);
+      cos_v[t * head_dim + half + i] = std::cos(angle);
+      sin_v[t * head_dim + i] = std::sin(angle);
+      sin_v[t * head_dim + half + i] = std::sin(angle);
+    }
+  }
+  TfTensor cos_t({.type = Type::kFP32,
+                  .shape = {1, 1, seq, head_dim},
+                  .buffer = OwningCpuBuffer::Copy<Type::kFP32>(cos_v)});
+  TfTensor sin_t({.type = Type::kFP32,
+                  .shape = {1, 1, seq, head_dim},
+                  .buffer = OwningCpuBuffer::Copy<Type::kFP32>(sin_v)});
+  return {cos_t, sin_t};
+}
+
+TfTensor ApplyRope(const TfTensor& x, const TfTensor& cos,
+                   const TfTensor& sin) {
+  const auto& s = x.GetShape();
+  int half = s[3] / 2;
+  TfTensor x1 = Slice(x, {0, 0, 0, 0}, {s[0], s[1], s[2], half});
+  TfTensor x2 = Slice(x, {0, 0, 0, half}, {s[0], s[1], s[2], half});
+  TfTensor rot = Concatenation({Mul(x2, Const1(-1.0f)), x1}, /*axis=*/3);
+  return Add(Mul(x, cos), Mul(rot, sin));
+}
+
+// Baked causal + sliding-window additive mask [1,1,T,T]:
+// key j visible from query i iff i-window < j <= i.
+TfTensor SlidingCausalMask(int T, int window) {
+  std::vector<float> mask(static_cast<size_t>(T) * T, kMaskFloor);
+  for (int i = 0; i < T; ++i) {
+    for (int j = std::max(0, i - window + 1); j <= i; ++j) {
+      mask[static_cast<size_t>(i) * T + j] = 0.0f;
+    }
+  }
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1, 1, T, T},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>(mask)});
+}
+
+// x [1, T, hidden] -> [1, T, hidden]; MHA (heads == kv heads), no qk-norm.
+TfTensor PreTransformer(const CodecConfig& config, TfTensor x, int T,
+                        const WeightMap& weights) {
+  const std::string base = "decoder.pre_transformer";
+  x = FullyConnected(x, W(weights, base + ".input_proj.weight"),
+                     W(weights, base + ".input_proj.bias"));
+
+  auto [cos, sin] = ConstRope(T, config.tf_head_dim, config.rope_theta);
+  TfTensor mask = SlidingCausalMask(T, config.sliding_window);
+  float scale = 1.0f / std::sqrt(static_cast<float>(config.tf_head_dim));
+
+  for (int l = 0; l < config.tf_layers; ++l) {
+    std::string p = absl::StrCat(base, ".layers.", l);
+    TfTensor h = RmsNorm(x, W(weights, p + ".input_layernorm.weight"),
+                         config.tf_eps);
+    TfTensor q = FullyConnected(h, W(weights, p + ".self_attn.q_proj.weight"));
+    TfTensor k = FullyConnected(h, W(weights, p + ".self_attn.k_proj.weight"));
+    TfTensor v = FullyConnected(h, W(weights, p + ".self_attn.v_proj.weight"));
+    q = Transpose(Reshape(q, {1, T, config.tf_heads, config.tf_head_dim}),
+                  {0, 2, 1, 3});
+    k = Transpose(Reshape(k, {1, T, config.tf_heads, config.tf_head_dim}),
+                  {0, 2, 1, 3});
+    v = Transpose(Reshape(v, {1, T, config.tf_heads, config.tf_head_dim}),
+                  {0, 2, 1, 3});
+    q = ApplyRope(q, cos, sin);
+    k = ApplyRope(k, cos, sin);
+    TfTensor scores = BatchMatMul(q, k, /*adj_x=*/false, /*adj_y=*/true);
+    scores = Add(Mul(scores, Const1(scale)), mask);
+    TfTensor attn = BatchMatMul(Softmax(scores), v);
+    attn = Reshape(Transpose(attn, {0, 2, 1, 3}),
+                   {1, T, config.tf_heads * config.tf_head_dim});
+    attn = FullyConnected(attn, W(weights, p + ".self_attn.o_proj.weight"));
+    x = Add(x, Mul(attn, W(weights, p + ".self_attn_layer_scale.scale")));
+
+    TfTensor f = RmsNorm(x, W(weights, p + ".post_attention_layernorm.weight"),
+                         config.tf_eps);
+    TfTensor gate = FullyConnected(f, W(weights, p + ".mlp.gate_proj.weight"));
+    TfTensor up = FullyConnected(f, W(weights, p + ".mlp.up_proj.weight"));
+    TfTensor ffn = FullyConnected(Mul(Silu(gate), up),
+                                  W(weights, p + ".mlp.down_proj.weight"));
+    x = Add(x, Mul(ffn, W(weights, p + ".mlp_layer_scale.scale")));
+  }
+
+  x = RmsNorm(x, W(weights, base + ".norm.weight"), config.tf_eps);
+  return FullyConnected(x, W(weights, base + ".output_proj.weight"),
+                        W(weights, base + ".output_proj.bias"));
+}
+
+// ---- ConvNeXt / decoder blocks ------------------------------------------
+
+TfTensor ConvNeXtBlock(const TfTensor& x, const std::string& p,
+                       const WeightMap& weights) {
+  TfTensor h = CausalDwConv(x, W(weights, p + ".dwconv.conv.weight"),
+                            W(weights, p + ".dwconv.conv.bias"));
+  h = LayerNorm(h, W(weights, p + ".norm.weight"),
+                W(weights, p + ".norm.bias"), 1e-6f);
+  h = FullyConnected(h, W(weights, p + ".pwconv1.weight"),
+                     W(weights, p + ".pwconv1.bias"));
+  h = Gelu(h);
+  h = FullyConnected(h, W(weights, p + ".pwconv2.weight"),
+                     W(weights, p + ".pwconv2.bias"));
+  h = Mul(h, W(weights, p + ".gamma"));
+  return Add(x, h);
+}
+
+TfTensor ResidualUnit(const TfTensor& x, const std::string& p, int dilation,
+                      const WeightMap& weights) {
+  TfTensor h = Snake(x, W(weights, p + ".act1.alpha_exp"),
+                     W(weights, p + ".act1.beta_inv"));
+  h = CausalConv(h, W(weights, p + ".conv1.conv.weight"),
+                 W(weights, p + ".conv1.conv.bias"), dilation);
+  h = Snake(h, W(weights, p + ".act2.alpha_exp"),
+            W(weights, p + ".act2.beta_inv"));
+  h = CausalConv(h, W(weights, p + ".conv2.conv.weight"),
+                 W(weights, p + ".conv2.conv.bias"));
+  return Add(x, h);
+}
+
+}  // namespace
+
+TfTensor MakeCodesInput(const CodecConfig& config, int frames) {
+  return TfTensor({.name = "codes",
+                   .type = Type::kI32,
+                   .shape = {config.num_quantizers, frames}});
+}
+
+TfTensor BuildCodecDecode(const CodecConfig& config, const TfTensor& codes,
+                          int frames, const WeightMap& weights) {
+  const int T = frames;
+
+  // RVQ -> [1,1,T,512] -> causal pre_conv k3 -> [1,1,T,1024].
+  TfTensor h = RvqDecode(config, codes, T, weights);
+  h = CausalConv(h, W(weights, "decoder.pre_conv.conv.weight"),
+                 W(weights, "decoder.pre_conv.conv.bias"));
+
+  // pre_transformer on [1,T,latent].
+  h = Reshape(h, {1, T, config.latent_dim});
+  h = PreTransformer(config, h, T, weights);
+  h = Reshape(h, {1, 1, T, config.latent_dim});
+
+  // upsample stages: TransConv(k=s=r) + ConvNeXt.
+  for (size_t i = 0; i < config.upsampling_ratios.size(); ++i) {
+    int r = config.upsampling_ratios[i];
+    std::string p = absl::StrCat("decoder.upsample.", i);
+    h = CausalTransConv(h, W(weights, p + ".0.conv.weight"),
+                        W(weights, p + ".0.conv.bias"), r);
+    h = ConvNeXtBlock(h, p + ".1", weights);
+  }
+
+  // decoder stack: conv k7 -> 4 blocks -> Snake -> conv k7 -> clamp.
+  h = CausalConv(h, W(weights, "decoder.decoder.0.conv.weight"),
+                 W(weights, "decoder.decoder.0.conv.bias"));
+  for (size_t i = 0; i < config.upsample_rates.size(); ++i) {
+    int rate = config.upsample_rates[i];
+    std::string p = absl::StrCat("decoder.decoder.", i + 1, ".block");
+    h = Snake(h, W(weights, p + ".0.alpha_exp"),
+              W(weights, p + ".0.beta_inv"));
+    h = CausalTransConv(h, W(weights, p + ".1.conv.weight"),
+                        W(weights, p + ".1.conv.bias"), rate);
+    const int dilations[3] = {1, 3, 9};
+    for (int u = 0; u < 3; ++u) {
+      h = ResidualUnit(h, absl::StrCat(p, ".", u + 2), dilations[u], weights);
+    }
+  }
+  int last = static_cast<int>(config.upsample_rates.size()) + 1;
+  h = Snake(h, W(weights, absl::StrCat("decoder.decoder.", last, ".alpha_exp")),
+            W(weights, absl::StrCat("decoder.decoder.", last, ".beta_inv")));
+  h = CausalConv(
+      h, W(weights, absl::StrCat("decoder.decoder.", last + 1, ".conv.weight")),
+      W(weights, absl::StrCat("decoder.decoder.", last + 1, ".conv.bias")));
+
+  h = Maximum(Minimum(h, Const1(1.0f)), Const1(-1.0f));
+  TfTensor wav = Reshape(h, {1, T * config.total_upsample()});
+  wav.SetName("wav");
+  return wav;
+}
+
+}  // namespace litert::tensor::examples::codec

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.h
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.h
@@ -1,0 +1,63 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Codec decoder step-graph (Tensor API, TfLite backend).
+//
+// One call decodes a fixed window of codec frames to waveform:
+//   codes [16, T] kI32  ->  wav [1, T*1920] kFP32 in [-1, 1] at 24 kHz.
+//
+// Pipeline (mirrors qwen3tts_work/qtok12 modeling, all in-graph):
+//   RVQ decode (16 x 1-D-indices Gather on precomputed EMA tables + two
+//   1x1 output projections, semantic + acoustic sum)
+//   -> causal pre_conv k3 (512 -> 1024)
+//   -> pre_transformer: input_proj -> 8 x [x += scale_a*attn(rms(x));
+//      x += scale_m*mlp(rms(x))] with rope(theta 1e4) and a baked
+//      causal+sliding-window(72) additive mask -> norm -> output_proj
+//   -> 2 x [TransposeConv k=s=2 + ConvNeXt block (causal dw k7, LayerNorm,
+//      pw 1024->4096 GELU 4096->1024, gamma, residual)]
+//   -> conv k7 (1024 -> 1536) -> 4 decoder blocks (SnakeBeta, causal
+//      TransposeConv k=2r s=r, 3 residual units at dilations 1/3/9)
+//      1536 -> 768 -> 384 -> 192 -> 96
+//   -> SnakeBeta -> conv k7 (96 -> 1) -> clamp(-1, 1).
+//
+// The whole stack is causal, so the host runs production-style chunking:
+// 64-frame chunks with 25 frames of left context, cropping ctx*1920 samples.
+// Weights come preprocessed from LoadCodecWeights (TFLite filter layouts,
+// EMA tables divided out, Snake exp() folded); see codec_weights.h.
+
+#ifndef SPEECHLM_STAGE1_CODEC_DECODE_CODEC_GRAPH_H_
+#define SPEECHLM_STAGE1_CODEC_DECODE_CODEC_GRAPH_H_
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "tensor/backends/tflite/arithmetic_tflite.h"
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_config.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::codec {
+
+using TfTensor = ::litert::tensor::Tensor<::litert::tensor::TfLiteMixinTag>;
+using WeightMap = absl::flat_hash_map<std::string, TfTensor>;
+
+// Input: codes [num_quantizers, frames] kI32, named "codes".
+TfTensor MakeCodesInput(const CodecConfig& config, int frames);
+
+// Output: wav [1, frames * 1920] kFP32, named "wav".
+TfTensor BuildCodecDecode(const CodecConfig& config, const TfTensor& codes,
+                          int frames, const WeightMap& weights);
+
+}  // namespace litert::tensor::examples::codec
+
+#endif  // SPEECHLM_STAGE1_CODEC_DECODE_CODEC_GRAPH_H_

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_main.cc
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_main.cc
@@ -1,0 +1,258 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Codec decoder host reference: serialize the fixed-window decode graph,
+// run production-style chunking (64-frame chunks + 25 frames left context),
+// benchmark, and optionally dump the waveform for the numpy equivalence
+// check (verify/numpy_codec_ref.py).
+//
+//   bazel build -c opt //models/qwen/qwen3_tts/tensor_api/codec_decode:codec_main
+//   codec_main --weights=.../speech_tokenizer/model.safetensors \
+//     --frames=128 --accelerator=cpu --dump_wav=/tmp/wav.f32
+//
+// Codes input: --codes_file (raw i32 [16, frames]) or deterministic
+// synthetic codes. Real-time budget: 24000 samples/s.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "tensor/backends/tflite/tflite_flatbuffer_conversion.h"
+#include "tensor/datatypes.h"
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_config.h"
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.h"
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_weights.h"
+#include "tensor/runners/litert/litert_dynamic_runner.h"
+#include "tensor/tensor.h"
+
+ABSL_FLAG(std::string, weights, "",
+          "speech_tokenizer/model.safetensors path (required)");
+ABSL_FLAG(int, frames, 128, "Total codec frames of the synthetic utterance");
+ABSL_FLAG(int, runs, 8, "Timed chunk invocations (after 2 warmup)");
+ABSL_FLAG(std::string, accelerator, "cpu", "cpu|gpu");
+ABSL_FLAG(std::string, gpu_precision, "fp16", "fp16|fp32");
+ABSL_FLAG(std::string, gpu_buffer_storage, "default",
+          "default|buffer|texture2d");
+ABSL_FLAG(std::string, codes_file, "",
+          "Raw i32 file [16, frames] (empty = deterministic synthetic codes)");
+ABSL_FLAG(std::string, dump_wav, "",
+          "If set, write the full decoded waveform as raw fp32");
+ABSL_FLAG(std::string, tflite_path, "/tmp/codec_decode.tflite",
+          "Where to write the serialized model");
+
+namespace {
+
+using ::litert::tensor::Create;
+using ::litert::tensor::LitertDynamicRunner;
+using ::litert::tensor::ModelFactory;
+using ::litert::tensor::Type;
+namespace codec = ::litert::tensor::examples::codec;
+
+absl::Status Run() {
+  codec::CodecConfig config;
+  const int frames = absl::GetFlag(FLAGS_frames);
+  const int window = config.chunk_frames + config.context_frames;  // 89
+  const int up = config.total_upsample();
+  const std::string weights_path = absl::GetFlag(FLAGS_weights);
+  if (weights_path.empty()) {
+    return absl::InvalidArgumentError("--weights is required");
+  }
+
+  auto weights_or = codec::LoadCodecWeights(config, weights_path);
+  if (!weights_or.ok()) return weights_or.status();
+  std::cout << "weights: " << weights_path << " (" << weights_or->size()
+            << " graph constants)" << std::endl;
+
+  codec::TfTensor codes_in = codec::MakeCodesInput(config, window);
+  codec::TfTensor wav_out =
+      codec::BuildCodecDecode(config, codes_in, window, *weights_or);
+
+  ModelFactory factory;
+  {
+    std::vector<::litert::tensor::TensorHandle> ins = {codes_in};
+    std::vector<::litert::tensor::TensorHandle> outs = {wav_out};
+    auto status = factory.AddSignature(ins, outs, "decode");
+    if (!status.ok()) return status;
+  }
+  const std::string tflite_path = absl::GetFlag(FLAGS_tflite_path);
+  auto save_status = factory.Save(tflite_path);
+  if (!save_status.ok()) return save_status;
+  std::cout << "Serialized: " << tflite_path << " (window " << window
+            << " frames -> " << window * up << " samples)" << std::endl;
+
+  auto env = ::litert::Environment::Create({});
+  if (!env) return absl::InternalError("Environment::Create failed");
+  auto options = ::litert::Options::Create();
+  if (!options) return absl::InternalError("Options::Create failed");
+  const bool use_gpu = absl::GetFlag(FLAGS_accelerator) == "gpu";
+  options->SetHardwareAccelerators(use_gpu ? ::litert::HwAccelerators::kGpu
+                                           : ::litert::HwAccelerators::kCpu);
+  if (use_gpu) {
+    auto gpu_options = options->GetGpuOptions();
+    if (gpu_options.HasValue()) {
+      const std::string precision = absl::GetFlag(FLAGS_gpu_precision);
+      if (precision == "fp32") {
+        gpu_options->SetPrecision(::litert::GpuOptions::Precision::kFp32);
+      } else if (precision != "fp16") {
+        return absl::InvalidArgumentError("--gpu_precision must be fp16|fp32");
+      }
+      const std::string storage = absl::GetFlag(FLAGS_gpu_buffer_storage);
+      if (storage == "buffer") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kBuffer);
+      } else if (storage == "texture2d") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kTexture2D);
+      } else if (storage != "default") {
+        return absl::InvalidArgumentError(
+            "--gpu_buffer_storage must be default|buffer|texture2d");
+      }
+      std::cout << "gpu precision: " << precision << ", storage: " << storage
+                << std::endl;
+    }
+  }
+  auto runner_or = LitertDynamicRunner::Create(*env, tflite_path, *options);
+  if (!runner_or.ok()) return runner_or.status();
+  auto runner = std::move(*runner_or);
+
+  // --- utterance codes [16, frames] ---
+  std::vector<int32_t> codes(static_cast<size_t>(config.num_quantizers) *
+                             frames);
+  const std::string codes_file = absl::GetFlag(FLAGS_codes_file);
+  if (codes_file.empty()) {
+    unsigned state = 12345u;
+    for (auto& c : codes) {
+      state = state * 1664525u + 1013904223u;
+      c = static_cast<int32_t>((state >> 8) % config.codebook_size);
+    }
+  } else {
+    std::ifstream in(codes_file, std::ios::binary);
+    if (!in) return absl::NotFoundError("codes_file: " + codes_file);
+    in.read(reinterpret_cast<char*>(codes.data()),
+            codes.size() * sizeof(int32_t));
+    if (static_cast<size_t>(in.gcount()) != codes.size() * sizeof(int32_t)) {
+      return absl::InvalidArgumentError("codes_file smaller than 16 x frames");
+    }
+  }
+
+  // --- chunked decode: 64-frame chunks, 25 frames left context ---
+  std::vector<float> wav;
+  wav.reserve(static_cast<size_t>(frames) * up);
+  std::vector<double> chunk_ms;
+  int start = 0;
+  while (start < frames) {
+    int ctx = std::min(config.context_frames, start);
+    int end = std::min(start + config.chunk_frames, frames);
+    // Window layout: [ctx frames of context][end-start new frames][pad].
+    std::vector<int32_t> win(static_cast<size_t>(config.num_quantizers) *
+                                 window,
+                             0);
+    for (int q = 0; q < config.num_quantizers; ++q) {
+      for (int t = 0; t < ctx + (end - start); ++t) {
+        win[static_cast<size_t>(q) * window + t] =
+            codes[static_cast<size_t>(q) * frames + (start - ctx) + t];
+      }
+    }
+    auto st = runner.SetInput(
+        "decode", "codes",
+        Create("codes", Type::kI32, {config.num_quantizers, window},
+               std::move(win)));
+    if (!st.ok()) return st;
+
+    auto t0 = std::chrono::steady_clock::now();
+    st = runner.Run("decode");
+    auto t1 = std::chrono::steady_clock::now();
+    if (!st.ok()) return st;
+    chunk_ms.push_back(
+        std::chrono::duration<double, std::milli>(t1 - t0).count());
+
+    auto out = runner.GetOutput("decode", "wav");
+    if (!out.ok()) return out.status();
+    auto buffer = out->GetBuffer();
+    if (!buffer.ok()) return buffer.status();
+    auto lock = buffer->Lock();
+    const float* data = reinterpret_cast<const float*>(lock.data());
+    // Crop the context and any right padding.
+    wav.insert(wav.end(), data + static_cast<size_t>(ctx) * up,
+               data + static_cast<size_t>(ctx + (end - start)) * up);
+    start = end;
+  }
+
+  // --- steady-state benchmark on a full window ---
+  const int runs = absl::GetFlag(FLAGS_runs);
+  std::vector<double> bench_ms;
+  for (int r = 0; r < runs + 2; ++r) {
+    auto t0 = std::chrono::steady_clock::now();
+    auto st = runner.Run("decode");
+    auto t1 = std::chrono::steady_clock::now();
+    if (!st.ok()) return st;
+    if (r >= 2) {
+      bench_ms.push_back(
+          std::chrono::duration<double, std::milli>(t1 - t0).count());
+    }
+  }
+  std::sort(bench_ms.begin(), bench_ms.end());
+  double median = bench_ms[bench_ms.size() / 2];
+  double audio_ms = 1000.0 * config.chunk_frames * up / 24000.0;
+
+  double sum_sq = 0.0;
+  float peak = 0.0f;
+  bool finite = true;
+  for (float v : wav) {
+    if (!std::isfinite(v)) finite = false;
+    sum_sq += static_cast<double>(v) * v;
+    peak = std::max(peak, std::fabs(v));
+  }
+  std::cout << "decoded " << frames << " frames -> " << wav.size()
+            << " samples; RMS " << std::sqrt(sum_sq / wav.size()) << ", peak "
+            << peak << (finite ? " (all finite)" : " (NON-FINITE!)")
+            << std::endl;
+  std::cout << "chunk window " << window << " frames: median " << median
+            << " ms (" << bench_ms.size() << " runs) vs " << audio_ms
+            << " ms of new audio => RTF " << (median / audio_ms) << std::endl;
+  if (!finite) return absl::InternalError("non-finite waveform");
+
+  const std::string dump = absl::GetFlag(FLAGS_dump_wav);
+  if (!dump.empty()) {
+    std::ofstream out(dump, std::ios::binary);
+    if (!out) return absl::InternalError("cannot write " + dump);
+    out.write(reinterpret_cast<const char*>(wav.data()),
+              wav.size() * sizeof(float));
+    std::cout << "wav dumped to " << dump << std::endl;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  absl::Status status = Run();
+  if (!status.ok()) {
+    std::cerr << "FAILED: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_weights.cc
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_weights.cc
@@ -1,0 +1,265 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Codec decoder weight loading. See codec_weights.h.
+
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_weights.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/strings/match.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/examples/gemma3/safetensor_loader.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::codec {
+
+namespace {
+
+using ::litert::tensor::examples::SafetensorLoader;
+
+// Mirrors the loader's is_layernorm predicate (safetensor_loader.cc), which
+// adds a Gemma-style +1.0 these norms must not have.
+bool LoaderAddsGemmaNormOffset(const std::string& name) {
+  return absl::StrContains(name, "layernorm") ||
+         absl::EndsWith(name, "norm.weight");
+}
+
+struct RawTensor {
+  std::vector<float> data;
+  std::vector<int> shape;
+};
+
+absl::StatusOr<RawTensor> ReadTensor(const SafetensorLoader& loader,
+                                     const std::string& name) {
+  auto handle_or = loader.LoadTensor(
+      name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
+  if (!handle_or.ok()) {
+    return absl::NotFoundError(
+        absl::StrCat("missing ", name, ": ", handle_or.status().message()));
+  }
+  TfTensor t(*handle_or);
+  RawTensor raw;
+  const auto& s = t.GetShape();
+  raw.shape.assign(s.begin(), s.end());
+  auto buffer = t.GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->Lock();
+  const float* p = reinterpret_cast<const float*>(lock.data());
+  raw.data.assign(p, p + lock.size() / sizeof(float));
+  if (LoaderAddsGemmaNormOffset(name)) {
+    for (float& v : raw.data) v -= 1.0f;
+  }
+  return raw;
+}
+
+TfTensor MakeConst(const std::string& name, const std::vector<int>& shape,
+                   std::vector<float> data) {
+  return TfTensor({.name = name,
+                   .type = Type::kFP32,
+                   .shape = shape,
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>(data)});
+}
+
+// torch Conv1d [out, in, k] -> TFLite Conv2D filter [out, 1, k, in].
+TfTensor ConvFilter(const std::string& name, const RawTensor& w) {
+  int out = w.shape[0], in = w.shape[1], k = w.shape[2];
+  std::vector<float> data(w.data.size());
+  for (int o = 0; o < out; ++o)
+    for (int j = 0; j < k; ++j)
+      for (int i = 0; i < in; ++i)
+        data[(static_cast<size_t>(o) * k + j) * in + i] =
+            w.data[(static_cast<size_t>(o) * in + i) * k + j];
+  return MakeConst(name, {out, 1, k, in}, std::move(data));
+}
+
+// torch depthwise Conv1d [C, 1, k] -> TFLite DepthwiseConv2D [1, 1, k, C].
+TfTensor DwConvFilter(const std::string& name, const RawTensor& w) {
+  int c = w.shape[0], k = w.shape[2];
+  std::vector<float> data(w.data.size());
+  for (int j = 0; j < k; ++j)
+    for (int ch = 0; ch < c; ++ch)
+      data[static_cast<size_t>(j) * c + ch] =
+          w.data[static_cast<size_t>(ch) * k + j];
+  return MakeConst(name, {1, 1, k, c}, std::move(data));
+}
+
+// torch ConvTranspose1d [in, out, k] -> TFLite TransposeConv [out, 1, k, in].
+TfTensor TransConvFilter(const std::string& name, const RawTensor& w) {
+  int in = w.shape[0], out = w.shape[1], k = w.shape[2];
+  std::vector<float> data(w.data.size());
+  for (int o = 0; o < out; ++o)
+    for (int j = 0; j < k; ++j)
+      for (int i = 0; i < in; ++i)
+        data[(static_cast<size_t>(o) * k + j) * in + i] =
+            w.data[(static_cast<size_t>(i) * out + o) * k + j];
+  return MakeConst(name, {out, 1, k, in}, std::move(data));
+}
+
+}  // namespace
+
+absl::StatusOr<WeightMap> LoadCodecWeights(const CodecConfig& config,
+                                           const std::string& path) {
+  auto loader_or = SafetensorLoader::Load(path);
+  if (!loader_or.ok()) return loader_or.status();
+  auto loader = std::move(*loader_or);
+
+  WeightMap weights;
+  auto read = [&](const std::string& name) { return ReadTensor(loader, name); };
+
+  // Pass a raw tensor through unchanged (norm fixup already applied).
+  auto passthrough = [&](const std::string& name) -> absl::Status {
+    auto raw = read(name);
+    if (!raw.ok()) return raw.status();
+    weights[name] = MakeConst(name, raw->shape, std::move(raw->data));
+    return absl::OkStatus();
+  };
+  // Snake params: store exp(alpha) and 1/(exp(beta)+1e-9).
+  auto snake = [&](const std::string& base) -> absl::Status {
+    auto alpha = read(base + ".alpha");
+    if (!alpha.ok()) return alpha.status();
+    auto beta = read(base + ".beta");
+    if (!beta.ok()) return beta.status();
+    std::vector<float> ae(alpha->data.size()), bi(beta->data.size());
+    for (size_t i = 0; i < ae.size(); ++i) ae[i] = std::exp(alpha->data[i]);
+    for (size_t i = 0; i < bi.size(); ++i)
+      bi[i] = 1.0f / (std::exp(beta->data[i]) + 1e-9f);
+    weights[base + ".alpha_exp"] =
+        MakeConst(base + ".alpha_exp", alpha->shape, std::move(ae));
+    weights[base + ".beta_inv"] =
+        MakeConst(base + ".beta_inv", beta->shape, std::move(bi));
+    return absl::OkStatus();
+  };
+  auto conv = [&](const std::string& name) -> absl::Status {
+    auto w = read(name + ".weight");
+    if (!w.ok()) return w.status();
+    weights[name + ".weight"] = ConvFilter(name + ".weight", *w);
+    return passthrough(name + ".bias");
+  };
+  auto transconv = [&](const std::string& name) -> absl::Status {
+    auto w = read(name + ".weight");
+    if (!w.ok()) return w.status();
+    weights[name + ".weight"] = TransConvFilter(name + ".weight", *w);
+    return passthrough(name + ".bias");
+  };
+
+#define RETURN_IF_ERROR(expr)                \
+  do {                                       \
+    absl::Status _st = (expr);               \
+    if (!_st.ok()) return _st;               \
+  } while (false)
+
+  // --- RVQ: EMA tables + squeezed output projections ---
+  for (int q = 0; q < config.num_quantizers; ++q) {
+    std::string base =
+        q == 0 ? "decoder.quantizer.rvq_first.vq.layers.0._codebook"
+               : absl::StrCat("decoder.quantizer.rvq_rest.vq.layers.", q - 1,
+                              "._codebook");
+    auto sum = read(base + ".embedding_sum");
+    if (!sum.ok()) return sum.status();
+    auto usage = read(base + ".cluster_usage");
+    if (!usage.ok()) return usage.status();
+    int rows = sum->shape[0], dim = sum->shape[1];
+    std::vector<float> table(sum->data.size());
+    for (int r = 0; r < rows; ++r) {
+      float u = std::max(usage->data[r], config.vq_eps);
+      for (int d = 0; d < dim; ++d)
+        table[static_cast<size_t>(r) * dim + d] =
+            sum->data[static_cast<size_t>(r) * dim + d] / u;
+    }
+    std::string tname = absl::StrCat("codebook_table_", q);
+    weights[tname] = MakeConst(tname, {rows, dim}, std::move(table));
+  }
+  for (const std::string side : {"rvq_first", "rvq_rest"}) {
+    std::string name = absl::StrCat("decoder.quantizer.", side, ".output_proj");
+    auto w = read(name + ".weight");  // [512, 256, 1]
+    if (!w.ok()) return w.status();
+    weights[name] = MakeConst(name, {w->shape[0], w->shape[1]},
+                              std::move(w->data));
+  }
+
+  // --- pre_conv + pre_transformer ---
+  RETURN_IF_ERROR(conv("decoder.pre_conv.conv"));
+  {
+    const std::string base = "decoder.pre_transformer";
+    RETURN_IF_ERROR(passthrough(base + ".input_proj.weight"));
+    RETURN_IF_ERROR(passthrough(base + ".input_proj.bias"));
+    RETURN_IF_ERROR(passthrough(base + ".output_proj.weight"));
+    RETURN_IF_ERROR(passthrough(base + ".output_proj.bias"));
+    RETURN_IF_ERROR(passthrough(base + ".norm.weight"));
+    for (int l = 0; l < config.tf_layers; ++l) {
+      std::string p = absl::StrCat(base, ".layers.", l);
+      for (const char* suffix :
+           {".input_layernorm.weight", ".post_attention_layernorm.weight",
+            ".self_attn.q_proj.weight", ".self_attn.k_proj.weight",
+            ".self_attn.v_proj.weight", ".self_attn.o_proj.weight",
+            ".self_attn_layer_scale.scale", ".mlp.gate_proj.weight",
+            ".mlp.up_proj.weight", ".mlp.down_proj.weight",
+            ".mlp_layer_scale.scale"}) {
+        RETURN_IF_ERROR(passthrough(p + suffix));
+      }
+    }
+  }
+
+  // --- upsample stages ---
+  for (size_t i = 0; i < config.upsampling_ratios.size(); ++i) {
+    std::string p = absl::StrCat("decoder.upsample.", i);
+    RETURN_IF_ERROR(transconv(p + ".0.conv"));
+    {
+      std::string c = p + ".1";
+      auto w = read(c + ".dwconv.conv.weight");
+      if (!w.ok()) return w.status();
+      weights[c + ".dwconv.conv.weight"] =
+          DwConvFilter(c + ".dwconv.conv.weight", *w);
+      RETURN_IF_ERROR(passthrough(c + ".dwconv.conv.bias"));
+      for (const char* suffix :
+           {".norm.weight", ".norm.bias", ".pwconv1.weight", ".pwconv1.bias",
+            ".pwconv2.weight", ".pwconv2.bias", ".gamma"}) {
+        RETURN_IF_ERROR(passthrough(c + suffix));
+      }
+    }
+  }
+
+  // --- decoder stack ---
+  RETURN_IF_ERROR(conv("decoder.decoder.0.conv"));
+  for (size_t i = 0; i < config.upsample_rates.size(); ++i) {
+    std::string p = absl::StrCat("decoder.decoder.", i + 1, ".block");
+    RETURN_IF_ERROR(snake(p + ".0"));
+    RETURN_IF_ERROR(transconv(p + ".1.conv"));
+    for (int u = 2; u <= 4; ++u) {
+      std::string r = absl::StrCat(p, ".", u);
+      RETURN_IF_ERROR(snake(r + ".act1"));
+      RETURN_IF_ERROR(conv(r + ".conv1.conv"));
+      RETURN_IF_ERROR(snake(r + ".act2"));
+      RETURN_IF_ERROR(conv(r + ".conv2.conv"));
+    }
+  }
+  int last = static_cast<int>(config.upsample_rates.size()) + 1;
+  RETURN_IF_ERROR(snake(absl::StrCat("decoder.decoder.", last)));
+  RETURN_IF_ERROR(conv(absl::StrCat("decoder.decoder.", last + 1, ".conv")));
+
+#undef RETURN_IF_ERROR
+  return weights;
+}
+
+}  // namespace litert::tensor::examples::codec

--- a/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_weights.h
+++ b/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_weights.h
@@ -1,0 +1,46 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Codec decoder checkpoint loading + host-side preprocessing.
+//
+// Reads speech_tokenizer/model.safetensors (via the gemma3 example's
+// SafetensorLoader) and returns graph-ready constants:
+//  - conv weights permuted to TFLite layouts: Conv [out,1,k,in], depthwise
+//    [1,1,k,C], transpose-conv [out,1,k,in] (from torch [in,out,k]);
+//  - EMA codebooks divided out: codebook_table_q = embedding_sum /
+//    max(cluster_usage, eps), q = 0..15;
+//  - RVQ 1x1 output projections squeezed to 2-D matmul weights;
+//  - SnakeBeta parameters folded: <base>.alpha_exp = exp(alpha),
+//    <base>.beta_inv = 1/(exp(beta)+1e-9);
+//  - the gemma3 loader's +1.0 Gemma-norm offset undone on *layernorm* /
+//    *norm.weight tensors (Qwen norms are raw; ConvNeXt LayerNorm bias is
+//    unaffected).
+
+#ifndef SPEECHLM_STAGE1_CODEC_DECODE_CODEC_WEIGHTS_H_
+#define SPEECHLM_STAGE1_CODEC_DECODE_CODEC_WEIGHTS_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_config.h"
+#include "models/qwen/qwen3_tts/tensor_api/codec_decode/codec_graph.h"
+
+namespace litert::tensor::examples::codec {
+
+absl::StatusOr<WeightMap> LoadCodecWeights(const CodecConfig& config,
+                                           const std::string& path);
+
+}  // namespace litert::tensor::examples::codec
+
+#endif  // SPEECHLM_STAGE1_CODEC_DECODE_CODEC_WEIGHTS_H_

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/BUILD
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/BUILD
@@ -1,0 +1,121 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(
+    "@litert_archive//litert/build_common:special_rule.bzl",
+    "litert_android_linkopts",
+    "litert_gpu_accelerator_prebuilts",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "talker_config",
+    hdrs = ["talker_config.h"],
+)
+
+cc_library(
+    name = "talker_graph",
+    srcs = ["talker_graph.cc"],
+    hdrs = ["talker_graph.h"],
+    deps = [
+        ":talker_config",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
+        "@flatbuffers",
+    ],
+)
+
+cc_library(
+    name = "talker_weights",
+    srcs = ["talker_weights.cc"],
+    hdrs = ["talker_weights.h"],
+    deps = [
+        ":talker_config",
+        ":talker_graph",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor/examples/gemma3:safetensor_loader",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_binary(
+    name = "attn_bench",
+    srcs = ["attn_bench.cc"],
+    copts = ["-DGOOGLE_COMMANDLINEFLAGS_FULL_API=1"] + select({
+        "@litert_archive//litert:android": ["-DABSL_FLAGS_STRIP_NAMES=0"],
+        "//conditions:default": [],
+    }),
+    data = litert_gpu_accelerator_prebuilts(),
+    linkopts = litert_android_linkopts(),
+    deps = [
+        "@litert_archive//litert/cc:litert_common",
+        "@litert_archive//litert/cc:litert_environment",
+        "@litert_archive//litert/cc:litert_options",
+        "@litert_archive//litert/cc/options:litert_gpu_options",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+        "@litert_archive//tensor/backends/tflite:tflite_flatbuffer_conversion",
+        "@litert_archive//tensor/runners/litert:feedback_loop_config",
+        "@litert_archive//tensor/runners/litert:litert_dynamic_runner",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@flatbuffers",
+    ],
+)
+
+cc_binary(
+    name = "talker_main",
+    srcs = ["talker_main.cc"],
+    copts = ["-DGOOGLE_COMMANDLINEFLAGS_FULL_API=1"] + select({
+        "@litert_archive//litert:android": ["-DABSL_FLAGS_STRIP_NAMES=0"],
+        "//conditions:default": [],
+    }),
+    data = litert_gpu_accelerator_prebuilts(),
+    linkopts = litert_android_linkopts(),
+    deps = [
+        ":talker_config",
+        ":talker_graph",
+        ":talker_weights",
+        "@litert_archive//litert/cc:litert_common",
+        "@litert_archive//litert/cc:litert_environment",
+        "@litert_archive//litert/cc:litert_options",
+        "@litert_archive//litert/cc/options:litert_gpu_options",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:tflite_flatbuffer_conversion",
+        "@litert_archive//tensor/runners/litert:litert_dynamic_runner",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/attn_bench.cc
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/attn_bench.cc
@@ -1,0 +1,1093 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Attention micro-benchmark: raw ops vs odml.scaled_dot_product_attention vs
+// odml.runtime_bmm, at the talker decode shapes (heads 16 / kv 8 / head_dim
+// 128 / 1024-slot static cache, q_seq = 1).
+//
+//   bazel build -c opt //models/qwen/qwen3_tts/tensor_api/talker_step:attn_bench
+//   attn_bench --variant=raw|sdpa|rbmm --accelerator=cpu|gpu \
+//              --fills=64,512,1024 [--mha] [--blocks=28]
+//
+// One graph = `--blocks` chained attention blocks sharing the same cache
+// inputs (q_{i+1} = out_i), so per-run time ~= the attention load of one
+// talker decode frame. All variants consume identical logical inputs and
+// produce outputs in the same linear element order, so results are directly
+// comparable across variants and backends.
+//
+//   raw : the talker's GqaAttention fold (BatchMatMul + mask add + Softmax).
+//   sdpa: odml.scaled_dot_product_attention composite, BSND inputs
+//         (q [1,1,H,D], k/v [1,S,G,D], additive mask 4th input, scale attr);
+//         decomposition = the raw fold, so CPU runs are the reference.
+//   rbmm: odml.runtime_bmm composite pair (QK^T with is_src=false, then
+//         scores x V with is_src=true), fp32 BMM path (transpose_right),
+//         runtime control tensor int32 [1,1,1,7] with element 2 = active
+//         token count; V is provided transposed [1,G,D,S] so valid positions
+//         sit on channels for the src-side runtime bound. The additive mask
+//         stays in-graph between the two composites, so the CPU
+//         decomposition (plain BatchMatMul, ignores the control tensor) is
+//         exact and the GPU kernel's runtime bound is observable as a pure
+//         perf effect (and any tail-garbage leak shows up as a numeric
+//         mismatch vs the CPU reference).
+//
+// The active length is runtime input only (mask contents / control tensor),
+// so one flatbuffer serves every fill level. K/V rows at or beyond the
+// active length are filled with `--canary` to expose reads past the bound.
+// A CPU runner on the same flatbuffer is always created as the numeric
+// reference; GPU runs report max |rel| vs that reference per fill.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/str_split.h"  // from @com_google_absl
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "tensor/arithmetic.h"
+#include "tensor/backends/tflite/arithmetic_tflite.h"
+#include "tensor/backends/tflite/tflite_flatbuffer_conversion.h"
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/runners/litert/feedback_loop_config.h"
+#include "tensor/runners/litert/litert_dynamic_runner.h"
+#include "tensor/tensor.h"
+
+ABSL_FLAG(std::string, variant, "raw", "raw|sdpa|rbmm|cache_rbmm");
+ABSL_FLAG(std::string, multi_host_cache, "zeros",
+          "cache_rbmm multi_steps: what the measured GPU runner's host cache "
+          "inputs carry per step. zeros = all-zero every step; real = true "
+          "prefix rows every step; once = bind zeros at pos=0 then never "
+          "re-set (probes whether re-binding resets delegate cache state)");
+ABSL_FLAG(bool, feedback_loops, false,
+          "cache_rbmm multi_steps: register cache_k/v as FeedbackLoopConfig "
+          "pairs (PR #8796 runner API): caches become signature outputs, the "
+          "runner swaps input<->output buffers between Run() calls, and the "
+          "GPU runs in external-tensors mode. Host cache inputs are never "
+          "bound (the swap chain owns them; unwritten rows are never read).");
+ABSL_FLAG(int, multi_steps, 0,
+          "cache_rbmm only: run N chained decode steps (pos = 0..N-1) on one "
+          "runner instance and verify each step against the CPU reference. "
+          "The GPU runner gets ZEROED host cache inputs, so agreement proves "
+          "the delegate-managed cache accumulates across Run() calls.");
+ABSL_FLAG(bool, cache_qk_bound, false,
+          "cache_rbmm only: bound the QK side with the active length instead "
+          "of running it unbounded (probes the intended composition for "
+          "delegate-managed caches, where the host cannot pre-zero the "
+          "packed cache storage)");
+ABSL_FLAG(std::string, accelerator, "cpu", "cpu|gpu");
+ABSL_FLAG(int, blocks, 28, "chained attention blocks (one talker frame = 28)");
+ABSL_FLAG(int, heads, 16, "query heads");
+ABSL_FLAG(int, kv_groups, 8, "kv groups (GQA); ignored with --mha");
+ABSL_FLAG(int, head_dim, 128, "head dim");
+ABSL_FLAG(int, max_seq, 1024, "static cache slots");
+ABSL_FLAG(bool, mha, false,
+          "repeat K/V host-side to one group per head (MHA-shaped control; "
+          "isolates GQA handling in the composite kernels)");
+ABSL_FLAG(std::string, fills, "64,512,1024",
+          "comma list of active lengths to measure");
+ABSL_FLAG(bool, param_align4, false,
+          "round the control tensor's active count up to a multiple of 4 "
+          "(probes the 'aligned' semantics of element 2; mask stays exact)");
+ABSL_FLAG(int, runs, 50, "timed runs per fill");
+ABSL_FLAG(int, warmup, 5, "untimed warmup runs per fill");
+ABSL_FLAG(float, canary, 1000.0f,
+          "K/V value at rows >= active (leak detector; 0 to disable)");
+ABSL_FLAG(int, seed, 123, "input RNG seed");
+ABSL_FLAG(std::string, gpu_precision, "fp16", "fp16|fp32");
+ABSL_FLAG(std::string, gpu_buffer_storage, "default",
+          "default|buffer|texture2d (Metal needs buffer at max_seq >= 1024)");
+ABSL_FLAG(std::string, tflite_path, "/tmp/attn_bench.tflite",
+          "where to write the flatbuffer");
+ABSL_FLAG(std::string, dump_out, "",
+          "optional path to write the final output floats (cross-variant "
+          "exact diffing)");
+ABSL_FLAG(bool, debug_softmax, false,
+          "rbmm only: also output block-0 softmax [1,G,gsz,S] and print its "
+          "tail statistics on the measured runner (mask-vs-bound probe)");
+ABSL_FLAG(std::string, rbmm_mode, "corrected",
+          "rbmm only. 'masked': scale+mask add between the composites (the "
+          "additive mask gets fused into the bounded QK kernel's epilogue on "
+          "ML Drift, so the zero tail reaches the softmax unmasked - kept as "
+          "the repro of that boundary). 'nomask': rbmm_qk -> softmax -> "
+          "rbmm_av with pre-scaled Q, no correction (shows the raw boundary "
+          "semantics). 'corrected': nomask + exact renormalization - the "
+          "tail is known to be uniform e^{-m}/Z, so out * 1/(1 - "
+          "tail_count*p0) with p0 = attn[..., S-1] recovers masked attention "
+          "exactly, PROVIDED cache slots at/after the active length are "
+          "zero (the natural DUS cache state; canary is forced to 0)");
+
+namespace {
+
+using ::litert::tensor::Add;
+using ::litert::tensor::BatchMatMul;
+using ::litert::tensor::Create;
+using ::litert::tensor::LitertDynamicRunner;
+using ::litert::tensor::ModelFactory;
+using ::litert::tensor::Mul;
+using ::litert::tensor::OwningCpuBuffer;
+using ::litert::tensor::Div;
+using ::litert::tensor::DynamicUpdateSlice;
+using ::litert::tensor::Reshape;
+using ::litert::tensor::Slice;
+using ::litert::tensor::Softmax;
+using ::litert::tensor::Sub;
+using ::litert::tensor::StableHLOComposite;
+using ::litert::tensor::StableHLOCompositeOptions;
+using ::litert::tensor::TensorHandle;
+using ::litert::tensor::Transpose;
+using ::litert::tensor::Type;
+using TfTensor = ::litert::tensor::Tensor<::litert::tensor::TfLiteMixinTag>;
+
+// fp16-safe additive mask floor (talker convention).
+constexpr float kMaskFloor = -30000.0f;
+
+struct Geometry {
+  int heads;      // query heads H
+  int groups;     // kv groups G (== H with --mha)
+  int group_sz;   // H / G
+  int head_dim;   // D
+  int max_seq;    // S
+};
+
+TfTensor Const1(float value) {
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>({value})});
+}
+
+std::vector<uint8_t> RuntimeBmmAttributes(bool is_src) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() {
+    fbb.Bool("is_global", true);
+    fbb.Bool("is_src", is_src);
+    fbb.Bool("rhs_cache_update", false);
+  });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+std::vector<uint8_t> SdpaAttributes(float scale) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() { fbb.Float("scale", scale); });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// The talker's GqaAttention fold on pre-shaped tensors. q [1,H,seq,D],
+// k/v [1,G,S,D] -> [1,H,seq,D]. Used directly by the raw variant and as the
+// sdpa decomposition body (after BSND->BNSD transposes).
+TfTensor FoldAttention(const Geometry& g, const TfTensor& q, const TfTensor& k,
+                       const TfTensor& v, const TfTensor& mask) {
+  const int seq = q.GetShape()[2];
+  const float scale = 1.0f / std::sqrt(static_cast<float>(g.head_dim));
+  TfTensor qg = Reshape(q, {g.groups, 1, g.group_sz * seq, g.head_dim});
+  TfTensor kg = Reshape(k, {g.groups, 1, g.max_seq, g.head_dim});
+  TfTensor vg = Reshape(v, {g.groups, 1, g.max_seq, g.head_dim});
+  TfTensor scores = BatchMatMul(qg, kg, /*adj_x=*/false, /*adj_y=*/true);
+  scores = Reshape(scores, {1, g.heads, seq, g.max_seq});
+  scores = Mul(scores, Const1(scale));
+  scores = Add(scores, mask);
+  TfTensor attn = Softmax(scores);
+  attn = Reshape(attn, {g.groups, 1, g.group_sz * seq, g.max_seq});
+  TfTensor out = BatchMatMul(attn, vg);
+  return Reshape(out, {1, g.heads, seq, g.head_dim});
+}
+
+// One sdpa composite block. q [1,1,H,D] BSND, k/v [1,S,G,D], mask
+// [1,1,1,S] additive -> [1,1,H,D].
+TfTensor SdpaBlock(const Geometry& g, const TfTensor& q, const TfTensor& k,
+                   const TfTensor& v, const TfTensor& mask) {
+  const float scale = 1.0f / std::sqrt(static_cast<float>(g.head_dim));
+  StableHLOCompositeOptions opts{
+      .name = "odml.scaled_dot_product_attention",
+      .composite_attributes = SdpaAttributes(scale)};
+  auto out = StableHLOComposite(
+      opts,
+      [&g](TfTensor dq, TfTensor dk, TfTensor dv, TfTensor dm) {
+        TfTensor qt = Transpose(dq, {0, 2, 1, 3});   // [1,H,1,D]
+        TfTensor kt = Transpose(dk, {0, 2, 1, 3});   // [1,G,S,D]
+        TfTensor vt = Transpose(dv, {0, 2, 1, 3});
+        TfTensor o = FoldAttention(g, qt, kt, vt, dm);
+        return Transpose(o, {0, 2, 1, 3});           // back to [1,1,H,D]
+      },
+      q, k, v, mask);
+  return out;
+}
+
+// One runtime_bmm block on pre-folded tensors. qf [1,G,gsz,D],
+// k [1,G,S,D], v_t [1,G,D,S], mask [1,1,1,S], param int32 [1,1,1,7]
+// -> [1,G,gsz,D]. The decompositions are plain BatchMatMuls that ignore the
+// control tensor; correctness on CPU comes from the in-graph mask.
+enum class RbmmMode { kMasked, kNoMask, kCorrected, kAvBound };
+
+TfTensor RuntimeBmmBlock(const Geometry& g, const TfTensor& qf,
+                         const TfTensor& k, const TfTensor& v_t,
+                         const TfTensor& mask, const TfTensor& param,
+                         const TfTensor& param_full,
+                         const TfTensor& tail_count, RbmmMode mode,
+                         TfTensor* attn_out = nullptr) {
+  const float scale = 1.0f / std::sqrt(static_cast<float>(g.head_dim));
+  const bool pre_scale =
+      mode == RbmmMode::kNoMask || mode == RbmmMode::kCorrected;
+  TfTensor lhs = pre_scale ? Mul(qf, Const1(scale)) : qf;
+  StableHLOCompositeOptions qk_opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(/*is_src=*/false)};
+  // avbound: the QK side runs UNBOUNDED (param_full has element 2 == S) so
+  // every tail score is deterministically written (zero K rows give zero
+  // scores) and the fused scale+mask epilogue covers the full width; only
+  // the AV side is runtime-bounded. This is the sound composition when a
+  // full-width softmax sits between the two composites - a dst-bounded QK
+  // leaves its tail UNWRITTEN (stale memory), which a full-width softmax
+  // then reads.
+  TfTensor scores = StableHLOComposite(
+      qk_opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      lhs, k, mode == RbmmMode::kAvBound ? param_full : param);  // [1,G,gsz,S]
+  if (mode == RbmmMode::kMasked || mode == RbmmMode::kAvBound) {
+    scores = Mul(scores, Const1(scale));
+    scores = Add(scores, mask);
+  }
+  TfTensor attn = Softmax(scores);
+  if (attn_out != nullptr) *attn_out = attn;
+  StableHLOCompositeOptions av_opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(/*is_src=*/true)};
+  TfTensor out = StableHLOComposite(
+      av_opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      attn, v_t, param);  // [1,G,gsz,D]
+  if (mode == RbmmMode::kCorrected) {
+    // Tail slots enter the softmax as exp(0 - rowmax) each (bounded kernels
+    // zero-fill; zero cache rows give zero scores on the decomposition), so
+    // the denominator is inflated by tail_count * p0 where p0 is any tail
+    // probability - the last slot is one whenever active < S, and the factor
+    // degenerates to 1 at full fill. Rescaling the src-bounded AV output by
+    // 1 / (1 - tail_count * p0) is exact renormalization, not an
+    // approximation.
+    TfTensor p0 = Slice(attn, {0, 0, 0, g.max_seq - 1},
+                        {1, g.groups, g.group_sz, 1});
+    TfTensor corr =
+        Div(Const1(1.0f), Sub(Const1(1.0f), Mul(p0, tail_count)));
+    out = Mul(out, corr);
+  }
+  return out;
+}
+
+std::vector<uint8_t> CacheUpdateAttributes(int kv_cache_batch_size,
+                                           int cache_size, int head_size) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() {
+    fbb.Int("kv_cache_batch_size", kv_cache_batch_size);
+    fbb.Int("cache_size", cache_size);
+    fbb.Int("head_size", head_size);
+  });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// One decode step through the odml.cache_update + odml.runtime_bmm pair -
+// the fused write/read pattern the delegate implements (cache_update stores
+// K in the QK FC-weights layout and V in the AV layout; runtime_bmm's
+// FC-external-weights path engages because the RHS producer is
+// add_values_to_cache). The composite carries 7 inputs so the CPU
+// decomposition can express the same update as DYNAMIC_UPDATE_SLICE
+// (src_k, src_v, control tensor, k cache, v cache, and the two write-index
+// vectors); the GPU parser reads only the first three. Control tensor
+// element 0 = write offset, element 1 = active tokens (cache_update),
+// element 2 = active tokens (runtime_bmm bound).
+TfTensor CacheRbmmStep(const Geometry& g, const TfTensor& q,
+                       const TfTensor& src_k, const TfTensor& src_v,
+                       const TfTensor& mask, const TfTensor& param,
+                       const TfTensor& param_full, const TfTensor& cache_k_in,
+                       const TfTensor& cache_v_in, const TfTensor& pos_k,
+                       const TfTensor& pos_v, bool qk_bound,
+                       TfTensor* cache_k_out = nullptr,
+                       TfTensor* cache_v_out = nullptr) {
+  const float scale = 1.0f / std::sqrt(static_cast<float>(g.head_dim));
+  StableHLOCompositeOptions cu_opts{
+      .name = "odml.cache_update",
+      .composite_attributes = CacheUpdateAttributes(
+          g.groups, g.max_seq, g.head_dim)};
+  auto caches = StableHLOComposite(
+      cu_opts,
+      [](TfTensor sk, TfTensor sv, TfTensor /*p*/, TfTensor ck, TfTensor cv,
+         TfTensor pk, TfTensor pv) {
+        TfTensor k_new = DynamicUpdateSlice(ck, sk, pk);
+        // V cache is stored transposed ([1, G, D, S]); write this step's row
+        // as a column.
+        TfTensor sv_t = Transpose(sv, {0, 1, 3, 2});
+        TfTensor v_new = DynamicUpdateSlice(cv, sv_t, pv);
+        return std::make_tuple(k_new, v_new);
+      },
+      src_k, src_v, param, cache_k_in, cache_v_in, pos_k, pos_v);
+  TfTensor cache_k_new = std::get<0>(caches);
+  TfTensor cache_v_new = std::get<1>(caches);
+  cache_k_new.SetName("cache_k_new");
+  cache_v_new.SetName("cache_v_new");
+  if (cache_k_out != nullptr) *cache_k_out = cache_k_new;
+  if (cache_v_out != nullptr) *cache_v_out = cache_v_new;
+
+  TfTensor lhs = Mul(q, Const1(scale));
+  StableHLOCompositeOptions qk_opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(/*is_src=*/false)};
+  TfTensor scores = StableHLOComposite(
+      qk_opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      lhs, cache_k_new, qk_bound ? param : param_full);
+  scores = Add(scores, mask);
+  TfTensor attn = Softmax(scores);
+  StableHLOCompositeOptions av_opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(/*is_src=*/true)};
+  TfTensor out = StableHLOComposite(
+      av_opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      attn, cache_v_new, param);
+  return out;  // [1, G, gsz, D]
+}
+
+struct HostData {
+  std::vector<float> q;         // H*D, block-0 query
+  std::vector<float> k;         // G*S*D logical [g][s][d]
+  std::vector<float> v;         // G*S*D logical [g][s][d]
+};
+
+HostData MakeHostData(const Geometry& g, int seed) {
+  std::mt19937 rng(seed);
+  std::normal_distribution<float> dist(0.0f, 0.5f);
+  HostData d;
+  d.q.resize(static_cast<size_t>(g.heads) * g.head_dim);
+  for (auto& x : d.q) x = dist(rng);
+  const size_t kv = static_cast<size_t>(g.groups) * g.max_seq * g.head_dim;
+  d.k.resize(kv);
+  d.v.resize(kv);
+  for (auto& x : d.k) x = dist(rng);
+  for (auto& x : d.v) x = dist(rng);
+  return d;
+}
+
+// Layout packers. Rows >= active are overwritten with the canary value.
+std::vector<float> PackBnsd(const Geometry& g, const std::vector<float>& src,
+                            int active, float canary) {
+  std::vector<float> out(src);
+  for (int gi = 0; gi < g.groups; ++gi)
+    for (int s = active; s < g.max_seq; ++s)
+      for (int di = 0; di < g.head_dim; ++di)
+        out[(static_cast<size_t>(gi) * g.max_seq + s) * g.head_dim + di] =
+            canary;
+  return out;
+}
+
+std::vector<float> PackBsnd(const Geometry& g, const std::vector<float>& src,
+                            int active, float canary) {
+  std::vector<float> out(src.size());
+  for (int s = 0; s < g.max_seq; ++s)
+    for (int gi = 0; gi < g.groups; ++gi)
+      for (int di = 0; di < g.head_dim; ++di)
+        out[(static_cast<size_t>(s) * g.groups + gi) * g.head_dim + di] =
+            s < active
+                ? src[(static_cast<size_t>(gi) * g.max_seq + s) * g.head_dim +
+                      di]
+                : canary;
+  return out;
+}
+
+std::vector<float> PackTransposed(const Geometry& g,
+                                  const std::vector<float>& src, int active,
+                                  float canary) {
+  std::vector<float> out(src.size());
+  for (int gi = 0; gi < g.groups; ++gi)
+    for (int di = 0; di < g.head_dim; ++di)
+      for (int s = 0; s < g.max_seq; ++s)
+        out[(static_cast<size_t>(gi) * g.head_dim + di) * g.max_seq + s] =
+            s < active
+                ? src[(static_cast<size_t>(gi) * g.max_seq + s) * g.head_dim +
+                      di]
+                : canary;
+  return out;
+}
+
+std::vector<float> MakeMask(int max_seq, int active) {
+  std::vector<float> m(max_seq, kMaskFloor);
+  std::fill(m.begin(), m.begin() + active, 0.0f);
+  return m;
+}
+
+// One cache_rbmm decode step's inputs: the step writes position `pos` and
+// attends over [0, active) (active = pos + 1 in a plain decode loop). The
+// host cache inputs carry the prefix rows [0, pos) — they feed only the CPU
+// decomposition. zero_host_caches hands the measured GPU runner all-zero
+// host caches instead: the delegate path never reads them, so agreement
+// with the CPU reference then PROVES the delegate-managed cache persisted
+// across Run() calls.
+enum class HostCacheMode { kReal, kZeros, kSkip };
+
+absl::Status SetCacheStepInputs(LitertDynamicRunner& runner,
+                                const Geometry& g, const HostData& data,
+                                int pos, int active,
+                                HostCacheMode cache_mode) {
+  auto st = runner.SetInput("main", "q",
+                            Create("q", Type::kFP32,
+                                   {1, g.groups, g.group_sz, g.head_dim},
+                                   std::vector<float>(data.q)));
+  if (!st.ok())
+    return absl::InternalError(absl::StrCat("q: ", st.message()));
+  std::vector<float> row_k(static_cast<size_t>(g.groups) * g.head_dim);
+  std::vector<float> row_v(row_k.size());
+  for (int gi = 0; gi < g.groups; ++gi)
+    for (int di = 0; di < g.head_dim; ++di) {
+      size_t src = (static_cast<size_t>(gi) * g.max_seq + pos) * g.head_dim +
+                   di;
+      row_k[static_cast<size_t>(gi) * g.head_dim + di] = data.k[src];
+      row_v[static_cast<size_t>(gi) * g.head_dim + di] = data.v[src];
+    }
+  st = runner.SetInput("main", "src_k",
+                       Create("src_k", Type::kFP32,
+                              {1, g.groups, 1, g.head_dim},
+                              std::move(row_k)));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("src_k: ", st.message()));
+  st = runner.SetInput("main", "src_v",
+                       Create("src_v", Type::kFP32,
+                              {1, g.groups, 1, g.head_dim},
+                              std::move(row_v)));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("src_v: ", st.message()));
+  const size_t cache_elems =
+      static_cast<size_t>(g.groups) * g.max_seq * g.head_dim;
+  if (cache_mode != HostCacheMode::kSkip) {
+    st = runner.SetInput("main", "cache_k_in",
+                         Create("cache_k_in", Type::kFP32,
+                                {1, g.groups, g.max_seq, g.head_dim},
+                                cache_mode == HostCacheMode::kZeros
+                                    ? std::vector<float>(cache_elems, 0.0f)
+                                    : PackBnsd(g, data.k, pos, 0.0f)));
+    if (!st.ok()) return absl::InternalError(absl::StrCat("cache_k_in: ", st.message()));
+    st = runner.SetInput("main", "cache_v_in",
+                         Create("cache_v_in", Type::kFP32,
+                                {1, g.groups, g.head_dim, g.max_seq},
+                                cache_mode == HostCacheMode::kZeros
+                                    ? std::vector<float>(cache_elems, 0.0f)
+                                    : PackTransposed(g, data.v, pos, 0.0f)));
+    if (!st.ok()) return absl::InternalError(absl::StrCat("cache_v_in: ", st.message()));
+  }
+  std::vector<int32_t> p(7, active);
+  p[0] = pos;
+  st = runner.SetInput("main", "param",
+                       Create("param", Type::kI32, {1, 1, 1, 7},
+                              std::move(p)));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("param: ", st.message()));
+  std::vector<int32_t> pf(7, g.max_seq);
+  pf[0] = pos;
+  pf[1] = active;
+  st = runner.SetInput("main", "param_full",
+                       Create("param_full", Type::kI32, {1, 1, 1, 7},
+                              std::move(pf)));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("param_full: ", st.message()));
+  st = runner.SetInput("main", "pos_k",
+                       Create("pos_k", Type::kI32, {4},
+                              std::vector<int32_t>{0, 0, pos, 0}));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("pos_k: ", st.message()));
+  st = runner.SetInput("main", "pos_v",
+                       Create("pos_v", Type::kI32, {4},
+                              std::vector<int32_t>{0, 0, 0, pos}));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("pos_v: ", st.message()));
+  st = runner.SetInput("main", "mask",
+                       Create("mask", Type::kFP32, {1, 1, 1, g.max_seq},
+                              MakeMask(g.max_seq, active)));
+  if (!st.ok()) return absl::InternalError(absl::StrCat("mask: ", st.message()));
+  return absl::OkStatus();
+}
+
+absl::Status SetCommonInputs(LitertDynamicRunner& runner,
+                             const Geometry& g, const std::string& variant,
+                             const HostData& data, int active, float canary,
+                             bool param_align4) {
+  auto st = absl::OkStatus();
+  if (variant == "cache_rbmm") {
+    // The step writes position active-1; the cache inputs carry positions
+    // [0, active-1) and the composite adds the last row.
+    return SetCacheStepInputs(runner, g, data, /*pos=*/active - 1, active,
+                              HostCacheMode::kReal);
+  }
+  if (variant == "raw" || variant == "rbmm") {
+    std::vector<int> q_shape = variant == "raw"
+                                   ? std::vector<int>{1, g.heads, 1, g.head_dim}
+                                   : std::vector<int>{1, g.groups, g.group_sz,
+                                                      g.head_dim};
+    st = runner.SetInput("main", "q",
+                         Create("q", Type::kFP32, q_shape,
+                                std::vector<float>(data.q)));
+    if (!st.ok()) return st;
+    st = runner.SetInput(
+        "main", "k_cache",
+        Create("k_cache", Type::kFP32, {1, g.groups, g.max_seq, g.head_dim},
+               PackBnsd(g, data.k, active, canary)));
+    if (!st.ok()) return st;
+    if (variant == "raw") {
+      st = runner.SetInput(
+          "main", "v_cache",
+          Create("v_cache", Type::kFP32, {1, g.groups, g.max_seq, g.head_dim},
+                 PackBnsd(g, data.v, active, canary)));
+    } else {
+      st = runner.SetInput(
+          "main", "v_cache_t",
+          Create("v_cache_t", Type::kFP32,
+                 {1, g.groups, g.head_dim, g.max_seq},
+                 PackTransposed(g, data.v, active, canary)));
+    }
+    if (!st.ok()) return st;
+  } else {  // sdpa
+    st = runner.SetInput("main", "q",
+                         Create("q", Type::kFP32, {1, 1, g.heads, g.head_dim},
+                                std::vector<float>(data.q)));
+    if (!st.ok()) return st;
+    st = runner.SetInput(
+        "main", "k_cache",
+        Create("k_cache", Type::kFP32, {1, g.max_seq, g.groups, g.head_dim},
+               PackBsnd(g, data.k, active, canary)));
+    if (!st.ok()) return st;
+    st = runner.SetInput(
+        "main", "v_cache",
+        Create("v_cache", Type::kFP32, {1, g.max_seq, g.groups, g.head_dim},
+               PackBsnd(g, data.v, active, canary)));
+    if (!st.ok()) return st;
+  }
+  const std::string rbmm_mode = absl::GetFlag(FLAGS_rbmm_mode);
+  const bool rbmm_has_mask =
+      rbmm_mode == "masked" || rbmm_mode == "avbound";
+  if (variant != "rbmm" || rbmm_has_mask) {
+    st = runner.SetInput("main", "mask",
+                         Create("mask", Type::kFP32, {1, 1, 1, g.max_seq},
+                                MakeMask(g.max_seq, active)));
+    if (!st.ok()) return st;
+  }
+  if (variant == "rbmm") {
+    int p2 = param_align4 ? (active + 3) / 4 * 4 : active;
+    std::vector<int32_t> param(7, p2);
+    st = runner.SetInput("main", "param",
+                         Create("param", Type::kI32, {1, 1, 1, 7},
+                                std::move(param)));
+    if (!st.ok()) return st;
+    if (rbmm_mode == "corrected") {
+      st = runner.SetInput(
+          "main", "tail_count",
+          Create("tail_count", Type::kFP32, {1},
+                 std::vector<float>{static_cast<float>(g.max_seq - active)}));
+      if (!st.ok()) return st;
+    }
+    if (rbmm_mode == "avbound") {
+      st = runner.SetInput("main", "param_full",
+                           Create("param_full", Type::kI32, {1, 1, 1, 7},
+                                  std::vector<int32_t>(7, g.max_seq)));
+      if (!st.ok()) return st;
+    }
+  }
+  return st;
+}
+
+absl::Status RunBench() {
+  const std::string variant = absl::GetFlag(FLAGS_variant);
+  if (variant != "raw" && variant != "sdpa" && variant != "rbmm" &&
+      variant != "cache_rbmm") {
+    return absl::InvalidArgumentError(
+        "--variant must be raw|sdpa|rbmm|cache_rbmm");
+  }
+  const bool mha = absl::GetFlag(FLAGS_mha);
+  Geometry g;
+  g.heads = absl::GetFlag(FLAGS_heads);
+  g.groups = mha ? g.heads : absl::GetFlag(FLAGS_kv_groups);
+  g.group_sz = g.heads / g.groups;
+  g.head_dim = absl::GetFlag(FLAGS_head_dim);
+  g.max_seq = absl::GetFlag(FLAGS_max_seq);
+  const int blocks = absl::GetFlag(FLAGS_blocks);
+
+  // ---- Build the graph.
+  std::vector<TensorHandle> inputs;
+  TfTensor out;
+  TfTensor attn0;
+  TfTensor cache_k_new_out;
+  TfTensor cache_v_new_out;
+  TfTensor mask({.name = "mask",
+                 .type = Type::kFP32,
+                 .shape = {1, 1, 1, g.max_seq}});
+  if (variant == "raw") {
+    TfTensor q({.name = "q",
+                .type = Type::kFP32,
+                .shape = {1, g.heads, 1, g.head_dim}});
+    TfTensor k({.name = "k_cache",
+                .type = Type::kFP32,
+                .shape = {1, g.groups, g.max_seq, g.head_dim}});
+    TfTensor v({.name = "v_cache",
+                .type = Type::kFP32,
+                .shape = {1, g.groups, g.max_seq, g.head_dim}});
+    TfTensor x = q;
+    for (int b = 0; b < blocks; ++b) x = FoldAttention(g, x, k, v, mask);
+    out = x;
+    inputs = {q, k, v, mask};
+  } else if (variant == "sdpa") {
+    TfTensor q({.name = "q",
+                .type = Type::kFP32,
+                .shape = {1, 1, g.heads, g.head_dim}});
+    TfTensor k({.name = "k_cache",
+                .type = Type::kFP32,
+                .shape = {1, g.max_seq, g.groups, g.head_dim}});
+    TfTensor v({.name = "v_cache",
+                .type = Type::kFP32,
+                .shape = {1, g.max_seq, g.groups, g.head_dim}});
+    TfTensor x = q;
+    for (int b = 0; b < blocks; ++b) x = SdpaBlock(g, x, k, v, mask);
+    out = x;
+    inputs = {q, k, v, mask};
+  } else if (variant == "rbmm") {
+    TfTensor q({.name = "q",
+                .type = Type::kFP32,
+                .shape = {1, g.groups, g.group_sz, g.head_dim}});
+    TfTensor k({.name = "k_cache",
+                .type = Type::kFP32,
+                .shape = {1, g.groups, g.max_seq, g.head_dim}});
+    TfTensor v_t({.name = "v_cache_t",
+                  .type = Type::kFP32,
+                  .shape = {1, g.groups, g.head_dim, g.max_seq}});
+    TfTensor param({.name = "param",
+                    .type = Type::kI32,
+                    .shape = {1, 1, 1, 7}});
+    TfTensor tail_count({.name = "tail_count",
+                         .type = Type::kFP32,
+                         .shape = {1}});
+    TfTensor param_full({.name = "param_full",
+                         .type = Type::kI32,
+                         .shape = {1, 1, 1, 7}});
+    const std::string mode_str = absl::GetFlag(FLAGS_rbmm_mode);
+    if (mode_str != "masked" && mode_str != "nomask" &&
+        mode_str != "corrected" && mode_str != "avbound") {
+      return absl::InvalidArgumentError(
+          "--rbmm_mode must be masked|nomask|corrected|avbound");
+    }
+    const RbmmMode mode = mode_str == "masked"      ? RbmmMode::kMasked
+                          : mode_str == "nomask"    ? RbmmMode::kNoMask
+                          : mode_str == "corrected" ? RbmmMode::kCorrected
+                                                    : RbmmMode::kAvBound;
+    TfTensor x = q;
+    for (int b = 0; b < blocks; ++b)
+      x = RuntimeBmmBlock(g, x, k, v_t, mask, param, param_full, tail_count,
+                          mode,
+                          (b == 0 && absl::GetFlag(FLAGS_debug_softmax))
+                              ? &attn0
+                              : nullptr);
+    out = Reshape(x, {1, g.heads, 1, g.head_dim});
+    if (mode == RbmmMode::kMasked) {
+      inputs = {q, k, v_t, mask, param};
+    } else if (mode == RbmmMode::kNoMask) {
+      inputs = {q, k, v_t, param};
+    } else if (mode == RbmmMode::kCorrected) {
+      inputs = {q, k, v_t, param, tail_count};
+    } else {
+      inputs = {q, k, v_t, mask, param, param_full};
+    }
+  }
+  if (variant == "cache_rbmm") {
+    // Single decode step through cache_update + runtime_bmm; the cache is
+    // threaded through the composite, so block-chaining does not apply.
+    TfTensor q({.name = "q",
+                .type = Type::kFP32,
+                .shape = {1, g.groups, g.group_sz, g.head_dim}});
+    TfTensor src_k({.name = "src_k",
+                    .type = Type::kFP32,
+                    .shape = {1, g.groups, 1, g.head_dim}});
+    TfTensor src_v({.name = "src_v",
+                    .type = Type::kFP32,
+                    .shape = {1, g.groups, 1, g.head_dim}});
+    TfTensor param({.name = "param",
+                    .type = Type::kI32,
+                    .shape = {1, 1, 1, 7}});
+    TfTensor param_full({.name = "param_full",
+                         .type = Type::kI32,
+                         .shape = {1, 1, 1, 7}});
+    TfTensor cache_k_in({.name = "cache_k_in",
+                         .type = Type::kFP32,
+                         .shape = {1, g.groups, g.max_seq, g.head_dim}});
+    TfTensor cache_v_in({.name = "cache_v_in",
+                         .type = Type::kFP32,
+                         .shape = {1, g.groups, g.head_dim, g.max_seq}});
+    TfTensor pos_k({.name = "pos_k", .type = Type::kI32, .shape = {4}});
+    TfTensor pos_v({.name = "pos_v", .type = Type::kI32, .shape = {4}});
+    TfTensor step =
+        CacheRbmmStep(g, q, src_k, src_v, mask, param, param_full, cache_k_in,
+                      cache_v_in, pos_k, pos_v,
+                      absl::GetFlag(FLAGS_cache_qk_bound), &cache_k_new_out,
+                      &cache_v_new_out);
+    out = Reshape(step, {1, g.heads, 1, g.head_dim});
+    inputs = {q,          src_k, src_v, mask,  param,
+              param_full, cache_k_in,   cache_v_in, pos_k, pos_v};
+  }
+  out.SetName("out");
+
+  ModelFactory factory;
+  std::vector<TensorHandle> outputs = {out};
+  if (variant == "cache_rbmm" && absl::GetFlag(FLAGS_feedback_loops)) {
+    // Feedback-loop mode: the caches are signature outputs the runner swaps
+    // back into the inputs between Run() calls (PR #8796 contract).
+    outputs.push_back(cache_k_new_out);
+    outputs.push_back(cache_v_new_out);
+  }
+  const bool debug_softmax =
+      absl::GetFlag(FLAGS_debug_softmax) && variant == "rbmm";
+  if (debug_softmax) {
+    attn0.SetName("attn0");
+    outputs.push_back(attn0);
+  }
+  auto st = factory.AddSignature(inputs, outputs, "main");
+  if (!st.ok()) return st;
+  const std::string path = absl::GetFlag(FLAGS_tflite_path);
+  st = factory.Save(path);
+  if (!st.ok()) return st;
+  std::cout << "serialized " << variant << " x" << blocks << " blocks ("
+            << (mha ? "MHA-shaped" : "GQA") << ", G=" << g.groups
+            << ") -> " << path << std::endl;
+
+  // ---- Runners: CPU reference always; GPU if requested.
+  auto env = ::litert::Environment::Create({});
+  if (!env) return absl::InternalError("Environment::Create failed");
+
+  auto cpu_options = ::litert::Options::Create();
+  if (!cpu_options) return absl::InternalError("Options::Create failed");
+  cpu_options->SetHardwareAccelerators(::litert::HwAccelerators::kCpu);
+  auto cpu_runner_or = LitertDynamicRunner::Create(*env, path, *cpu_options);
+  if (!cpu_runner_or.ok()) return cpu_runner_or.status();
+  auto cpu_runner = std::move(*cpu_runner_or);
+
+  const bool use_gpu = absl::GetFlag(FLAGS_accelerator) == "gpu";
+  const bool feedback = variant == "cache_rbmm" &&
+                        absl::GetFlag(FLAGS_multi_steps) > 0 &&
+                        absl::GetFlag(FLAGS_feedback_loops);
+  std::unique_ptr<LitertDynamicRunner> gpu_runner;
+  // CPU feedback validation: a second, loop-registered CPU runner as the
+  // measured side; cpu_runner stays the stateless per-step reference.
+  std::unique_ptr<LitertDynamicRunner> cpu_looped;
+  if (!use_gpu && feedback) {
+    auto looped_options = ::litert::Options::Create();
+    if (!looped_options) return absl::InternalError("Options::Create failed");
+    looped_options->SetHardwareAccelerators(::litert::HwAccelerators::kCpu);
+    auto looped_or = LitertDynamicRunner::Create(
+        *env, path, *looped_options,
+        {{"cache_k_in", "cache_k_new"}, {"cache_v_in", "cache_v_new"}});
+    if (!looped_or.ok()) return looped_or.status();
+    cpu_looped =
+        std::make_unique<LitertDynamicRunner>(std::move(*looped_or));
+  }
+  if (use_gpu) {
+    auto options = ::litert::Options::Create();
+    if (!options) return absl::InternalError("Options::Create failed");
+    options->SetHardwareAccelerators(::litert::HwAccelerators::kGpu);
+    auto gpu_options = options->GetGpuOptions();
+    if (gpu_options.HasValue()) {
+      if (absl::GetFlag(FLAGS_gpu_precision) == "fp32") {
+        gpu_options->SetPrecision(::litert::GpuOptions::Precision::kFp32);
+      }
+      const std::string storage = absl::GetFlag(FLAGS_gpu_buffer_storage);
+      if (storage == "buffer") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kBuffer);
+      } else if (storage == "texture2d") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kTexture2D);
+      }
+    }
+    auto gpu_runner_or =
+        feedback
+            ? LitertDynamicRunner::Create(
+                  *env, path, *options,
+                  {{"cache_k_in", "cache_k_new"}, {"cache_v_in", "cache_v_new"}})
+            : LitertDynamicRunner::Create(*env, path, *options);
+    if (!gpu_runner_or.ok()) return gpu_runner_or.status();
+    gpu_runner = std::make_unique<LitertDynamicRunner>(
+        std::move(*gpu_runner_or));
+  }
+  LitertDynamicRunner& measured =
+      use_gpu ? *gpu_runner : (cpu_looped ? *cpu_looped : cpu_runner);
+
+  const HostData data = MakeHostData(g, absl::GetFlag(FLAGS_seed));
+  float canary = absl::GetFlag(FLAGS_canary);
+  if (variant == "rbmm" && absl::GetFlag(FLAGS_rbmm_mode) == "corrected" &&
+      canary != 0.0f) {
+    std::cout << "corrected mode requires zero tail cache slots; forcing "
+                 "--canary=0"
+              << std::endl;
+    canary = 0.0f;
+  }
+  const bool align4 = absl::GetFlag(FLAGS_param_align4);
+  const int runs = absl::GetFlag(FLAGS_runs);
+  const int warmup = absl::GetFlag(FLAGS_warmup);
+
+  std::vector<std::string> fill_strs =
+      absl::StrSplit(absl::GetFlag(FLAGS_fills), ',', absl::SkipEmpty());
+
+  auto read_output = [](LitertDynamicRunner& runner,
+                        std::vector<float>& sink) -> absl::Status {
+    auto out = runner.GetOutput("main", "out");
+    if (!out.ok()) return out.status();
+    auto buffer = out->GetBuffer();
+    if (!buffer.ok()) return buffer.status();
+    auto lock = buffer->Lock();
+    const float* data = reinterpret_cast<const float*>(lock.data());
+    sink.assign(data, data + lock.size() / sizeof(float));
+    return absl::OkStatus();
+  };
+
+  const int multi_steps = absl::GetFlag(FLAGS_multi_steps);
+  if (variant == "cache_rbmm" && multi_steps > 0) {
+    // Chained decode: one runner instance, pos = 0..N-1. Each step's CPU
+    // reference is computed statelessly from host-provided prefix rows; the
+    // measured GPU runner gets zeroed host caches (see SetCacheStepInputs),
+    // so per-step agreement proves cross-Run() cache accumulation.
+    if (multi_steps > g.max_seq) {
+      return absl::InvalidArgumentError("--multi_steps must be <= max_seq");
+    }
+    double worst_rel = 0.0;
+    int worst_step = -1;
+    std::vector<double> ms;
+    ms.reserve(multi_steps);
+    for (int pos = 0; pos < multi_steps; ++pos) {
+      const int active = pos + 1;
+      st = SetCacheStepInputs(cpu_runner, g, data, pos, active,
+                              HostCacheMode::kReal);
+      if (!st.ok()) return st;
+      st = cpu_runner.Run("main");
+      if (!st.ok()) return st;
+      std::vector<float> ref;
+      st = read_output(cpu_runner, ref);
+      if (!st.ok()) return st;
+
+      if (use_gpu || cpu_looped) {
+        const std::string hc = absl::GetFlag(FLAGS_multi_host_cache);
+        // Feedback mode: the swap chain owns the cache bindings, so never
+        // re-set them. On GPU unwritten rows are never read (masked); the
+        // CPU decomposition flows the whole buffer through DUS, so seed
+        // zeros once at pos=0 there.
+        const HostCacheMode measured_mode =
+            feedback ? (cpu_looped && pos == 0 ? HostCacheMode::kZeros
+                                               : HostCacheMode::kSkip)
+            : hc == "real" ? HostCacheMode::kReal
+            : hc == "once" ? (pos == 0 ? HostCacheMode::kZeros
+                                       : HostCacheMode::kSkip)
+                           : HostCacheMode::kZeros;
+        st = SetCacheStepInputs(measured, g, data, pos, active, measured_mode);
+        if (!st.ok()) return st;
+        auto t0 = std::chrono::steady_clock::now();
+        st = measured.Run("main");
+        auto t1 = std::chrono::steady_clock::now();
+        if (!st.ok()) return st;
+        ms.push_back(
+            std::chrono::duration<double, std::milli>(t1 - t0).count());
+        std::vector<float> got;
+        st = read_output(measured, got);
+        if (!st.ok()) return st;
+        double max_rel = 0.0;
+        size_t worst_i = 0;
+        for (size_t i = 0; i < ref.size(); ++i) {
+          double denom =
+              std::max(1e-3, std::fabs(static_cast<double>(ref[i])));
+          double rel = std::fabs(got[i] - ref[i]) / denom;
+          if (rel > max_rel) {
+            max_rel = rel;
+            worst_i = i;
+          }
+        }
+        if (max_rel > worst_rel) {
+          worst_rel = max_rel;
+          worst_step = pos;
+        }
+        if (max_rel > 1e-3 || pos < 3 || pos == multi_steps - 1 ||
+            (pos + 1) % 64 == 0) {
+          std::printf(
+              "  step pos=%d active=%d max_rel=%.3g%s got[w]=%.6f ref[w]=%.6f "
+              "ms=%.3f\n",
+              pos, active, max_rel, max_rel > 1e-3 ? " MISMATCH" : "",
+              got[worst_i], ref[worst_i], ms.back());
+        }
+      }
+    }
+    if (use_gpu || cpu_looped) {
+      std::sort(ms.begin(), ms.end());
+      const std::string mode_desc =
+          absl::GetFlag(FLAGS_feedback_loops)
+              ? "FEEDBACK LOOPS #8796"
+              : absl::StrCat("host_cache=",
+                             absl::GetFlag(FLAGS_multi_host_cache));
+      std::printf(
+          "multi_steps=%d (%s): worst max_rel=%.3g at "
+          "pos=%d -> %s; per-step median_ms=%.3f min=%.3f max=%.3f\n",
+          multi_steps, mode_desc.c_str(), worst_rel, worst_step,
+          worst_rel <= 1e-3 ? "cache state ACCUMULATES across Run() calls"
+                            : "MISMATCH — state did NOT accumulate",
+          ms[ms.size() / 2], ms.front(), ms.back());
+    } else {
+      std::cout << "multi_steps on CPU exercises only the stateless "
+                   "decomposition (host caches feed it); nothing to verify"
+                << std::endl;
+    }
+    return absl::OkStatus();
+  }
+
+  for (const std::string& fs : fill_strs) {
+    const int active = std::stoi(fs);
+
+    // Reference output on CPU.
+    st = SetCommonInputs(cpu_runner, g, variant, data, active, canary, align4);
+    if (!st.ok()) return st;
+    st = cpu_runner.Run("main");
+    if (!st.ok()) return st;
+    std::vector<float> ref_data;
+    st = read_output(cpu_runner, ref_data);
+    if (!st.ok()) return st;
+
+    // Measured runner.
+    double max_rel = 0.0;
+    if (use_gpu) {
+      st = SetCommonInputs(measured, g, variant, data, active, canary, align4);
+      if (!st.ok()) return st;
+      st = measured.Run("main");
+      if (!st.ok()) return st;
+      std::vector<float> got;
+      st = read_output(measured, got);
+      if (!st.ok()) return st;
+      size_t worst = 0;
+      for (size_t i = 0; i < ref_data.size(); ++i) {
+        double denom = std::max(1e-3, std::fabs(static_cast<double>(
+            ref_data[i])));
+        double rel = std::fabs(got[i] - ref_data[i]) / denom;
+        if (rel > max_rel) {
+          max_rel = rel;
+          worst = i;
+        }
+      }
+      if (max_rel > 1e-3) {
+        int bad = 0;
+        for (size_t i = 0; i < ref_data.size(); ++i) {
+          double denom = std::max(1e-3, std::fabs(static_cast<double>(
+              ref_data[i])));
+          if (std::fabs(got[i] - ref_data[i]) / denom > 1e-3) bad++;
+        }
+        std::printf(
+            "  MISMATCH fill=%d: %d/%zu elems rel>1e-3; worst i=%zu (head=%zu "
+            "dim=%zu) got=%.6f ref=%.6f; gpu[0..3]=[%.5f %.5f %.5f %.5f]\n",
+            active, bad, ref_data.size(), worst,
+            worst / static_cast<size_t>(g.head_dim),
+            worst % static_cast<size_t>(g.head_dim), got[worst],
+            ref_data[worst], got[0], got[1], got[2], got[3]);
+      }
+      if (debug_softmax) {
+        auto a_or = measured.GetOutput("main", "attn0");
+        if (a_or.ok()) {
+          auto buffer = a_or->GetBuffer();
+          if (buffer.ok()) {
+            auto lock = buffer->Lock();
+            const float* a = reinterpret_cast<const float*>(lock.data());
+            double active_sum = 0.0, tail_sum = 0.0, tail_max = 0.0;
+            for (int s = 0; s < g.max_seq; ++s) {
+              if (s < active) {
+                active_sum += a[s];
+              } else {
+                tail_sum += a[s];
+                tail_max = std::max(tail_max, static_cast<double>(a[s]));
+              }
+            }
+            std::printf(
+                "  softmax row0 (measured): active_sum=%.6f tail_sum=%.6f "
+                "tail_max=%.6g tail[active]=%.6g tail[last]=%.6g\n",
+                active_sum, tail_sum, tail_max,
+                static_cast<double>(active < g.max_seq ? a[active] : 0.f),
+                static_cast<double>(a[g.max_seq - 1]));
+          }
+        }
+      }
+    }
+
+    for (int i = 0; i < warmup; ++i) {
+      st = measured.Run("main");
+      if (!st.ok()) return st;
+    }
+    std::vector<double> ms;
+    ms.reserve(runs);
+    for (int i = 0; i < runs; ++i) {
+      auto t0 = std::chrono::steady_clock::now();
+      st = measured.Run("main");
+      if (!st.ok()) return st;
+      auto t1 = std::chrono::steady_clock::now();
+      ms.push_back(
+          std::chrono::duration<double, std::milli>(t1 - t0).count());
+    }
+    std::sort(ms.begin(), ms.end());
+    const double median = ms[ms.size() / 2];
+
+    double mean_abs = 0.0;
+    for (float x : ref_data) mean_abs += std::fabs(x);
+    mean_abs /= ref_data.size();
+
+    std::printf(
+        "variant=%s accel=%s%s fill=%d blocks=%d median_ms=%.3f min=%.3f "
+        "max=%.3f cpu_ref_mean_abs=%.6f sample=[%.5f %.5f %.5f %.5f]%s\n",
+        variant.c_str(), use_gpu ? "gpu" : "cpu",
+        mha ? " (mha)" : "", active, blocks, median, ms.front(), ms.back(),
+        mean_abs, ref_data[0], ref_data[1], ref_data[2], ref_data[3],
+        use_gpu ? absl::StrCat(" gpu_vs_cpu_max_rel=", max_rel).c_str() : "");
+
+    const std::string dump = absl::GetFlag(FLAGS_dump_out);
+    if (!dump.empty()) {
+      const std::string p = absl::StrCat(dump, ".fill", active, ".bin");
+      FILE* f = std::fopen(p.c_str(), "wb");
+      if (f) {
+        std::fwrite(ref_data.data(), sizeof(float), ref_data.size(), f);
+        std::fclose(f);
+        std::cout << "wrote CPU-ref output " << p << std::endl;
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  auto st = RunBench();
+  if (!st.ok()) {
+    std::cerr << "ERROR: " << st.message() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h
@@ -1,0 +1,76 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Talker step-graph — Stage 2 config, aligned with the real
+// Qwen/Qwen3-TTS-12Hz-0.6B-Base checkpoint (config.json talker_config +
+// code_predictor_config + model.safetensors tensor shapes).
+
+#ifndef SPEECHLM_STAGE1_TALKER_STEP_TALKER_CONFIG_H_
+#define SPEECHLM_STAGE1_TALKER_STEP_TALKER_CONFIG_H_
+
+namespace litert::tensor::examples::talker {
+
+struct TalkerConfig {
+  // Talker backbone (qwen3_tts_talker, 0.6B).
+  int emb_dim = 1024;
+  int n_layers = 28;
+  int n_heads = 16;
+  int n_kv_groups = 8;
+  int head_dim = 128;
+  int hidden_dim = 3072;
+  float rms_norm_eps = 1e-6f;
+  float rope_base = 1000000.0f;
+
+  // Sequence / cache.
+  int max_seq = 1024;
+  int prefill_len = 64;
+
+  // Codec token space: the talker predicts group 0 over 3072 ids (2048 codec
+  // codes + specials, e.g. eos 2150); the code predictor fills groups 1..15
+  // over 2048.
+  int talker_vocab = 3072;
+  int codec_vocab = 2048;
+  int codec_eos_id = 2150;
+  int num_code_groups = 16;
+
+  // Code predictor (qwen3_tts_talker_code_predictor): 5-layer transformer,
+  // same head geometry as the talker, per-group embeddings and lm_heads.
+  int cp_layers = 5;
+
+  // 1920-sample codec hop @ 24 kHz = 80 ms/frame; the "12Hz" model name
+  // rounds down. RTF budgets must use 80 ms, not 83.3.
+  double frame_rate_hz = 12.5;
+
+  // Backbone attention via odml.runtime_bmm composites (the "avbound"
+  // composition: QK unbounded so the fused mask epilogue covers the full
+  // width, AV side runtime-bounded). Changes the value-cache layout to
+  // [1, kv, head_dim, max_seq] and adds runtime control-tensor inputs.
+  bool use_runtime_bmm = false;
+
+  // Emit every RMS norm as the odml.rms_norm composite (epsilon attr,
+  // constant 1-D scale input; decomposition = the raw MEAN/RSQRT/MUL math,
+  // so CPU execution is unchanged). Fused kernels exist on Metal and CL.
+  bool use_rms_norm_composite = false;
+
+  int qkv_out_dim() const { return n_heads * head_dim; }
+  int kv_out_dim() const { return n_kv_groups * head_dim; }
+  int num_sub_groups() const { return num_code_groups - 1; }
+  // Code predictor sequence: [talker hidden, cb0 embed, 14 sub embeds] — the
+  // 15th sub code never feeds back in-frame.
+  int cp_max_seq() const { return num_code_groups + 1; }
+};
+
+}  // namespace litert::tensor::examples::talker
+
+#endif  // SPEECHLM_STAGE1_TALKER_STEP_TALKER_CONFIG_H_

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.cc
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.cc
@@ -1,0 +1,640 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Talker step-graph — Stage 2. See talker_graph.h.
+
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/log/absl_check.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+#include "tensor/arithmetic.h"
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::talker {
+
+namespace {
+
+// fp16-safe additive mask floor (fp32 -1e9 overflows fp16 on GPU).
+constexpr float kMaskFloor = -30000.0f;
+
+TfTensor Const1(float value) {
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>({value})});
+}
+
+// Deterministic LCG so runs are reproducible without an RNG dependency.
+std::vector<float> SyntheticData(size_t count, unsigned& state, float scale) {
+  std::vector<float> data(count);
+  for (size_t i = 0; i < count; ++i) {
+    state = state * 1664525u + 1013904223u;
+    data[i] = scale * (static_cast<float>(state >> 8) /
+                           static_cast<float>(1u << 24) * 2.0f -
+                       1.0f);
+  }
+  return data;
+}
+
+TfTensor SyntheticWeight(const std::string& name, const std::vector<int>& shape,
+                         unsigned& state, float scale = 0.02f) {
+  size_t count = 1;
+  for (int d : shape) count *= static_cast<size_t>(d);
+  return TfTensor({.name = name,
+                   .type = Type::kFP32,
+                   .shape = shape,
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>(
+                       SyntheticData(count, state, scale))});
+}
+
+const TfTensor& GetWeight(const WeightMap& weights, const std::string& name) {
+  auto it = weights.find(name);
+  ABSL_CHECK(it != weights.end()) << "missing weight: " << name;
+  return it->second;
+}
+
+// Toggled per BuildTalkerStep call from TalkerConfig::use_rms_norm_composite
+// (single-threaded graph construction).
+bool g_rms_norm_composite = false;
+
+// RMS normalization composed from primitives.
+TfTensor RmsNormRaw(const TfTensor& input, const TfTensor& scale, float eps) {
+  TfTensor x_squared = Mul(input, input);
+  int last_axis = static_cast<int>(input.GetShape().size()) - 1;
+  TfTensor mean_squared = Mean(x_squared, {last_axis}, /*keep_dims=*/true);
+  TfTensor inv_rms = Rsqrt(Add(mean_squared, Const1(eps)));
+  return Mul(Mul(input, inv_rms), scale);
+}
+
+std::vector<uint8_t> RmsNormAttributes(float eps) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() { fbb.Float("epsilon", eps); });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// RMS norm, optionally as the odml.rms_norm composite (fused ML Drift
+// kernels on Metal and CL; the decomposition is the raw math, so CPU
+// execution is identical either way).
+TfTensor RmsNorm(const TfTensor& input, const TfTensor& scale, float eps) {
+  if (!g_rms_norm_composite) return RmsNormRaw(input, scale, eps);
+  StableHLOCompositeOptions opts{.name = "odml.rms_norm",
+                                 .composite_attributes =
+                                     RmsNormAttributes(eps)};
+  return StableHLOComposite(
+      opts,
+      [eps](TfTensor x, TfTensor s) { return RmsNormRaw(x, s, eps); }, input,
+      scale);
+}
+
+TfTensor Silu(const TfTensor& x) { return Mul(x, Logistic(x)); }
+
+// Rotate-half RoPE with cos/sin provided as tensors (host input for the
+// talker; baked constants for the code predictor).
+TfTensor ApplyRope(const TfTensor& x, const TfTensor& cos,
+                   const TfTensor& sin) {
+  const auto& s = x.GetShape();  // [1, heads, seq, head_dim]
+  int half = s[3] / 2;
+  TfTensor x1 = Slice(x, {0, 0, 0, 0}, {s[0], s[1], s[2], half});
+  TfTensor x2 = Slice(x, {0, 0, 0, half}, {s[0], s[1], s[2], half});
+  TfTensor rotated = Concatenation({Mul(x2, Const1(-1.0f)), x1}, /*axis=*/3);
+  return Add(Mul(x, cos), Mul(rotated, sin));
+}
+
+// HF-pairing GQA attention core without materializing repeated K/V: fold the
+// kv groups into the batch axis and each group's q heads into the sequence
+// axis, so q head h reads kv group h / (heads/kv) — repeat_interleave
+// semantics. (A plain Tile pairs head h with group h % kv instead — wrong
+// whenever 1 < kv < heads; the gemma3 example only supports kv == 1, where
+// the two coincide. Gather-axis-1 repeat is rejected by the Metal delegate.)
+// q [1, heads, seq, hd], k/v [1, kv, kv_seq, hd], mask [1, 1|heads, seq,
+// kv_seq] additive -> output [1, heads, seq, hd].
+TfTensor GqaAttention(const TfTensor& q, const TfTensor& k, const TfTensor& v,
+                      const TfTensor& mask, int n_heads, int n_kv_groups,
+                      int head_dim) {
+  int g = n_heads / n_kv_groups;
+  int seq = q.GetShape()[2];
+  int kv_seq = k.GetShape()[2];
+  float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+
+  TfTensor qg = Reshape(q, {n_kv_groups, 1, g * seq, head_dim});
+  TfTensor kg = Reshape(k, {n_kv_groups, 1, kv_seq, head_dim});
+  TfTensor vg = Reshape(v, {n_kv_groups, 1, kv_seq, head_dim});
+
+  TfTensor scores = BatchMatMul(qg, kg, /*adj_x=*/false, /*adj_y=*/true);
+  scores = Reshape(scores, {1, n_heads, seq, kv_seq});
+  scores = Mul(scores, Const1(scale));
+  scores = Add(scores, mask);
+  TfTensor attn = Softmax(scores);
+  attn = Reshape(attn, {n_kv_groups, 1, g * seq, kv_seq});
+  TfTensor out = BatchMatMul(attn, vg);
+  return Reshape(out, {1, n_heads, seq, head_dim});
+}
+
+std::vector<uint8_t> RuntimeBmmAttributes(bool is_src) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() {
+    fbb.Bool("is_global", true);
+    fbb.Bool("is_src", is_src);
+    fbb.Bool("rhs_cache_update", false);
+  });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// GQA attention via the odml.runtime_bmm composite pair in the "avbound"
+// composition: the QK side runs UNBOUNDED (runtime_param_full carries
+// max_seq) so every tail score is deterministically written and the fused
+// scale/mask epilogue covers the full width; only the scores x V side is
+// runtime-bounded (runtime_param carries the active length). A dst-bounded
+// QK would leave its output tail unwritten, which the full-width Softmax in
+// between would then read - see the attn_bench findings. The decompositions
+// are plain BatchMatMuls, so CPU execution equals the raw-op path exactly.
+// q [1, heads, seq, hd], k [1, kv, max_seq, hd], v_t [1, kv, hd, max_seq],
+// mask [1, 1|heads, seq, max_seq] additive -> output [1, heads, seq, hd].
+TfTensor RbmmGqaAttention(const TfTensor& q, const TfTensor& k,
+                          const TfTensor& v_t, const TfTensor& mask,
+                          const TfTensor& runtime_param,
+                          const TfTensor& runtime_param_full, int n_heads,
+                          int n_kv_groups, int head_dim, int max_seq) {
+  int g = n_heads / n_kv_groups;
+  int seq = q.GetShape()[2];
+  float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+
+  TfTensor qg = Reshape(q, {1, n_kv_groups, g * seq, head_dim});
+  StableHLOCompositeOptions qk_opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(/*is_src=*/false)};
+  TfTensor scores = StableHLOComposite(
+      qk_opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      qg, k, runtime_param_full);  // [1, kv, g*seq, max_seq]
+  scores = Reshape(scores, {1, n_heads, seq, max_seq});
+  scores = Mul(scores, Const1(scale));
+  scores = Add(scores, mask);
+  TfTensor attn = Softmax(scores);
+  attn = Reshape(attn, {1, n_kv_groups, g * seq, max_seq});
+  StableHLOCompositeOptions av_opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(/*is_src=*/true)};
+  TfTensor out = StableHLOComposite(
+      av_opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      attn, v_t, runtime_param);  // [1, kv, g*seq, hd]
+  return Reshape(out, {1, n_heads, seq, head_dim});
+}
+
+// Generic pre-norm GQA transformer layer used by both the talker backbone and
+// the code predictor. `k_ext`/`v_ext` (optional) provide externally updated
+// caches for attention; when null, attention runs over this call's k/v only.
+struct LayerWeights {
+  std::string prefix;
+};
+
+struct AttentionResult {
+  TfTensor output;
+  TfTensor key_cache;
+  TfTensor value_cache;
+};
+
+// Talker self-attention with a FIXED-SIZE cache updated in-graph via
+// DynamicUpdateSlice at the runtime cache_position (both signatures pass the
+// position as an input — the Metal delegate rejects constant start_indices).
+AttentionResult TalkerAttention(const TalkerConfig& config,
+                                const TfTensor& input, const std::string& prefix,
+                                const TalkerInputs& inputs, int layer_idx,
+                                const WeightMap& weights) {
+  const auto& in_shape = input.GetShape();
+  int seq = in_shape[1];
+
+  TfTensor q = FullyConnected(input, GetWeight(weights, prefix + ".q_proj.weight"));
+  TfTensor k = FullyConnected(input, GetWeight(weights, prefix + ".k_proj.weight"));
+  TfTensor v = FullyConnected(input, GetWeight(weights, prefix + ".v_proj.weight"));
+
+  q = Reshape(q, {1, seq, config.n_heads, config.head_dim});
+  q = Transpose(q, {0, 2, 1, 3});
+  k = Reshape(k, {1, seq, config.n_kv_groups, config.head_dim});
+  k = Transpose(k, {0, 2, 1, 3});
+  v = Reshape(v, {1, seq, config.n_kv_groups, config.head_dim});
+  v = Transpose(v, {0, 2, 1, 3});
+
+  q = RmsNorm(q, GetWeight(weights, prefix + ".q_norm.weight"),
+              config.rms_norm_eps);
+  k = RmsNorm(k, GetWeight(weights, prefix + ".k_norm.weight"),
+              config.rms_norm_eps);
+
+  q = ApplyRope(q, inputs.rope_cos, inputs.rope_sin);
+  k = ApplyRope(k, inputs.rope_cos, inputs.rope_sin);
+
+  TfTensor key_cache_new = DynamicUpdateSlice(inputs.key_caches[layer_idx], k,
+                                              inputs.cache_position);
+  key_cache_new.SetName(absl::StrCat("key_cache_", layer_idx, "_new"));
+
+  TfTensor value_cache_new;
+  TfTensor out;
+  if (config.use_runtime_bmm) {
+    // Value cache lives transposed ([1, kv, hd, max_seq]); write this call's
+    // rows as columns at the runtime position on the last axis.
+    TfTensor v_t = Transpose(v, {0, 1, 3, 2});  // [1, kv, hd, seq]
+    value_cache_new = DynamicUpdateSlice(inputs.value_caches[layer_idx], v_t,
+                                         inputs.cache_position_vt);
+    value_cache_new.SetName(absl::StrCat("value_cache_", layer_idx, "_new"));
+    out = RbmmGqaAttention(q, key_cache_new, value_cache_new,
+                           inputs.attention_mask, inputs.runtime_param,
+                           inputs.runtime_param_full, config.n_heads,
+                           config.n_kv_groups, config.head_dim,
+                           config.max_seq);
+  } else {
+    value_cache_new = DynamicUpdateSlice(inputs.value_caches[layer_idx], v,
+                                         inputs.cache_position);
+    value_cache_new.SetName(absl::StrCat("value_cache_", layer_idx, "_new"));
+    out =
+        GqaAttention(q, key_cache_new, value_cache_new, inputs.attention_mask,
+                     config.n_heads, config.n_kv_groups, config.head_dim);
+  }
+
+  out = Transpose(out, {0, 2, 1, 3});
+  out = Reshape(out, {1, seq, config.qkv_out_dim()});
+  out = FullyConnected(out, GetWeight(weights, prefix + ".o_proj.weight"));
+  return {out, key_cache_new, value_cache_new};
+}
+
+TfTensor FeedForward(const TfTensor& input, const std::string& prefix,
+                     const WeightMap& weights) {
+  TfTensor gate = FullyConnected(input, GetWeight(weights, prefix + ".gate_proj.weight"));
+  TfTensor up = FullyConnected(input, GetWeight(weights, prefix + ".up_proj.weight"));
+  return FullyConnected(Mul(Silu(gate), up),
+                        GetWeight(weights, prefix + ".down_proj.weight"));
+}
+
+// Code predictor incremental stepper — the KV-CACHED in-graph form of the
+// production folded MTP (export_mtp_folded.py): step t processes ONE token
+// at rope position t, appending per-layer K/V onto growing Concatenation
+// caches (all shapes static in the unroll; causal by construction, no mask;
+// no DynamicUpdateSlice needed). Replaces the earlier naive full re-forward
+// per group, whose ~8.4x extra CP FLOPs put the one-call graph BEHIND the
+// production host-loop floor on phone CPUs (see notes/pixel8a-ab.md).
+struct CpCacheState {
+  // Per layer: [1, kv, t+1, hd] roped keys / values accumulated so far.
+  std::vector<TfTensor> k, v;
+};
+
+// Per-position rope constants [1, 1, 1, head_dim].
+std::pair<TfTensor, TfTensor> ConstRopeAt(int pos, int head_dim, float base) {
+  std::vector<float> cos_v(head_dim), sin_v(head_dim);
+  int half = head_dim / 2;
+  for (int i = 0; i < half; ++i) {
+    float freq = std::pow(base, -2.0f * static_cast<float>(i) / head_dim);
+    float angle = static_cast<float>(pos) * freq;
+    cos_v[i] = cos_v[half + i] = std::cos(angle);
+    sin_v[i] = sin_v[half + i] = std::sin(angle);
+  }
+  TfTensor cos_t({.type = Type::kFP32,
+                  .shape = {1, 1, 1, head_dim},
+                  .buffer = OwningCpuBuffer::Copy<Type::kFP32>(cos_v)});
+  TfTensor sin_t({.type = Type::kFP32,
+                  .shape = {1, 1, 1, head_dim},
+                  .buffer = OwningCpuBuffer::Copy<Type::kFP32>(sin_v)});
+  return {cos_t, sin_t};
+}
+
+// One CP step: x [1, 1, emb] at position t -> final-normed hidden [1, 1, emb].
+TfTensor CpStep(const TalkerConfig& config, TfTensor x, int t,
+                CpCacheState& state, const WeightMap& weights) {
+  auto [cos, sin] = ConstRopeAt(t, config.head_dim, config.rope_base);
+  TfTensor zero_mask(
+      {.type = Type::kFP32,
+       .shape = {1, 1, 1, t + 1},
+       .buffer = OwningCpuBuffer::Copy<Type::kFP32>(
+           std::vector<float>(t + 1, 0.0f))});
+
+  for (int i = 0; i < config.cp_layers; ++i) {
+    std::string p = absl::StrCat("talker.code_predictor.model.layers.", i);
+    TfTensor h = RmsNorm(x, GetWeight(weights, p + ".input_layernorm.weight"),
+                         config.rms_norm_eps);
+    TfTensor q =
+        FullyConnected(h, GetWeight(weights, p + ".self_attn.q_proj.weight"));
+    TfTensor k =
+        FullyConnected(h, GetWeight(weights, p + ".self_attn.k_proj.weight"));
+    TfTensor v =
+        FullyConnected(h, GetWeight(weights, p + ".self_attn.v_proj.weight"));
+    q = Transpose(Reshape(q, {1, 1, config.n_heads, config.head_dim}),
+                  {0, 2, 1, 3});
+    k = Transpose(Reshape(k, {1, 1, config.n_kv_groups, config.head_dim}),
+                  {0, 2, 1, 3});
+    v = Transpose(Reshape(v, {1, 1, config.n_kv_groups, config.head_dim}),
+                  {0, 2, 1, 3});
+    q = RmsNorm(q, GetWeight(weights, p + ".self_attn.q_norm.weight"),
+                config.rms_norm_eps);
+    k = RmsNorm(k, GetWeight(weights, p + ".self_attn.k_norm.weight"),
+                config.rms_norm_eps);
+    q = ApplyRope(q, cos, sin);
+    k = ApplyRope(k, cos, sin);
+
+    if (t == 0) {
+      state.k.push_back(k);
+      state.v.push_back(v);
+    } else {
+      state.k[i] = Concatenation({state.k[i], k}, /*axis=*/2);
+      state.v[i] = Concatenation({state.v[i], v}, /*axis=*/2);
+    }
+
+    TfTensor out = GqaAttention(q, state.k[i], state.v[i], zero_mask,
+                                config.n_heads, config.n_kv_groups,
+                                config.head_dim);
+    out = Reshape(Transpose(out, {0, 2, 1, 3}), {1, 1, config.qkv_out_dim()});
+    out = FullyConnected(out, GetWeight(weights, p + ".self_attn.o_proj.weight"));
+    x = Add(x, out);
+
+    TfTensor f = RmsNorm(
+        x, GetWeight(weights, p + ".post_attention_layernorm.weight"),
+        config.rms_norm_eps);
+    x = Add(x, FeedForward(f, p + ".mlp", weights));
+  }
+  return RmsNorm(x,
+                 GetWeight(weights, "talker.code_predictor.model.norm.weight"),
+                 config.rms_norm_eps);
+}
+
+// 1-D-indices Gather of one embedding row: ids [1,1] -> [1,1,emb].
+TfTensor GatherRow(const TfTensor& table, const TfTensor& id, int emb_dim) {
+  TfTensor flat = Reshape(id, {1});
+  TfTensor row = Gather(table, flat, /*axis=*/0);
+  return Reshape(row, {1, 1, emb_dim});
+}
+
+}  // namespace
+
+std::vector<TfTensor> TalkerInputs::AsList(bool is_decode) const {
+  std::vector<TfTensor> list;
+  if (is_decode) {
+    list.push_back(feedback_emb);
+    list.push_back(text_track_emb);
+  } else {
+    list.push_back(embedded_input);
+  }
+  list.push_back(cb0_bias);
+  list.push_back(cache_position);
+  list.push_back(rope_cos);
+  list.push_back(rope_sin);
+  list.push_back(attention_mask);
+  if (has_runtime_bmm) {
+    list.push_back(runtime_param);
+    list.push_back(runtime_param_full);
+    list.push_back(cache_position_vt);
+  }
+  for (size_t i = 0; i < key_caches.size(); ++i) {
+    list.push_back(key_caches[i]);
+    list.push_back(value_caches[i]);
+  }
+  return list;
+}
+
+std::vector<TfTensor> TalkerOutputs::AsList() const {
+  std::vector<TfTensor> list;
+  list.push_back(codec_frame);
+  list.push_back(cb0_logits);
+  list.push_back(frame_feedback_emb);
+  for (size_t i = 0; i < key_caches.size(); ++i) {
+    list.push_back(key_caches[i]);
+    list.push_back(value_caches[i]);
+  }
+  return list;
+}
+
+TalkerInputs MakeTalkerInputs(const TalkerConfig& config, bool is_decode) {
+  TalkerInputs inputs;
+  int seq = is_decode ? 1 : config.prefill_len;
+
+  if (is_decode) {
+    inputs.feedback_emb = TfTensor({.name = "feedback_emb",
+                                    .type = Type::kFP32,
+                                    .shape = {1, 1, config.emb_dim}});
+    inputs.text_track_emb = TfTensor({.name = "text_track_emb",
+                                      .type = Type::kFP32,
+                                      .shape = {1, 1, config.emb_dim}});
+  } else {
+    inputs.embedded_input =
+        TfTensor({.name = "embedded_input",
+                  .type = Type::kFP32,
+                  .shape = {1, seq, config.emb_dim}});
+  }
+  inputs.cb0_bias = TfTensor({.name = "cb0_bias",
+                              .type = Type::kFP32,
+                              .shape = {1, config.talker_vocab}});
+  inputs.cache_position =
+      TfTensor({.name = "cache_position", .type = Type::kI32, .shape = {4}});
+  inputs.rope_cos = TfTensor({.name = "rope_cos",
+                              .type = Type::kFP32,
+                              .shape = {1, 1, seq, config.head_dim}});
+  inputs.rope_sin = TfTensor({.name = "rope_sin",
+                              .type = Type::kFP32,
+                              .shape = {1, 1, seq, config.head_dim}});
+  inputs.attention_mask = TfTensor({.name = "attention_mask",
+                                    .type = Type::kFP32,
+                                    .shape = {1, 1, seq, config.max_seq}});
+  if (config.use_runtime_bmm) {
+    inputs.has_runtime_bmm = true;
+    inputs.runtime_param = TfTensor({.name = "runtime_param",
+                                     .type = Type::kI32,
+                                     .shape = {1, 1, 1, 7}});
+    inputs.runtime_param_full = TfTensor({.name = "runtime_param_full",
+                                          .type = Type::kI32,
+                                          .shape = {1, 1, 1, 7}});
+    inputs.cache_position_vt = TfTensor(
+        {.name = "cache_position_vt", .type = Type::kI32, .shape = {4}});
+  }
+  inputs.key_caches.reserve(config.n_layers);
+  inputs.value_caches.reserve(config.n_layers);
+  for (int i = 0; i < config.n_layers; ++i) {
+    inputs.key_caches.push_back(TfTensor(
+        {.name = absl::StrCat("key_cache_", i),
+         .type = Type::kFP32,
+         .shape = {1, config.n_kv_groups, config.max_seq, config.head_dim}}));
+    std::vector<int> v_shape =
+        config.use_runtime_bmm
+            ? std::vector<int>{1, config.n_kv_groups, config.head_dim,
+                               config.max_seq}
+            : std::vector<int>{1, config.n_kv_groups, config.max_seq,
+                               config.head_dim};
+    inputs.value_caches.push_back(TfTensor({.name = absl::StrCat(
+                                                "value_cache_", i),
+                                            .type = Type::kFP32,
+                                            .shape = v_shape}));
+  }
+  return inputs;
+}
+
+std::vector<WeightSpec> GetWeightSpecs(const TalkerConfig& config) {
+  std::vector<WeightSpec> specs;
+  auto add = [&](const std::string& name, const std::vector<int>& shape,
+                 float scale = 0.02f) {
+    specs.push_back({name, shape, scale});
+  };
+  auto add_backbone = [&](const std::string& base, int n_layers) {
+    for (int i = 0; i < n_layers; ++i) {
+      std::string p = absl::StrCat(base, ".layers.", i);
+      add(p + ".input_layernorm.weight", {config.emb_dim}, 1.0f);
+      add(p + ".self_attn.q_proj.weight", {config.qkv_out_dim(), config.emb_dim});
+      add(p + ".self_attn.k_proj.weight", {config.kv_out_dim(), config.emb_dim});
+      add(p + ".self_attn.v_proj.weight", {config.kv_out_dim(), config.emb_dim});
+      add(p + ".self_attn.o_proj.weight", {config.emb_dim, config.qkv_out_dim()});
+      add(p + ".self_attn.q_norm.weight", {config.head_dim}, 1.0f);
+      add(p + ".self_attn.k_norm.weight", {config.head_dim}, 1.0f);
+      add(p + ".post_attention_layernorm.weight", {config.emb_dim}, 1.0f);
+      add(p + ".mlp.gate_proj.weight", {config.hidden_dim, config.emb_dim});
+      add(p + ".mlp.up_proj.weight", {config.hidden_dim, config.emb_dim});
+      add(p + ".mlp.down_proj.weight", {config.emb_dim, config.hidden_dim});
+    }
+    add(base + ".norm.weight", {config.emb_dim}, 1.0f);
+  };
+
+  // Talker backbone + heads (real checkpoint names/shapes).
+  add_backbone("talker.model", config.n_layers);
+  add("talker.model.codec_embedding.weight",
+      {config.talker_vocab, config.emb_dim});
+  add("talker.codec_head.weight", {config.talker_vocab, config.emb_dim});
+
+  // Code predictor: shared 5-layer backbone + per-group embeddings and heads.
+  add_backbone("talker.code_predictor.model", config.cp_layers);
+  for (int g = 0; g < config.num_sub_groups(); ++g) {
+    add(absl::StrCat("talker.code_predictor.model.codec_embedding.", g,
+                     ".weight"),
+        {config.codec_vocab, config.emb_dim});
+    add(absl::StrCat("talker.code_predictor.lm_head.", g, ".weight"),
+        {config.codec_vocab, config.emb_dim});
+  }
+  return specs;
+}
+
+WeightMap MakeSyntheticWeights(const TalkerConfig& config, unsigned seed) {
+  WeightMap weights;
+  unsigned state = seed;
+  for (const WeightSpec& spec : GetWeightSpecs(config)) {
+    weights[spec.name] =
+        SyntheticWeight(spec.name, spec.shape, state, spec.init_scale);
+  }
+  return weights;
+}
+
+TalkerOutputs BuildTalkerStep(const TalkerConfig& config,
+                              const TalkerInputs& inputs,
+                              const WeightMap& weights, bool is_decode) {
+  g_rms_norm_composite = config.use_rms_norm_composite;
+  const TfTensor& codec_table =
+      GetWeight(weights, "talker.model.codec_embedding.weight");
+
+  // --- Talker input ---
+  TfTensor hidden;
+  if (is_decode) {
+    // Dual-track aggregation in-graph: prev-frame feedback + text-track row.
+    hidden = Add(inputs.feedback_emb, inputs.text_track_emb);
+  } else {
+    hidden = inputs.embedded_input;
+  }
+
+  // --- Talker backbone ---
+  TalkerOutputs outputs;
+  outputs.key_caches.reserve(config.n_layers);
+  outputs.value_caches.reserve(config.n_layers);
+  for (int i = 0; i < config.n_layers; ++i) {
+    std::string p = absl::StrCat("talker.model.layers.", i);
+    TfTensor attn_in = RmsNorm(
+        hidden, GetWeight(weights, p + ".input_layernorm.weight"),
+        config.rms_norm_eps);
+    AttentionResult attn = TalkerAttention(config, attn_in, p + ".self_attn",
+                                           inputs, i, weights);
+    hidden = Add(hidden, attn.output);
+    outputs.key_caches.push_back(attn.key_cache);
+    outputs.value_caches.push_back(attn.value_cache);
+
+    TfTensor ffn_in = RmsNorm(
+        hidden, GetWeight(weights, p + ".post_attention_layernorm.weight"),
+        config.rms_norm_eps);
+    hidden = Add(hidden, FeedForward(ffn_in, p + ".mlp", weights));
+  }
+  hidden = RmsNorm(hidden, GetWeight(weights, "talker.model.norm.weight"),
+                   config.rms_norm_eps);
+  if (!is_decode) {
+    hidden = Slice(hidden, {0, config.prefill_len - 1, 0},
+                   {1, 1, config.emb_dim});
+  }
+  // `hidden` is the talker's last hidden state [1, 1, emb].
+
+  // --- cb0: talker codec head + host bias (suppression / penalties) ---
+  TfTensor cb0_logits =
+      FullyConnected(hidden, GetWeight(weights, "talker.codec_head.weight"));
+  outputs.cb0_logits = cb0_logits;
+  outputs.cb0_logits.SetName("cb0_logits");
+  TfTensor cb0_biased = Add(cb0_logits, Reshape(inputs.cb0_bias,
+                                                {1, 1, config.talker_vocab}));
+  TfTensor cb0 = ArgMax(cb0_biased, -1, Type::kI32);  // [1, 1]
+  TfTensor cb0_emb = GatherRow(codec_table, cb0, config.emb_dim);
+
+  // --- Code predictor, KV-cached incremental unroll (16 steps) ---
+  // Mirrors the production folded MTP: step 0 consumes the talker hidden,
+  // step 1 the cb0 embed; step t>=1 emits code t-1 via lm_head[t-1] and
+  // feeds its per-group embedding into step t+1.
+  std::vector<TfTensor> frame_ids;
+  frame_ids.reserve(config.num_code_groups);
+  frame_ids.push_back(cb0);
+
+  CpCacheState cp_state;
+  TfTensor cp_in = hidden;
+  TfTensor feedback_sum = cb0_emb;
+  for (int t = 0; t < config.num_code_groups; ++t) {
+    TfTensor cp_hidden = CpStep(config, cp_in, t, cp_state, weights);
+    if (t == 0) {
+      cp_in = cb0_emb;
+      continue;
+    }
+    int g = t - 1;
+    TfTensor logits = FullyConnected(
+        cp_hidden,
+        GetWeight(weights,
+                  absl::StrCat("talker.code_predictor.lm_head.", g, ".weight")));
+    TfTensor id = ArgMax(logits, -1, Type::kI32);  // [1, 1]
+    frame_ids.push_back(id);
+    TfTensor emb = GatherRow(
+        GetWeight(weights,
+                  absl::StrCat("talker.code_predictor.model.codec_embedding.",
+                               g, ".weight")),
+        id, config.emb_dim);
+    feedback_sum = Add(feedback_sum, emb);
+    if (t + 1 < config.num_code_groups) cp_in = emb;
+  }
+
+  outputs.codec_frame =
+      Concatenation(absl::MakeSpan(frame_ids), /*axis=*/1);  // [1, 16] kI32
+  outputs.codec_frame.SetName("codec_frame");
+  outputs.frame_feedback_emb = feedback_sum;
+  outputs.frame_feedback_emb.SetName("frame_feedback_emb");
+  return outputs;
+}
+
+}  // namespace litert::tensor::examples::talker

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.h
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.h
@@ -1,0 +1,135 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Talker step-graph — Stage 2 (structure aligned with the real
+// Qwen/Qwen3-TTS-12Hz-0.6B-Base checkpoint; synthetic weights until the
+// safetensors loader is wired).
+//
+// One decode signature = one full 12Hz frame, all in-graph:
+//   talker backbone (28L, fixed-size KV cache via DynamicUpdateSlice at a
+//   runtime position) -> cb0 logits (+ host-provided additive bias for
+//   suppression/penalties) -> greedy cb0 -> the 5-layer code predictor
+//   unrolled in-graph as a KV-CACHED 16-step incremental pass (per-layer
+//   growing Concatenation caches, one token per step — the in-graph form of
+//   the production folded MTP) -> frame codes [1,16] -> next-frame feedback
+//   embedding (codec_emb[cb0] + sum of sub embeds) emitted as an output for
+//   rebinding into the next call.
+//
+// vs the existing production-style pipeline (hostloop_e2e): talker step and
+// folded-MTP are separate graphs and the dual-track frame aggregation
+// (codec_emb[cb0] + sum mtp_emb + text track) happens on the host with numpy
+// tables. Here talker + predictor + aggregation are ONE signature call; the
+// host only supplies the text-track row, the cb0 bias vector, rope rows, and
+// the cache position.
+//
+// The sequencing loop itself stays host/Engine-side (.tflite has no control
+// flow); no Custom() anywhere. Greedy decode in-graph; sampling would take a
+// host noise input (no RNG op — known API feedback item).
+
+#ifndef SPEECHLM_STAGE1_TALKER_STEP_TALKER_GRAPH_H_
+#define SPEECHLM_STAGE1_TALKER_STEP_TALKER_GRAPH_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "tensor/backends/tflite/arithmetic_tflite.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::talker {
+
+using TfTensor = ::litert::tensor::Tensor<::litert::tensor::TfLiteMixinTag>;
+using WeightMap = absl::flat_hash_map<std::string, TfTensor>;
+
+struct TalkerInputs {
+  // prefill: [1, prefill_len, emb_dim] kFP32 — precomputed dual-track prompt
+  // embeddings (text embedding + projection stay host-side in this stage).
+  TfTensor embedded_input;
+  // decode: [1, 1, emb_dim] kFP32 — previous frame's feedback embedding
+  // (rebound from the previous call's frame_feedback_emb output).
+  TfTensor feedback_emb;
+  // decode: [1, 1, emb_dim] kFP32 — text-track row (trailing text embed or
+  // tts_pad), host-provided per step.
+  TfTensor text_track_emb;
+  // [1, talker_vocab] kFP32 additive bias on cb0 logits — host encodes
+  // suppression of non-codec ids, EOS gating and repetition penalties here.
+  TfTensor cb0_bias;
+  // [4] kI32 {0, 0, position, 0} — runtime KV write position.
+  TfTensor cache_position;
+  // [1, 1, seq, head_dim] kFP32 each.
+  TfTensor rope_cos;
+  TfTensor rope_sin;
+  // decode: [1, 1, 1, max_seq]; prefill: [1, 1, prefill_len, max_seq].
+  TfTensor attention_mask;
+  // Per layer: [1, n_kv_groups, max_seq, head_dim] kFP32. With
+  // use_runtime_bmm the VALUE caches are stored transposed,
+  // [1, n_kv_groups, head_dim, max_seq], so valid positions sit on channels
+  // for the src-bounded scores x V composite.
+  std::vector<TfTensor> key_caches;
+  std::vector<TfTensor> value_caches;
+  // use_runtime_bmm only: odml.runtime_bmm control tensors, int32 [1,1,1,7]
+  // with element 2 = active token count (runtime_param) / max_seq
+  // (runtime_param_full, keeps the QK side unbounded), plus the value-cache
+  // write position as [4] {0,0,0,position} (cache_position_vt).
+  TfTensor runtime_param;
+  TfTensor runtime_param_full;
+  TfTensor cache_position_vt;
+  bool has_runtime_bmm = false;
+
+  std::vector<TfTensor> AsList(bool is_decode) const;
+};
+
+struct TalkerOutputs {
+  // [1, num_code_groups] kI32 — cb0 + 15 sub codes for this frame.
+  TfTensor codec_frame;
+  // [1, 1, talker_vocab] kFP32 — cb0 logits BEFORE the host bias (the
+  // in-graph greedy pick uses the biased ones). For host-side sampling and
+  // the numerical equivalence check.
+  TfTensor cb0_logits;
+  // [1, 1, emb_dim] kFP32 — codec_emb[cb0] + sum(sub embeds); feed back as
+  // feedback_emb next call (text track is added in-graph there).
+  TfTensor frame_feedback_emb;
+  // Updated fixed-size caches, same shapes as inputs.
+  std::vector<TfTensor> key_caches;
+  std::vector<TfTensor> value_caches;
+
+  std::vector<TfTensor> AsList() const;
+};
+
+TalkerInputs MakeTalkerInputs(const TalkerConfig& config, bool is_decode);
+
+// Every weight tensor the step graphs consume, under the REAL checkpoint
+// names (talker.model.layers.N..., talker.codec_head.weight,
+// talker.code_predictor.model.layers.N..., talker.code_predictor.lm_head.N...)
+// with the expected shape. Single source of truth for both the synthetic
+// generator and the safetensors loader.
+struct WeightSpec {
+  std::string name;
+  std::vector<int> shape;
+  float init_scale;  // synthetic init only: 1.0 for norms, 0.02 elsewhere
+};
+std::vector<WeightSpec> GetWeightSpecs(const TalkerConfig& config);
+
+// Synthetic weights for all GetWeightSpecs entries (safetensors swap is a
+// pure loader change).
+WeightMap MakeSyntheticWeights(const TalkerConfig& config, unsigned seed);
+
+TalkerOutputs BuildTalkerStep(const TalkerConfig& config,
+                              const TalkerInputs& inputs,
+                              const WeightMap& weights, bool is_decode);
+
+}  // namespace litert::tensor::examples::talker
+
+#endif  // SPEECHLM_STAGE1_TALKER_STEP_TALKER_GRAPH_H_

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/talker_main.cc
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/talker_main.cc
@@ -1,0 +1,700 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Talker step-graph — Stage 2 host reference loop.
+//
+// One decode signature call = one full 12Hz frame (talker + in-graph greedy
+// cb0 + unrolled 5-layer code predictor for the 15 sub-groups + next-frame
+// feedback embedding). Per step the host only stages: the rebound
+// frame_feedback_emb output, a text-track row, the cb0 bias vector, rope rows
+// and the cache position — vs the production host loop which runs talker and
+// folded-MTP as separate graphs and aggregates frame embeddings with numpy.
+//
+// Usage (from the litert-samples repository root):
+//   bazel build //models/qwen/qwen3_tts/tensor_api/talker_step:talker_main
+//   talker_main --layers=28 --weights=.../model.safetensors \
+//     --accelerator=gpu --gpu_buffer_storage=buffer
+//
+// NOTES: greedy decode; suppression via the cb0_bias input (specials masked,
+// EOS ignored in the benchmark loop). --weights loads the real bf16
+// checkpoint; without it, synthetic weights under the real tensor names.
+// On Metal use --gpu_buffer_storage=buffer for max_seq >= 1024 (texture
+// storage silently falls back to CPU) and --gpu_precision=fp32 for
+// CPU/numpy-parity verification (fp16 drift flips greedy codec ids).
+// Equivalence check: verify/numpy_talker_ref.py
+// (gen -> run with --prefill_emb_file/--dump_dir -> check).
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "tensor/backends/tflite/tflite_flatbuffer_conversion.h"
+#include "tensor/datatypes.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_weights.h"
+#include "tensor/runners/litert/litert_dynamic_runner.h"
+#include "tensor/tensor.h"
+
+ABSL_FLAG(int, layers, 4, "Talker layers (28 = full 0.6B shape)");
+ABSL_FLAG(int, steps, 48, "Decode steps (frames) to run");
+ABSL_FLAG(int, warmup, 3, "Warmup decode steps excluded from stats");
+ABSL_FLAG(int, max_seq, 256, "Fixed KV cache length");
+ABSL_FLAG(int, prefill_len, 64, "Static prefill length");
+ABSL_FLAG(std::string, accelerator, "cpu", "cpu|gpu");
+ABSL_FLAG(std::string, norms, "raw",
+          "raw|composite - emit RMS norms as raw ops or as the "
+          "odml.rms_norm composite (fused ML Drift kernels)");
+ABSL_FLAG(std::string, attention, "raw",
+          "raw|rbmm — backbone attention as raw ops or as the "
+          "odml.runtime_bmm composite pair (avbound composition; value "
+          "caches stored transposed, runtime control tensors added)");
+ABSL_FLAG(std::string, gpu_precision, "fp16",
+          "fp16|fp32 — GPU calculation precision (fp16 is the delegate "
+          "default; fp32 for CPU-parity verification runs)");
+ABSL_FLAG(std::string, gpu_buffer_storage, "default",
+          "default|buffer|texture2d — GPU tensor storage (texture2d hits "
+          "Metal texture size limits for long KV caches)");
+ABSL_FLAG(std::string, gpu_serialization_dir, "",
+          "If set, enable GPU program-cache serialization into this dir "
+          "(pairs with --gpu_cache_key; cuts repeat kernel-compile cost)");
+ABSL_FLAG(std::string, gpu_cache_key, "talker_step",
+          "Model cache key identifying this graph inside "
+          "--gpu_serialization_dir");
+ABSL_FLAG(int, gpu_compile_threads, 0,
+          ">0: threads for GPU kernel compilation (delegate default "
+          "otherwise)");
+ABSL_FLAG(bool, gpu_no_shader_opt, false,
+          "Disable GPU shader optimization to trade run speed for compile "
+          "time");
+ABSL_FLAG(bool, copy_rebind, false,
+          "Rebind KV caches by copying bytes into fresh input buffers "
+          "(emulates a naive host loop) instead of zero-copy handle "
+          "duplication; for measuring the rebind tax");
+ABSL_FLAG(std::string, tflite_path, "/tmp/talker_step.tflite",
+          "Where to write the serialized model");
+ABSL_FLAG(std::string, weights, "",
+          "model.safetensors path (empty = synthetic weights). Requires "
+          "--layers=28 unless testing a truncated stack.");
+ABSL_FLAG(std::string, weight_quant, "none",
+          "none|int8|int4 — per-channel symmetric quantization of the 2-D "
+          "matmul weights at load time (requires --weights)");
+ABSL_FLAG(std::string, prequant_weights, "",
+          "Companion safetensors with pre-quantized int4 matmul weights "
+          "(<name> I8 + <name>.scale F32, e.g. gptq_quantize.py output); "
+          "overrides --weight_quant for those weights (requires --weights)");
+ABSL_FLAG(std::string, prefill_emb_file, "",
+          "Raw fp32 file [prefill_len, 1024] for the prefill dual-track "
+          "embeddings (empty = synthetic)");
+ABSL_FLAG(std::string, text_track_file, "",
+          "Raw fp32 file [steps, 1024] of per-step text-track rows (empty = "
+          "constant 0.01 row)");
+ABSL_FLAG(double, sample_temp, 0.0,
+          "cb0 temperature sampling via Gumbel noise staged in the cb0_bias "
+          "input: argmax(logits + bias + T*g) == sample from "
+          "softmax((logits+bias)/T). 0 = greedy. No graph change involved.");
+ABSL_FLAG(int, sample_seed, 1, "RNG seed for --sample_temp");
+ABSL_FLAG(int, eos_id, -1,
+          "cb0 EOS id (2150 for Qwen3-TTS). >= 0: EOS is unmasked in cb0_bias "
+          "after min_new_tokens=2 frames (production semantics) and the loop "
+          "stops when cb0 == eos_id; the EOS frame is not counted or dumped. "
+          "-1 = benchmark mode (all specials suppressed, fixed steps)");
+ABSL_FLAG(std::string, dump_dir, "",
+          "If set, write frames.i32 ((1+steps) x 16), cb0_logits.f32 "
+          "((1+steps) x talker_vocab) and feedback.f32 ((1+steps) x emb_dim) "
+          "for the equivalence check");
+
+namespace {
+
+using ::litert::tensor::Create;
+using ::litert::tensor::LitertDynamicRunner;
+using ::litert::tensor::ModelFactory;
+using ::litert::tensor::Type;
+namespace talker = ::litert::tensor::examples::talker;
+
+constexpr float kMaskFloor = -30000.0f;  // fp16-safe
+
+void BuildRopeCosSin(int pos, int seq, int head_dim, float base,
+                     std::vector<float>& cos_out, std::vector<float>& sin_out) {
+  cos_out.resize(static_cast<size_t>(seq) * head_dim);
+  sin_out.resize(static_cast<size_t>(seq) * head_dim);
+  int half = head_dim / 2;
+  for (int s = 0; s < seq; ++s) {
+    for (int i = 0; i < half; ++i) {
+      float freq = std::pow(base, -2.0f * static_cast<float>(i) / head_dim);
+      float angle = static_cast<float>(pos + s) * freq;
+      cos_out[s * head_dim + i] = std::cos(angle);
+      cos_out[s * head_dim + half + i] = std::cos(angle);
+      sin_out[s * head_dim + i] = std::sin(angle);
+      sin_out[s * head_dim + half + i] = std::sin(angle);
+    }
+  }
+}
+
+std::vector<float> BuildMask(int seq_q, int valid_len, int max_seq) {
+  std::vector<float> mask(static_cast<size_t>(seq_q) * max_seq, kMaskFloor);
+  for (int s = 0; s < seq_q; ++s) {
+    int limit = std::min(valid_len + s + 1, max_seq);
+    for (int j = 0; j < limit; ++j) mask[s * max_seq + j] = 0.0f;
+  }
+  return mask;
+}
+
+// Suppress non-codec ids so greedy cb0 stays in [0, codec_vocab) during the
+// synthetic run (real loop: host also folds EOS gating + repetition
+// penalties into this vector).
+std::vector<float> BuildCb0Bias(const talker::TalkerConfig& config) {
+  std::vector<float> bias(config.talker_vocab, 0.0f);
+  for (int i = config.codec_vocab; i < config.talker_vocab; ++i)
+    bias[i] = kMaskFloor;
+  return bias;
+}
+
+absl::Status RunTalker() {
+  talker::TalkerConfig config;
+  config.n_layers = absl::GetFlag(FLAGS_layers);
+  config.max_seq = absl::GetFlag(FLAGS_max_seq);
+  config.prefill_len = absl::GetFlag(FLAGS_prefill_len);
+  const std::string attention = absl::GetFlag(FLAGS_attention);
+  if (attention != "raw" && attention != "rbmm") {
+    return absl::InvalidArgumentError("--attention must be raw|rbmm");
+  }
+  config.use_runtime_bmm = attention == "rbmm";
+  const std::string norms = absl::GetFlag(FLAGS_norms);
+  if (norms != "raw" && norms != "composite") {
+    return absl::InvalidArgumentError("--norms must be raw|composite");
+  }
+  config.use_rms_norm_composite = norms == "composite";
+  if (config.use_rms_norm_composite) {
+    std::cout << "norms: odml.rms_norm composite" << std::endl;
+  }
+  if (config.use_runtime_bmm) {
+    std::cout << "attention: odml.runtime_bmm (avbound)" << std::endl;
+  }
+  const int steps = absl::GetFlag(FLAGS_steps);
+  const int warmup = absl::GetFlag(FLAGS_warmup);
+  const std::string tflite_path = absl::GetFlag(FLAGS_tflite_path);
+
+  talker::WeightMap weights;
+  const std::string weights_path = absl::GetFlag(FLAGS_weights);
+  if (weights_path.empty()) {
+    weights = talker::MakeSyntheticWeights(config, /*seed=*/42);
+    std::cout << "weights: synthetic (seed 42)" << std::endl;
+  } else {
+    const std::string quant = absl::GetFlag(FLAGS_weight_quant);
+    talker::WeightQuantMode quant_mode;
+    if (quant == "none") {
+      quant_mode = talker::WeightQuantMode::kNone;
+    } else if (quant == "int8") {
+      quant_mode = talker::WeightQuantMode::kInt8;
+    } else if (quant == "int4") {
+      quant_mode = talker::WeightQuantMode::kInt4;
+    } else {
+      return absl::InvalidArgumentError("--weight_quant must be none|int8|int4");
+    }
+    const std::string prequant = absl::GetFlag(FLAGS_prequant_weights);
+    auto weights_or = talker::LoadCheckpointWeights(config, weights_path,
+                                                    quant_mode, prequant);
+    if (!weights_or.ok()) return weights_or.status();
+    weights = std::move(*weights_or);
+    std::cout << "weights: " << weights_path << " (" << weights.size()
+              << " tensors, bf16->fp32, quant=" << quant;
+    if (!prequant.empty()) std::cout << ", prequant=" << prequant;
+    std::cout << ")" << std::endl;
+  }
+
+  talker::TalkerInputs prefill_in = talker::MakeTalkerInputs(config, false);
+  talker::TalkerOutputs prefill_out =
+      talker::BuildTalkerStep(config, prefill_in, weights, false);
+
+  talker::TalkerInputs decode_in = talker::MakeTalkerInputs(config, true);
+  talker::TalkerOutputs decode_out =
+      talker::BuildTalkerStep(config, decode_in, weights, true);
+
+  ModelFactory factory;
+  {
+    std::vector<::litert::tensor::TensorHandle> ins, outs;
+    for (auto& t : prefill_in.AsList(false)) ins.push_back(t);
+    for (auto& t : prefill_out.AsList()) outs.push_back(t);
+    auto status = factory.AddSignature(ins, outs, "prefill");
+    if (!status.ok()) return status;
+  }
+  {
+    std::vector<::litert::tensor::TensorHandle> ins, outs;
+    for (auto& t : decode_in.AsList(true)) ins.push_back(t);
+    for (auto& t : decode_out.AsList()) outs.push_back(t);
+    auto status = factory.AddSignature(ins, outs, "decode");
+    if (!status.ok()) return status;
+  }
+  auto save_status = factory.Save(tflite_path);
+  if (!save_status.ok()) return save_status;
+  std::cout << "Serialized: " << tflite_path << std::endl;
+
+  auto env = ::litert::Environment::Create({});
+  if (!env) return absl::InternalError("Environment::Create failed");
+  auto options = ::litert::Options::Create();
+  if (!options) return absl::InternalError("Options::Create failed");
+  const bool use_gpu = absl::GetFlag(FLAGS_accelerator) == "gpu";
+  options->SetHardwareAccelerators(use_gpu ? ::litert::HwAccelerators::kGpu
+                                           : ::litert::HwAccelerators::kCpu);
+  if (use_gpu) {
+    auto gpu_options = options->GetGpuOptions();
+    if (gpu_options.HasValue()) {
+      const std::string precision = absl::GetFlag(FLAGS_gpu_precision);
+      if (precision == "fp32") {
+        gpu_options->SetPrecision(::litert::GpuOptions::Precision::kFp32);
+      } else if (precision != "fp16") {
+        return absl::InvalidArgumentError("--gpu_precision must be fp16|fp32");
+      }
+      const std::string storage = absl::GetFlag(FLAGS_gpu_buffer_storage);
+      if (storage == "buffer") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kBuffer);
+      } else if (storage == "texture2d") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kTexture2D);
+      } else if (storage != "default") {
+        return absl::InvalidArgumentError(
+            "--gpu_buffer_storage must be default|buffer|texture2d");
+      }
+      std::cout << "gpu precision: " << precision << ", storage: " << storage
+                << std::endl;
+      const std::string ser_dir = absl::GetFlag(FLAGS_gpu_serialization_dir);
+      if (!ser_dir.empty()) {
+        const std::string cache_key = absl::GetFlag(FLAGS_gpu_cache_key);
+        gpu_options->SetSerializationDir(ser_dir.c_str());
+        gpu_options->SetModelCacheKey(cache_key.c_str());
+        gpu_options->SetSerializeProgramCache(true);
+        std::cout << "gpu serialization: dir=" << ser_dir
+                  << " key=" << cache_key << std::endl;
+      }
+      const int compile_threads = absl::GetFlag(FLAGS_gpu_compile_threads);
+      if (compile_threads > 0) {
+        gpu_options->SetNumThreadsToCompile(compile_threads);
+        std::cout << "gpu compile threads: " << compile_threads << std::endl;
+      }
+      if (absl::GetFlag(FLAGS_gpu_no_shader_opt)) {
+        gpu_options->DisableShaderOptimization(true);
+        std::cout << "gpu shader optimization: disabled" << std::endl;
+      }
+    }
+  }
+  auto runner_or = LitertDynamicRunner::Create(*env, tflite_path, *options);
+  if (!runner_or.ok()) return runner_or.status();
+  auto runner = std::move(*runner_or);
+
+  const int C = config.num_code_groups;
+  const int hd = config.head_dim;
+  const int eos_id = absl::GetFlag(FLAGS_eos_id);
+  if (eos_id >= config.talker_vocab) {
+    return absl::InvalidArgumentError("--eos_id out of talker vocab range");
+  }
+  std::vector<float> cos_v, sin_v;
+  // EOS stays masked for the prefill frame and the first decode frame
+  // (min_new_tokens=2), then set_common picks up the unmasked entry.
+  std::vector<float> cb0_bias = BuildCb0Bias(config);
+  // Per-call bias actually sent to the graph: base bias, plus T-scaled
+  // Gumbel noise when sampling (argmax(l + T*g) samples softmax(l/T);
+  // masked entries stay ~kMaskFloor).
+  const double sample_temp = absl::GetFlag(FLAGS_sample_temp);
+  std::mt19937 sample_rng(absl::GetFlag(FLAGS_sample_seed));
+  std::uniform_real_distribution<float> sample_unif(1e-12f, 1.0f);
+  std::vector<float> cb0_bias_call;
+  auto stage_bias = [&]() {
+    cb0_bias_call = cb0_bias;
+    if (sample_temp > 0.0) {
+      for (float& b : cb0_bias_call) {
+        b += static_cast<float>(
+            sample_temp * -std::log(-std::log(sample_unif(sample_rng))));
+      }
+    }
+  };
+
+  auto set_common = [&](const std::string& sig, int pos, int seq,
+                        int valid_len) -> absl::Status {
+    auto st = runner.SetInput(sig, "cb0_bias",
+                              Create("cb0_bias", Type::kFP32,
+                                     {1, config.talker_vocab},
+                                     std::vector<float>(cb0_bias_call)));
+    if (!st.ok()) return st;
+    st = runner.SetInput(sig, "cache_position",
+                         Create("cache_position", Type::kI32, {4},
+                                std::vector<int32_t>{0, 0, pos, 0}));
+    if (!st.ok()) return st;
+    if (config.use_runtime_bmm) {
+      // AV-side active length must cover every position any query row can
+      // attend: BuildMask lets row s reach valid_len + s + 1 positions, so
+      // the max over rows is valid_len + seq (prefill: 0 + 64; decode:
+      // pos + 1).
+      const int active = std::min(valid_len + seq, config.max_seq);
+      st = runner.SetInput(sig, "runtime_param",
+                           Create("runtime_param", Type::kI32, {1, 1, 1, 7},
+                                  std::vector<int32_t>(7, active)));
+      if (!st.ok()) return st;
+      st = runner.SetInput(
+          sig, "runtime_param_full",
+          Create("runtime_param_full", Type::kI32, {1, 1, 1, 7},
+                 std::vector<int32_t>(7, config.max_seq)));
+      if (!st.ok()) return st;
+      st = runner.SetInput(sig, "cache_position_vt",
+                           Create("cache_position_vt", Type::kI32, {4},
+                                  std::vector<int32_t>{0, 0, 0, pos}));
+      if (!st.ok()) return st;
+    }
+    BuildRopeCosSin(pos, seq, hd, config.rope_base, cos_v, sin_v);
+    st = runner.SetInput(sig, "rope_cos",
+                         Create("rope_cos", Type::kFP32, {1, 1, seq, hd},
+                                std::vector<float>(cos_v)));
+    if (!st.ok()) return st;
+    st = runner.SetInput(sig, "rope_sin",
+                         Create("rope_sin", Type::kFP32, {1, 1, seq, hd},
+                                std::vector<float>(sin_v)));
+    if (!st.ok()) return st;
+    return runner.SetInput(sig, "attention_mask",
+                           Create("attention_mask", Type::kFP32,
+                                  {1, 1, seq, config.max_seq},
+                                  BuildMask(seq, valid_len, config.max_seq)));
+  };
+
+  // --- Prefill: dual-track prompt embeddings (file or synthetic) ---
+  {
+    std::vector<float> emb(static_cast<size_t>(config.prefill_len) *
+                           config.emb_dim);
+    const std::string emb_file = absl::GetFlag(FLAGS_prefill_emb_file);
+    if (emb_file.empty()) {
+      unsigned state = 7u;
+      for (auto& v : emb) {
+        state = state * 1664525u + 1013904223u;
+        v = 0.1f * (static_cast<float>(state >> 8) /
+                        static_cast<float>(1u << 24) * 2.0f -
+                    1.0f);
+      }
+    } else {
+      std::ifstream in(emb_file, std::ios::binary);
+      if (!in) return absl::NotFoundError("prefill_emb_file: " + emb_file);
+      in.read(reinterpret_cast<char*>(emb.data()),
+              emb.size() * sizeof(float));
+      if (static_cast<size_t>(in.gcount()) != emb.size() * sizeof(float)) {
+        return absl::InvalidArgumentError(
+            "prefill_emb_file smaller than prefill_len x emb_dim fp32");
+      }
+    }
+    auto st = runner.SetInput(
+        "prefill", "embedded_input",
+        Create("embedded_input", Type::kFP32,
+               {1, config.prefill_len, config.emb_dim}, std::move(emb)));
+    if (!st.ok()) return st;
+    stage_bias();
+    st = set_common("prefill", 0, config.prefill_len, 0);
+    if (!st.ok()) return st;
+    for (int i = 0; i < config.n_layers; ++i) {
+      size_t n = static_cast<size_t>(config.n_kv_groups) * config.max_seq * hd;
+      st = runner.SetInput(
+          "prefill", absl::StrCat("key_cache_", i),
+          Create(absl::StrCat("key_cache_", i).c_str(), Type::kFP32,
+                 {1, config.n_kv_groups, config.max_seq, hd},
+                 std::vector<float>(n, 0.0f)));
+      if (!st.ok()) return st;
+      std::vector<int> v_shape =
+          config.use_runtime_bmm
+              ? std::vector<int>{1, config.n_kv_groups, hd, config.max_seq}
+              : std::vector<int>{1, config.n_kv_groups, config.max_seq, hd};
+      st = runner.SetInput(
+          "prefill", absl::StrCat("value_cache_", i),
+          Create(absl::StrCat("value_cache_", i).c_str(), Type::kFP32,
+                 v_shape, std::vector<float>(n, 0.0f)));
+      if (!st.ok()) return st;
+    }
+    st = runner.Run("prefill");
+    if (!st.ok()) return st;
+  }
+
+  const bool copy_rebind = absl::GetFlag(FLAGS_copy_rebind);
+  std::vector<double> rebind_ms;
+  bool alias_checked = false;
+  bool cache_aliased = false;
+  auto copy_input = [&](const std::string& name,
+                        const ::litert::tensor::TensorHandle& t)
+      -> absl::Status {
+    auto buffer = t.GetBuffer();
+    if (!buffer.ok()) return buffer.status();
+    auto lock = buffer->Lock();
+    return runner.SetInput(
+        "decode", name,
+        absl::Span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(lock.data()), lock.size()));
+  };
+  auto rebind = [&](const std::string& from_sig) -> absl::Status {
+    auto r0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < config.n_layers; ++i) {
+      auto k = runner.GetOutput(from_sig, absl::StrCat("key_cache_", i, "_new"));
+      if (!k.ok()) return k.status();
+      auto v =
+          runner.GetOutput(from_sig, absl::StrCat("value_cache_", i, "_new"));
+      if (!v.ok()) return v.status();
+      absl::Status st;
+      if (copy_rebind) {
+        st = copy_input(absl::StrCat("key_cache_", i), *k);
+        if (!st.ok()) return st;
+        st = copy_input(absl::StrCat("value_cache_", i), *v);
+      } else {
+        st = runner.SetInput("decode", absl::StrCat("key_cache_", i), *k);
+        if (!st.ok()) return st;
+        st = runner.SetInput("decode", absl::StrCat("value_cache_", i), *v);
+      }
+      if (!st.ok()) return st;
+    }
+    auto fb = runner.GetOutput(from_sig, "frame_feedback_emb");
+    if (!fb.ok()) return fb.status();
+    auto st = copy_rebind ? copy_input("feedback_emb", *fb)
+                          : runner.SetInput("decode", "feedback_emb", *fb);
+    if (!st.ok()) return st;
+    rebind_ms.push_back(std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() - r0)
+                            .count());
+    // After the first decode->decode rebind, check whether the cache input
+    // now aliases the cache output buffer (in-place DUS eligibility).
+    if (!alias_checked && from_sig == "decode") {
+      alias_checked = true;
+      const void* p_in = nullptr;
+      const void* p_out = nullptr;
+      auto in_t = runner.GetInput("decode", "key_cache_0");
+      auto out_t = runner.GetOutput("decode", "key_cache_0_new");
+      if (in_t.ok() && out_t.ok()) {
+        {
+          auto b = in_t->GetBuffer();
+          if (b.ok()) {
+            auto lock = b->Lock();
+            p_in = lock.data();
+          }
+        }
+        {
+          auto b = out_t->GetBuffer();
+          if (b.ok()) {
+            auto lock = b->Lock();
+            p_out = lock.data();
+          }
+        }
+      }
+      cache_aliased = p_in != nullptr && p_in == p_out;
+    }
+    return absl::OkStatus();
+  };
+
+  auto read_frame = [&](const std::string& sig,
+                        std::vector<int32_t>& ids) -> absl::Status {
+    auto out = runner.GetOutput(sig, "codec_frame");
+    if (!out.ok()) return out.status();
+    auto buffer = out->GetBuffer();
+    if (!buffer.ok()) return buffer.status();
+    auto lock = buffer->Lock();
+    const int32_t* data = reinterpret_cast<const int32_t*>(lock.data());
+    ids.assign(data, data + C);
+    return absl::OkStatus();
+  };
+
+  const std::string dump_dir = absl::GetFlag(FLAGS_dump_dir);
+  std::vector<int32_t> dump_frames;
+  std::vector<float> dump_logits;
+  std::vector<float> dump_feedback;
+  auto read_floats = [&](const std::string& sig, const std::string& name,
+                         std::vector<float>& sink) -> absl::Status {
+    auto out = runner.GetOutput(sig, name);
+    if (!out.ok()) return out.status();
+    auto buffer = out->GetBuffer();
+    if (!buffer.ok()) return buffer.status();
+    auto lock = buffer->Lock();
+    const float* data = reinterpret_cast<const float*>(lock.data());
+    sink.insert(sink.end(), data, data + lock.size() / sizeof(float));
+    return absl::OkStatus();
+  };
+  auto dump_step = [&](const std::string& sig,
+                       const std::vector<int32_t>& ids) -> absl::Status {
+    if (dump_dir.empty()) return absl::OkStatus();
+    dump_frames.insert(dump_frames.end(), ids.begin(), ids.end());
+    auto st = read_floats(sig, "cb0_logits", dump_logits);
+    if (!st.ok()) return st;
+    return read_floats(sig, "frame_feedback_emb", dump_feedback);
+  };
+
+  std::vector<int32_t> frame(C, 0);
+  auto st = read_frame("prefill", frame);
+  if (!st.ok()) return st;
+  st = dump_step("prefill", frame);
+  if (!st.ok()) return st;
+  st = rebind("prefill");
+  if (!st.ok()) return st;
+
+  // Text track: per-step rows from file, or a constant synthetic row.
+  std::vector<float> text_track;
+  {
+    const std::string track_file = absl::GetFlag(FLAGS_text_track_file);
+    if (track_file.empty()) {
+      text_track.assign(static_cast<size_t>(steps) * config.emb_dim, 0.01f);
+    } else {
+      text_track.resize(static_cast<size_t>(steps) * config.emb_dim);
+      std::ifstream in(track_file, std::ios::binary);
+      if (!in) return absl::NotFoundError("text_track_file: " + track_file);
+      in.read(reinterpret_cast<char*>(text_track.data()),
+              text_track.size() * sizeof(float));
+      if (static_cast<size_t>(in.gcount()) !=
+          text_track.size() * sizeof(float)) {
+        return absl::InvalidArgumentError(
+            "text_track_file smaller than steps x emb_dim fp32");
+      }
+    }
+  }
+
+  std::vector<double> step_ms;
+  step_ms.reserve(steps);
+  bool eos_hit = false;
+  int frames_generated = 1;  // the prefill frame
+  int pos = config.prefill_len;
+  for (int step = 0; step < steps && pos < config.max_seq; ++step, ++pos) {
+    if (eos_id >= 0 && step == 1) cb0_bias[eos_id] = 0.0f;
+    const float* row = text_track.data() +
+                       static_cast<size_t>(step) * config.emb_dim;
+    st = runner.SetInput(
+        "decode", "text_track_emb",
+        Create("text_track_emb", Type::kFP32, {1, 1, config.emb_dim},
+               std::vector<float>(row, row + config.emb_dim)));
+    if (!st.ok()) return st;
+    stage_bias();
+    st = set_common("decode", pos, 1, pos);
+    if (!st.ok()) return st;
+
+    auto t0 = std::chrono::steady_clock::now();
+    st = runner.Run("decode");
+    auto t1 = std::chrono::steady_clock::now();
+    if (!st.ok()) return st;
+
+    if (step >= warmup) {
+      step_ms.push_back(
+          std::chrono::duration<double, std::milli>(t1 - t0).count());
+    }
+    st = read_frame("decode", frame);
+    if (!st.ok()) return st;
+    if (eos_id >= 0 && frame[0] == eos_id) {
+      eos_hit = true;
+      std::cout << "EOS at decode step " << step << "; frames generated: "
+                << frames_generated << std::endl;
+      break;
+    }
+    ++frames_generated;
+    st = dump_step("decode", frame);
+    if (!st.ok()) return st;
+    st = rebind("decode");
+    if (!st.ok()) return st;
+  }
+  if (eos_id >= 0 && !eos_hit) {
+    std::cout << "no EOS within " << steps << " steps; frames generated: "
+              << frames_generated << std::endl;
+  }
+
+  if (step_ms.empty()) return absl::InternalError("no timed steps");
+  std::sort(step_ms.begin(), step_ms.end());
+  double median = step_ms[step_ms.size() / 2];
+  double budget_ms = 1000.0 / config.frame_rate_hz;
+  std::cout << "layers=" << config.n_layers << " max_seq=" << config.max_seq
+            << " code_groups=" << C << " (cp " << config.cp_layers
+            << "L in-graph) accelerator=" << absl::GetFlag(FLAGS_accelerator)
+            << std::endl;
+  std::cout << "decode steps timed: " << step_ms.size() << ", median " << median
+            << " ms/frame (min " << step_ms.front() << ", max "
+            << step_ms.back() << ")" << std::endl;
+  if (!rebind_ms.empty()) {
+    std::sort(rebind_ms.begin(), rebind_ms.end());
+    std::cout << "cache rebind: median "
+              << rebind_ms[rebind_ms.size() / 2] << " ms/frame (max "
+              << rebind_ms.back() << ", mode="
+              << (copy_rebind ? "copy" : "zero-copy")
+              << ", decode in==out alias: "
+              << (cache_aliased ? "YES (in-place DUS eligible)" : "no")
+              << "); rebind is OUTSIDE the timed decode step" << std::endl;
+  }
+  std::cout << "RTF vs " << config.frame_rate_hz << "Hz budget (" << budget_ms
+            << " ms): " << (median / budget_ms)
+            << " (1 signature call per frame: talker + cb0 + 15-group code "
+               "predictor + feedback aggregation in-graph)"
+            << std::endl;
+  std::cout << "last frame ids:";
+  for (int32_t v : frame) std::cout << " " << v;
+  std::cout << std::endl;
+
+  // Numeric sanity on the last feedback embedding (catches fp blowups that
+  // greedy ids can mask).
+  {
+    std::vector<float> fb;
+    auto fst = read_floats("decode", "frame_feedback_emb", fb);
+    if (!fst.ok()) return fst;
+    double sum_sq = 0.0;
+    bool finite = true;
+    for (float v : fb) {
+      if (!std::isfinite(v)) finite = false;
+      sum_sq += static_cast<double>(v) * v;
+    }
+    std::cout << "last feedback emb: L2 " << std::sqrt(sum_sq)
+              << (finite ? " (all finite)" : " (NON-FINITE VALUES!)")
+              << std::endl;
+    if (!finite) return absl::InternalError("non-finite feedback embedding");
+  }
+
+  if (!dump_dir.empty()) {
+    auto write_raw = [&](const std::string& name, const void* data,
+                         size_t bytes) -> absl::Status {
+      std::string p = dump_dir + "/" + name;
+      std::ofstream out(p, std::ios::binary);
+      if (!out) return absl::InternalError("cannot write " + p);
+      out.write(reinterpret_cast<const char*>(data), bytes);
+      return absl::OkStatus();
+    };
+    st = write_raw("frames.i32", dump_frames.data(),
+                   dump_frames.size() * sizeof(int32_t));
+    if (!st.ok()) return st;
+    st = write_raw("cb0_logits.f32", dump_logits.data(),
+                   dump_logits.size() * sizeof(float));
+    if (!st.ok()) return st;
+    st = write_raw("feedback.f32", dump_feedback.data(),
+                   dump_feedback.size() * sizeof(float));
+    if (!st.ok()) return st;
+    std::cout << "dumped " << dump_frames.size() / C << " frames to "
+              << dump_dir << std::endl;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  absl::Status status = RunTalker();
+  if (!status.ok()) {
+    std::cerr << "FAILED: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/talker_weights.cc
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/talker_weights.cc
@@ -1,0 +1,278 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Real-checkpoint weight loading. See talker_weights.h.
+
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_weights.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/strings/match.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/str_join.h"  // from @com_google_absl
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/examples/gemma3/safetensor_loader.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::talker {
+
+namespace {
+
+// Mirrors the loader's is_layernorm predicate (safetensor_loader.cc), which
+// adds the Gemma-style +1.0 these Qwen3 norms must not have.
+bool LoaderAddsGemmaNormOffset(const std::string& name) {
+  return absl::StrContains(name, "layernorm") ||
+         absl::EndsWith(name, "norm.weight");
+}
+
+absl::Status SubtractOne(TfTensor& tensor) {
+  auto buffer = tensor.GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->LockMutable();
+  float* data = reinterpret_cast<float*>(lock.data());
+  size_t count = lock.size() / sizeof(float);
+  for (size_t i = 0; i < count; ++i) data[i] -= 1.0f;
+  return absl::OkStatus();
+}
+
+// 2-D [out, in] matmul weights get quantized; norms and embedding tables
+// (Gather sources) stay fp32.
+bool IsQuantizableFcWeight(const std::string& name) {
+  return absl::StrContains(name, "_proj.weight") ||
+         absl::EndsWith(name, "codec_head.weight") ||
+         absl::StrContains(name, ".lm_head.");
+}
+
+// Symmetric weight quantization. int8: per-channel along dim 0
+// (PerChannelAffineQuantization). int4: BLOCKWISE along the input dim
+// (block kInt4BlockSize, fp16 scales row-major [out, in/block], bit-packed
+// kI4 storage) — per-channel int4 measurably destroys this model (frame-0
+// logits decorrelate to cos~0), matching why production int4 uses
+// calibrated/blockwise schemes.
+constexpr int kInt4BlockSize = 32;
+
+// Bit-packs int4 codes (values in [-7,7], one int8 each) into the TFLite
+// kI4 layout (even index in the low nibble) and attaches blockwise-32
+// quantization. Shared by the in-process RTN path and the pre-quantized
+// (GPTQ) companion-file path.
+TfTensor BuildInt4Tensor(const int8_t* q, std::vector<float> scales,
+                         int out_channels, int in_dim,
+                         const std::string& name) {
+  const size_t count =
+      static_cast<size_t>(out_channels) * static_cast<size_t>(in_dim);
+  std::vector<char> packed((count + 1) / 2, 0);
+  for (size_t i = 0; i < count; ++i) {
+    char nib = static_cast<char>(q[i] & 0xF);
+    packed[i / 2] |= (i % 2 == 0) ? nib : static_cast<char>(nib << 4);
+  }
+  auto q_buffer = OwningCpuBuffer::Copy(packed.data(), packed.size());
+  TfTensor quantized({.name = name,
+                      .type = Type::kI4,
+                      .shape = {out_channels, in_dim},
+                      .buffer = std::move(q_buffer)});
+  quantized.SetQuantization(std::make_shared<BlockwiseQuantization>(
+      std::move(scales), std::vector<int64_t>(), kInt4BlockSize,
+      /*quantized_dimension=*/0));
+  return quantized;
+}
+
+absl::StatusOr<TfTensor> QuantizeFcWeight(const TfTensor& tensor,
+                                          const std::string& name,
+                                          WeightQuantMode mode) {
+  const auto& shape = tensor.GetShape();
+  if (shape.size() != 2) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(name, ": expected 2-D weight for quantization"));
+  }
+  const int out_channels = shape[0];
+  const int in_dim = shape[1];
+  auto buffer = tensor.GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->Lock();
+  const float* w = reinterpret_cast<const float*>(lock.data());
+
+  const bool int4 = mode == WeightQuantMode::kInt4;
+  const float qmax = int4 ? 7.0f : 127.0f;
+  const int block = int4 ? kInt4BlockSize : in_dim;
+  if (in_dim % block != 0) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(name, ": in_dim ", in_dim, " not divisible by block ",
+                     block));
+  }
+  const int blocks_per_row = in_dim / block;
+
+  std::vector<float> scales(static_cast<size_t>(out_channels) *
+                            blocks_per_row);
+  std::vector<int8_t> q(static_cast<size_t>(out_channels) * in_dim);
+  for (int c = 0; c < out_channels; ++c) {
+    const float* row = w + static_cast<size_t>(c) * in_dim;
+    int8_t* q_row = q.data() + static_cast<size_t>(c) * in_dim;
+    for (int b = 0; b < blocks_per_row; ++b) {
+      float amax = 0.0f;
+      for (int i = b * block; i < (b + 1) * block; ++i)
+        amax = std::max(amax, std::fabs(row[i]));
+      float scale = amax > 0.0f ? amax / qmax : 1.0f;
+      if (int4) {
+        // Blockwise scales are serialized as fp16; quantize against the
+        // fp16-rounded value the runtime will actually use.
+        scale = static_cast<float>(fp16_t(scale));
+      }
+      scales[static_cast<size_t>(c) * blocks_per_row + b] = scale;
+      for (int i = b * block; i < (b + 1) * block; ++i) {
+        float v = std::round(row[i] / scale);
+        q_row[i] = static_cast<int8_t>(std::min(qmax, std::max(-qmax, v)));
+      }
+    }
+  }
+
+  if (int4) return BuildInt4Tensor(q.data(), std::move(scales),
+                                   out_channels, in_dim, name);
+
+  auto q_buffer = OwningCpuBuffer::Copy(
+      reinterpret_cast<const char*>(q.data()), q.size());
+  TfTensor quantized({.name = name,
+                      .type = Type::kI8,
+                      .shape = {out_channels, in_dim},
+                      .buffer = std::move(q_buffer)});
+  quantized.SetQuantization(std::make_shared<PerChannelAffineQuantization>(
+      std::move(scales), std::vector<int64_t>(out_channels, 0),
+      /*quantized_dimension=*/0));
+  return quantized;
+}
+
+// Loads one pre-quantized int4 weight from a companion safetensors
+// (gemma3 side-tensor convention: `<name>` I8 [out,in] codes in [-7,7],
+// `<name>.scale` F32 [out, in/block] fp16-rounded blockwise scales) —
+// e.g. the GPTQ output of verify/gptq_quantize.py. Bit-packs into the
+// same kI4 + BlockwiseQuantization layout as the in-process RTN path.
+absl::StatusOr<TfTensor> LoadPrequantInt4Weight(const SafetensorLoader& ploader,
+                                                const std::string& name,
+                                                int out_channels, int in_dim) {
+  if (in_dim % kInt4BlockSize != 0) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(name, ": in_dim not divisible by block"));
+  }
+  const int blocks_per_row = in_dim / kInt4BlockSize;
+
+  auto qinfo_or = ploader.GetTensorInfo(name);
+  if (!qinfo_or.ok()) return qinfo_or.status();
+  const auto& qinfo = *qinfo_or;
+  const size_t q_count =
+      static_cast<size_t>(out_channels) * static_cast<size_t>(in_dim);
+  if (qinfo.dtype != safetensors::kINT8 ||
+      qinfo.data_end - qinfo.data_start != q_count) {
+    return absl::FailedPreconditionError(absl::StrCat(
+        name, ": prequant body must be I8 [", out_channels, ",", in_dim,
+        "]"));
+  }
+
+  auto sinfo_or = ploader.GetTensorInfo(name + ".scale");
+  if (!sinfo_or.ok()) return sinfo_or.status();
+  const auto& sinfo = *sinfo_or;
+  const size_t s_count =
+      static_cast<size_t>(out_channels) * static_cast<size_t>(blocks_per_row);
+  if (sinfo.dtype != safetensors::kFLOAT32 ||
+      sinfo.data_end - sinfo.data_start != s_count * sizeof(float)) {
+    return absl::FailedPreconditionError(absl::StrCat(
+        name, ".scale: must be F32 [", out_channels, ",", blocks_per_row,
+        "]"));
+  }
+
+  const int8_t* q = reinterpret_cast<const int8_t*>(
+      qinfo.storage->data_base + qinfo.data_start);
+  const float* s = reinterpret_cast<const float*>(
+      sinfo.storage->data_base + sinfo.data_start);
+  return BuildInt4Tensor(q, std::vector<float>(s, s + s_count), out_channels,
+                         in_dim, name);
+}
+
+}  // namespace
+
+absl::StatusOr<WeightMap> LoadCheckpointWeights(const TalkerConfig& config,
+                                                const std::string& path,
+                                                WeightQuantMode quant_mode,
+                                                const std::string& prequant_path) {
+  auto loader_or = SafetensorLoader::Load(path);
+  if (!loader_or.ok()) return loader_or.status();
+  auto loader = std::move(*loader_or);
+
+  std::optional<SafetensorLoader> prequant;
+  if (!prequant_path.empty()) {
+    auto ploader_or = SafetensorLoader::Load(prequant_path);
+    if (!ploader_or.ok()) return ploader_or.status();
+    prequant = std::move(*ploader_or);
+  }
+
+  WeightMap weights;
+  for (const WeightSpec& spec : GetWeightSpecs(config)) {
+    if (prequant.has_value() && IsQuantizableFcWeight(spec.name)) {
+      if (spec.shape.size() != 2) {
+        return absl::FailedPreconditionError(
+            absl::StrCat(spec.name, ": prequant weight must be 2-D"));
+      }
+      auto tensor_or = LoadPrequantInt4Weight(*prequant, spec.name,
+                                              spec.shape[0], spec.shape[1]);
+      if (!tensor_or.ok()) return tensor_or.status();
+      weights[spec.name] = std::move(*tensor_or);
+      continue;
+    }
+    auto handle_or = loader.LoadTensor(
+        spec.name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
+    if (!handle_or.ok()) {
+      return absl::NotFoundError(absl::StrCat(
+          "checkpoint missing ", spec.name, ": ",
+          handle_or.status().message()));
+    }
+    TfTensor tensor(*handle_or);
+
+    const auto& loaded_shape = tensor.GetShape();
+    std::vector<int> loaded(loaded_shape.begin(), loaded_shape.end());
+    if (loaded != spec.shape) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          spec.name, ": checkpoint shape [", absl::StrJoin(loaded, ","),
+          "] != expected [", absl::StrJoin(spec.shape, ","), "]"));
+    }
+
+    if (LoaderAddsGemmaNormOffset(spec.name)) {
+      auto status = SubtractOne(tensor);
+      if (!status.ok()) return status;
+    }
+
+    if (quant_mode != WeightQuantMode::kNone &&
+        IsQuantizableFcWeight(spec.name)) {
+      auto quantized_or = QuantizeFcWeight(tensor, spec.name, quant_mode);
+      if (!quantized_or.ok()) return quantized_or.status();
+      weights[spec.name] = std::move(*quantized_or);
+      continue;
+    }
+    tensor.SetName(spec.name);
+    weights[spec.name] = std::move(tensor);
+  }
+  return weights;
+}
+
+}  // namespace litert::tensor::examples::talker

--- a/models/qwen/qwen3_tts/tensor_api/talker_step/talker_weights.h
+++ b/models/qwen/qwen3_tts/tensor_api/talker_step/talker_weights.h
@@ -1,0 +1,57 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Real-checkpoint weight loading for the talker step-graph.
+//
+// Loads Qwen/Qwen3-TTS-12Hz-0.6B-Base model.safetensors (bf16 -> fp32) into
+// the WeightMap. Only the tensors the step graphs consume are loaded (talker
+// backbone + codec embedding/head + code predictor); text_embedding,
+// text_projection and the speaker encoder stay host-side.
+//
+// Reuses the gemma3 example's SafetensorLoader but undoes its Gemma-only
+// RMSNorm convention: that loader adds +1.0 to every tensor named
+// *layernorm* / *norm.weight (Gemma stores w-1); Qwen3 norms use the raw
+// weight, so the offset is subtracted back here.
+
+#ifndef SPEECHLM_STAGE1_TALKER_STEP_TALKER_WEIGHTS_H_
+#define SPEECHLM_STAGE1_TALKER_STEP_TALKER_WEIGHTS_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_config.h"
+#include "models/qwen/qwen3_tts/tensor_api/talker_step/talker_graph.h"
+
+namespace litert::tensor::examples::talker {
+
+// Optional in-process weight quantization applied while loading: per-channel
+// symmetric (zero_point 0, dim 0) int8 (±127) or int4 (±7, bit-packed kI4)
+// on the 2-D matmul weights (q/k/v/o, mlp, codec_head, lm_heads). Norms and
+// embedding tables (Gather sources) stay fp32.
+enum class WeightQuantMode { kNone, kInt8, kInt4 };
+
+// If `prequant_path` is non-empty, the quantizable 2-D matmul weights are
+// read pre-quantized from that companion safetensors (`<name>` I8 codes in
+// [-7,7] + `<name>.scale` F32 blockwise-32 scales — the output format of
+// verify/gptq_quantize.py) instead of being quantized in-process;
+// `quant_mode` then only applies to nothing (all quantizables must be in
+// the companion). Norms/embeddings still come from `path`.
+absl::StatusOr<WeightMap> LoadCheckpointWeights(
+    const TalkerConfig& config, const std::string& path,
+    WeightQuantMode quant_mode = WeightQuantMode::kNone,
+    const std::string& prequant_path = "");
+
+}  // namespace litert::tensor::examples::talker
+
+#endif  // SPEECHLM_STAGE1_TALKER_STEP_TALKER_WEIGHTS_H_

--- a/models/qwen/qwen3_tts/tensor_api/verify/audio_smoke.py
+++ b/models/qwen/qwen3_tts/tensor_api/verify/audio_smoke.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audio smoke: real-prompt talker rollout -> codec decode -> listenable wav.
+
+Chains the two Tensor API example binaries host-side (the production stage
+split): talker_main generates codec frames with in-graph greedy + EOS stop
+(--eos_id), this script transposes the frame dump to the codec's [16, T]
+layout, codec_main renders the waveform, and the raw fp32 is written as a
+16-bit PCM wav @ 24 kHz.
+
+Usage:
+  python3 audio_smoke.py \
+      --weights .../qwen3-tts-weights/model.safetensors \
+      --codec-weights .../qwen3-tts-weights/speech_tokenizer/model.safetensors \
+      --talker-bin .../bazel-bin/models/qwen/qwen3_tts/tensor_api/talker_step/talker_main \
+      --codec-bin .../bazel-bin/models/qwen/qwen3_tts/tensor_api/codec_decode/codec_main \
+      --workdir /tmp/smoke --out /tmp/smoke/smoke.wav \
+      [--text "..."] [--spk enrollment.npy] [--weight-quant int8]
+      [--accelerator gpu --gpu-precision fp32]
+
+Also renders externally supplied codes with --codes-npy (e.g. a PyTorch
+reference rollout) through the same codec graph for A/B listening.
+"""
+
+import argparse
+import pathlib
+import subprocess
+import sys
+import wave
+
+import numpy as np
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+from numpy_talker_ref import EOS_ID, GROUPS, REAL_TEXT, build_real_prompt
+
+SR = 24000
+
+
+def write_wav(path, x):
+    pcm = (np.clip(x, -1.0, 1.0) * 32767.0).astype('<i2')
+    with wave.open(str(path), 'wb') as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(SR)
+        w.writeframes(pcm.tobytes())
+    print(f'wrote {path}: {len(x)} samples = {len(x) / SR:.2f} s')
+
+
+def run(cmd):
+    print('+ ' + ' '.join(cmd), file=sys.stderr)
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    sys.stderr.write(proc.stdout + proc.stderr)
+    if proc.returncode != 0:
+        sys.exit(f'command failed ({proc.returncode})')
+    return proc.stdout
+
+
+def decode_codes(args, work, codes, tag):
+    """codes [T, 16] -> wav via codec_main; returns fp32 waveform."""
+    t = codes.shape[0]
+    codes_path = work / f'codes_{tag}.i32'
+    codes.T.astype(np.int32).tofile(codes_path)  # [16, T] codebook-major
+    wav_path = work / f'wav_{tag}.f32'
+    run([args.codec_bin,
+         f'--weights={args.codec_weights}',
+         f'--frames={t}',
+         f'--codes_file={codes_path}',
+         f'--dump_wav={wav_path}',
+         f'--accelerator={args.codec_accelerator}',
+         f'--gpu_precision={args.codec_gpu_precision}',
+         '--gpu_buffer_storage=buffer',
+         f'--tflite_path={work}/codec_decode.tflite',
+         '--runs=1'])
+    return np.fromfile(wav_path, np.float32)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--weights', required=True)
+    ap.add_argument('--codec-weights', required=True)
+    ap.add_argument('--talker-bin', required=True)
+    ap.add_argument('--codec-bin', required=True)
+    ap.add_argument('--workdir', required=True)
+    ap.add_argument('--out', required=True, help='output .wav path')
+    ap.add_argument('--text', default=REAL_TEXT)
+    ap.add_argument('--spk', default='',
+                    help='.npy 1024-d speaker x-vector (default zeros)')
+    ap.add_argument('--steps', type=int, default=240,
+                    help='decode-step cap; EOS usually stops earlier')
+    ap.add_argument('--max-seq', type=int, default=256)
+    ap.add_argument('--accelerator', default='cpu', help='talker: cpu|gpu')
+    ap.add_argument('--gpu-precision', default='fp32')
+    ap.add_argument('--weight-quant', default='none')
+    ap.add_argument('--prequant-weights', default='',
+                    help='talker: pre-quantized int4 companion safetensors '
+                         '(gptq_quantize.py output)')
+    ap.add_argument('--sample-temp', type=float, default=0.0,
+                    help='talker cb0 Gumbel temperature (0 = greedy)')
+    ap.add_argument('--sample-seed', type=int, default=1)
+    ap.add_argument('--codec-accelerator', default='cpu')
+    ap.add_argument('--codec-gpu-precision', default='fp32')
+    ap.add_argument('--codes-npy', default='',
+                    help='skip the talker: render these [T, 16] codes instead')
+    args = ap.parse_args()
+
+    work = pathlib.Path(args.workdir)
+    work.mkdir(parents=True, exist_ok=True)
+
+    if args.codes_npy:
+        codes = np.load(args.codes_npy).astype(np.int32)
+        assert codes.ndim == 2 and codes.shape[1] == GROUPS, codes.shape
+        write_wav(args.out, decode_codes(args, work, codes, 'ext'))
+        return
+
+    assert args.steps + 10 <= args.max_seq, 'steps must fit the KV cache'
+    spk = np.load(args.spk) if args.spk else None
+    prefill, track = build_real_prompt(args.weights, args.steps,
+                                       text=args.text, spk=spk)
+    prefill.tofile(work / 'prefill_emb.f32')
+    track.tofile(work / 'text_track.f32')
+    print(f'prompt: prefill {prefill.shape}, text_track {track.shape}, '
+          f'spk={"real" if spk is not None else "zeros"}')
+
+    run([args.talker_bin,
+         '--layers=28',
+         f'--max_seq={args.max_seq}',
+         '--prefill_len=10',
+         f'--steps={args.steps}',
+         '--warmup=3',
+         f'--weights={args.weights}',
+         f'--weight_quant={args.weight_quant}',
+         f'--prequant_weights={args.prequant_weights}',
+         f'--sample_temp={args.sample_temp}',
+         f'--sample_seed={args.sample_seed}',
+         f'--accelerator={args.accelerator}',
+         f'--gpu_precision={args.gpu_precision}',
+         '--gpu_buffer_storage=buffer',
+         f'--eos_id={EOS_ID}',
+         f'--prefill_emb_file={work}/prefill_emb.f32',
+         f'--text_track_file={work}/text_track.f32',
+         f'--dump_dir={work}',
+         f'--tflite_path={work}/talker_step.tflite'])
+
+    codes = np.fromfile(work / 'frames.i32', np.int32).reshape(-1, GROUPS)
+    dur = codes.shape[0] / 12.5
+    print(f'talker: {codes.shape[0]} frames = {dur:.2f} s @ 12.5 Hz')
+    assert (codes >= 0).all() and (codes < 2048).all(), 'non-codec id in dump'
+
+    write_wav(args.out, decode_codes(args, work, codes, 'talker'))
+
+
+if __name__ == '__main__':
+    main()

--- a/models/qwen/qwen3_tts/tensor_api/verify/enroll_speaker.py
+++ b/models/qwen/qwen3_tts/tensor_api/verify/enroll_speaker.py
@@ -1,0 +1,50 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Enroll a voice: reference audio (~3-10 s) -> 1024-d x-vector .npy.
+
+Runs the Qwen3-TTS ECAPA speaker encoder in PyTorch on the LOCAL checkpoint
+(the 76-tensor speaker_encoder is in model.safetensors) — a local-path
+variant of the production extract_speaker_embedding.py, so no HF download.
+The .npy drops into audio_smoke.py --spk / build_real_prompt(spk=...).
+
+Run with a python env that has torch + the checkpoint's speaker-encoder deps:
+  python3 enroll_speaker.py <checkpoint_dir> <ref.wav> <out.npy>
+"""
+
+import sys
+
+import librosa
+import numpy as np
+import torch
+
+from qwen_tts import Qwen3TTSModel
+
+
+def main():
+    ckpt, wav_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    wrapper = Qwen3TTSModel.from_pretrained(ckpt, device_map='cpu',
+                                            dtype=torch.float32)
+    audio, sr = librosa.load(wav_path, sr=24000, mono=True)
+    emb = wrapper.model.extract_speaker_embedding(
+        audio=audio.astype(np.float32), sr=sr)
+    emb = emb.detach().cpu().numpy().astype(np.float32).reshape(-1)
+    assert emb.shape == (1024,), emb.shape
+    np.save(out_path, emb)
+    print(f'saved {out_path}: shape {emb.shape} '
+          f'L2 {np.linalg.norm(emb):.3f} (finite={np.isfinite(emb).all()})')
+
+
+if __name__ == '__main__':
+    main()

--- a/models/qwen/qwen3_tts/tensor_api/verify/gptq_eval.py
+++ b/models/qwen/qwen3_tts/tensor_api/verify/gptq_eval.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Teacher-forced quality comparison: fp32 vs RTN-int4 vs GPTQ-int4.
+
+Rolls the fp32 reference on the real prompt to fix a trajectory, then
+re-runs each quantized variant ON THE SAME fp32 sequence prefixes
+(teacher forcing), so per-frame metrics measure weight-quant damage only,
+not autoregressive divergence:
+
+  - cb0 logits cosine vs fp32, per frame (median / min)
+  - cb0 greedy id match rate
+  - full 16-group frame id match rate (variant CP run on the fp32 h_last)
+
+Usage:
+  python3 gptq_eval.py --weights .../model.safetensors \
+      --gptq .../talker_gptq_int4.safetensors [--steps 48] [--layers 28]
+"""
+
+import argparse
+import sys
+
+import numpy as np
+
+import numpy_talker_ref as ref
+import gptq_quantize as gq
+
+
+def cos(a, b):
+    return float(np.dot(a, b) /
+                 ((np.linalg.norm(a) * np.linalg.norm(b)) + 1e-30))
+
+
+def rollout_fp32(w, layers, prefill, track, steps):
+    """Returns (seqs [list of row-lists per step], h_lasts, logits, frames)."""
+    seq = [row for row in prefill]
+    h_lasts, logits_all, frames, seq_lens = [], [], [], []
+    feedback = None
+    for step in range(steps + 1):
+        if step > 0:
+            seq.append(feedback + track[step - 1])
+        hidden = ref.backbone_forward(np.stack(seq), w, 'talker.model',
+                                      layers, np.arange(len(seq)))
+        h_last = hidden[-1]
+        lg = h_last @ w['talker.codec_head.weight'].T
+        ids, feedback = ref.predict_frame(h_last, lg, w)
+        h_lasts.append(h_last)
+        logits_all.append(lg)
+        frames.append(ids)
+        seq_lens.append(len(seq))
+    return np.stack(seq), seq_lens, h_lasts, logits_all, frames
+
+
+def eval_variant(tag, wv, layers, full_seq, seq_lens, h_lasts_fp32,
+                 logits_fp32, frames_fp32):
+    coss, cb0_hits, frame_hits, group_hits = [], 0, 0, 0
+    n = len(seq_lens)
+    for step in range(n):
+        S = seq_lens[step]
+        hidden = ref.backbone_forward(full_seq[:S], wv, 'talker.model',
+                                      layers, np.arange(S))
+        h_last = hidden[-1]
+        lg = h_last @ wv['talker.codec_head.weight'].T
+        coss.append(cos(lg, logits_fp32[step]))
+        cb0_fp32 = frames_fp32[step][0]
+        cb0_v = int(np.argmax(lg + ref.cb0_bias()))
+        cb0_hits += cb0_v == cb0_fp32
+        # CP damage isolated on the fp32 h_last (and fp32 cb0 via logits).
+        ids, _ = ref.predict_frame(h_lasts_fp32[step],
+                                   logits_fp32[step], wv)
+        frame_hits += ids == frames_fp32[step]
+        group_hits += sum(a == b for a, b in zip(ids, frames_fp32[step]))
+    print(f'{tag}: cb0-logit cos median {np.median(coss):.5f} '
+          f'(min {min(coss):.5f}) | cb0 id match {cb0_hits}/{n} | '
+          f'16-group frame match {frame_hits}/{n} | '
+          f'per-group match {group_hits}/{n * ref.GROUPS} '
+          f'({100.0 * group_hits / (n * ref.GROUPS):.1f}%)')
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--weights', required=True)
+    ap.add_argument('--gptq', required=True)
+    ap.add_argument('--layers', type=int, default=28)
+    ap.add_argument('--steps', type=int, default=48)
+    args = ap.parse_args()
+
+    names = ref.weight_names(args.layers)
+    w = ref.load_bf16_tensors(args.weights, names)
+    prefill, track = ref.build_real_prompt(args.weights, args.steps)
+
+    print(f'fp32 rollout ({args.steps} frames)...', file=sys.stderr)
+    full_seq, seq_lens, h_lasts, logits, frames = rollout_fp32(
+        w, args.layers, prefill, track, args.steps)
+
+    w_rtn = ref.quantize_weights_like_cpp(
+        ref.load_bf16_tensors(args.weights, names), 'int4')
+    eval_variant('RTN  int4-bw32', w_rtn, args.layers, full_seq, seq_lens,
+                 h_lasts, logits, frames)
+    del w_rtn
+
+    w_gptq = gq.apply_gptq_fakequant(
+        ref.load_bf16_tensors(args.weights, names), args.gptq)
+    eval_variant('GPTQ int4-bw32', w_gptq, args.layers, full_seq, seq_lens,
+                 h_lasts, logits, frames)
+
+
+if __name__ == '__main__':
+    main()

--- a/models/qwen/qwen3_tts/tensor_api/verify/gptq_quantize.py
+++ b/models/qwen/qwen3_tts/tensor_api/verify/gptq_quantize.py
@@ -1,0 +1,387 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPTQ quantizer for the Qwen3-TTS talker -> C++-layout-exact int4 blockwise-32.
+
+Produces a companion safetensors holding, for every weight that
+talker_weights.cc quantizes (IsQuantizableFcWeight: *_proj.weight,
+*codec_head.weight, *.lm_head.*), the GPTQ-quantized codes and scales:
+
+    <name>        I8  [out, in]      codes in [-7, 7]
+    <name>.scale  F32 [out, in/32]   fp16-rounded blockwise scales
+
+Scales are STATIC and computed from the original weights exactly as the
+C++ RTN does (fp16(amax/7) per 32-block, grid clamped to [-7, 7]); GPTQ
+only re-decides the rounding inside each block with Hessian error
+compensation. The file therefore drops into the exact TFLite INT4 +
+BlockwiseQuantization layout the graph already uses — same kernels, same
+speed, better rounding.
+
+Calibration: the fp32 numpy reference rollout (numpy_talker_ref) on real
+prompts — dual-track prefill from the checkpoint tokenizer + greedy
+decode — recording each linear's input rows exactly once per sequence
+position (all prefill rows at step 0, the one new row per decode step;
+CP rows once, on the final group forward of each frame).
+
+Usage:
+  python3 gptq_quantize.py --weights .../model.safetensors \
+      --out .../talker_gptq_int4.safetensors [--steps 64] [--layers 28]
+"""
+
+import argparse
+import json
+import struct
+import sys
+import time
+
+import numpy as np
+
+import numpy_talker_ref as ref
+
+INT4_BLOCK = ref.INT4_BLOCK
+
+# Extra calibration texts beyond the reference sentence (diversity: numbers,
+# punctuation, longer clauses).
+CALIB_TEXTS = [
+    ref.REAL_TEXT,
+    'The quick brown fox jumps over the lazy dog, while seventeen quiet '
+    'engineers watch the rain outside.',
+    'On Tuesday morning we measured latency on the phone: ninety-nine '
+    'milliseconds per frame, which is fast enough for streaming speech.',
+    'Really? I could hardly believe it — the tiny model spoke clearly, '
+    'paused naturally, and even laughed a little at the right moment!',
+    'Numbers to read aloud: three hundred twelve, forty-seven point five, '
+    'nineteen eighty-four, and one million two hundred thousand.',
+]
+
+
+def is_quantizable(name):
+    return ('_proj.weight' in name or name.endswith('codec_head.weight')
+            or '.lm_head.' in name)
+
+
+def hkey(name):
+    """Maps a quantizable weight name to its shared Hessian key (weights
+    fed by the same input rows share one accumulator)."""
+    if name.endswith('codec_head.weight'):
+        return 'codec_head_in'
+    if '.lm_head.' in name:
+        return name + ':in'  # each group head sees a distinct row
+    layer = name.rsplit('.', 3)[0]  # e.g. talker.model.layers.0
+    if name.endswith(('q_proj.weight', 'k_proj.weight', 'v_proj.weight')):
+        return layer + ':attn_in'
+    if name.endswith('o_proj.weight'):
+        return layer + ':o_in'
+    if name.endswith(('gate_proj.weight', 'up_proj.weight')):
+        return layer + ':mlp_in'
+    if name.endswith('down_proj.weight'):
+        return layer + ':down_in'
+    raise ValueError(name)
+
+
+class HessianAcc:
+    def __init__(self):
+        self.H = {}
+        self.rows = {}
+
+    def add(self, key, x):
+        x = np.asarray(x, np.float32)
+        if x.ndim == 1:
+            x = x[None]
+        if key not in self.H:
+            self.H[key] = x.T @ x
+            self.rows[key] = x.shape[0]
+        else:
+            self.H[key] += x.T @ x
+            self.rows[key] += x.shape[0]
+
+
+def backbone_forward_rec(x, w, base, n_layers, positions, acc, rec_from):
+    """ref.backbone_forward with input recording; records rows [rec_from:]
+    of each linear's input (each sequence position exactly once across the
+    rollout's repeated re-forwards)."""
+    S = x.shape[0]
+    cos, sin = ref.rope_tables(positions)
+    causal = np.full((S, S), ref.MASK_FLOOR, np.float32)
+    causal[np.tril_indices(S)] = 0.0
+
+    for i in range(n_layers):
+        p = f'{base}.layers.{i}'
+        h = ref.rms(x, w[f'{p}.input_layernorm.weight'])
+        acc.add(f'{p}:attn_in', h[rec_from:])
+        q = (h @ w[f'{p}.self_attn.q_proj.weight'].T).reshape(
+            S, ref.HEADS, ref.HD)
+        k = (h @ w[f'{p}.self_attn.k_proj.weight'].T).reshape(S, ref.KV,
+                                                              ref.HD)
+        v = (h @ w[f'{p}.self_attn.v_proj.weight'].T).reshape(S, ref.KV,
+                                                              ref.HD)
+        q = ref.rms(q, w[f'{p}.self_attn.q_norm.weight']).transpose(1, 0, 2)
+        k = ref.rms(k, w[f'{p}.self_attn.k_norm.weight']).transpose(1, 0, 2)
+        v = v.transpose(1, 0, 2)
+        q = ref.apply_rope(q, cos, sin)
+        k = ref.apply_rope(k, cos, sin)
+        k = np.repeat(k, ref.HEADS // ref.KV, axis=0)
+        v = np.repeat(v, ref.HEADS // ref.KV, axis=0)
+        scores = q @ k.transpose(0, 2, 1) * np.float32(ref.HD ** -0.5) + causal
+        o = ref.softmax(scores) @ v
+        o = o.transpose(1, 0, 2).reshape(S, ref.HEADS * ref.HD)
+        acc.add(f'{p}:o_in', o[rec_from:])
+        x = x + o @ w[f'{p}.self_attn.o_proj.weight'].T
+
+        h2 = ref.rms(x, w[f'{p}.post_attention_layernorm.weight'])
+        acc.add(f'{p}:mlp_in', h2[rec_from:])
+        ff = (ref.silu(h2 @ w[f'{p}.mlp.gate_proj.weight'].T) *
+              (h2 @ w[f'{p}.mlp.up_proj.weight'].T))
+        acc.add(f'{p}:down_in', ff[rec_from:])
+        x = x + ff @ w[f'{p}.mlp.down_proj.weight'].T
+    return ref.rms(x, w[f'{base}.norm.weight'])
+
+
+def predict_frame_rec(h_last, logits, w, acc):
+    """ref.predict_frame with recording: lm_head inputs per group, CP layer
+    inputs once (on the final group forward, whose per-position hiddens
+    equal the earlier forwards' — causal prefix stability)."""
+    cb0 = int(np.argmax(logits + ref.cb0_bias()))
+    cb0_emb = w['talker.model.codec_embedding.weight'][cb0]
+    ids = [cb0]
+    tokens = [h_last, cb0_emb]
+    feedback = cb0_emb.copy()
+    for g in range(ref.GROUPS - 1):
+        seq = np.stack(tokens)
+        last = g == ref.GROUPS - 2
+        if last:
+            h = backbone_forward_rec(seq, w, 'talker.code_predictor.model',
+                                     ref.CP_LAYERS, np.arange(len(tokens)),
+                                     acc, rec_from=0)[-1]
+        else:
+            h = ref.backbone_forward(seq, w, 'talker.code_predictor.model',
+                                     ref.CP_LAYERS,
+                                     np.arange(len(tokens)))[-1]
+        acc.add(f'talker.code_predictor.lm_head.{g}.weight:in', h)
+        lg = h @ w[f'talker.code_predictor.lm_head.{g}.weight'].T
+        idg = int(np.argmax(lg))
+        ids.append(idg)
+        emb = w[f'talker.code_predictor.model.codec_embedding.{g}.weight'][idg]
+        feedback = feedback + emb
+        if g < ref.GROUPS - 2:
+            tokens.append(emb)
+    return ids, feedback
+
+
+def collect_hessians(weights_path, w, layers, steps, texts):
+    acc = HessianAcc()
+    for ti, text in enumerate(texts):
+        prefill, track = ref.build_real_prompt(weights_path, steps, text=text)
+        seq = [row for row in prefill]
+        feedback = None
+        for step in range(steps + 1):
+            if step > 0:
+                seq.append(feedback + track[step - 1])
+            rec_from = 0 if step == 0 else len(seq) - 1
+            hidden = backbone_forward_rec(np.stack(seq), w, 'talker.model',
+                                          layers, np.arange(len(seq)), acc,
+                                          rec_from)
+            h_last = hidden[-1]
+            acc.add('codec_head_in', h_last)
+            logits = h_last @ w['talker.codec_head.weight'].T
+            ids, feedback = predict_frame_rec(h_last, logits, w, acc)
+            if step % 16 == 0:
+                print(f'calib text {ti}: frame {step}/{steps} cb0={ids[0]}',
+                      file=sys.stderr)
+    return acc
+
+
+def static_scales(W):
+    """Blockwise-32 scales exactly as talker_weights.cc: fp16(amax/7)."""
+    out, inner = W.shape
+    blocks = W.reshape(out, inner // INT4_BLOCK, INT4_BLOCK)
+    amax = np.abs(blocks).max(axis=2)
+    scale = np.where(amax > 0, amax / 7.0, 1.0)
+    return scale.astype(np.float16).astype(np.float32)  # [out, blocks]
+
+
+def weighted_err(E, H):
+    """Mean per-row quadratic error e H e^T (proxy for output MSE)."""
+    return float(np.einsum('oi,oi->', E @ H, E) / E.shape[0])
+
+
+def gptq_layer(W_orig, H, perc_damp=0.01):
+    """Returns (q int8 [out,in], scales f32 [out,blocks], loss_gptq,
+    loss_rtn). Static scales; column-serial GPTQ with lazy blocked
+    trailing updates (the standard 128-column scheme)."""
+    out, inn = W_orig.shape
+    scales = static_scales(W_orig)
+    col_scale = np.repeat(scales, INT4_BLOCK, axis=1)  # [out, in]
+
+    H_eval = ((H + H.T) * 0.5).astype(np.float64)
+
+    # RTN baseline (identical to the C++ in-process quant).
+    q_rtn = np.clip(np.round(W_orig / col_scale), -7, 7)
+    loss_rtn = weighted_err(
+        (W_orig - q_rtn * col_scale).astype(np.float64), H_eval)
+
+    H = H_eval.copy()
+    diag = np.einsum('ii->i', H)
+    dead = diag == 0.0
+    diag[dead] = 1.0
+    W = W_orig.astype(np.float32).copy()
+    W[:, dead] = 0.0
+    damp = perc_damp * float(np.mean(diag))
+    diag += damp
+
+    Hinv = np.linalg.inv(H)
+    # Upper factor U with H^{-1} = U^T U (torch cholesky(upper=True) == L^T).
+    U = np.linalg.cholesky(Hinv).T.astype(np.float32)
+
+    Q = np.zeros((out, inn), np.float32)
+    B = 128
+    for i1 in range(0, inn, B):
+        i2 = min(i1 + B, inn)
+        Wb = W[:, i1:i2]
+        Eb = np.zeros((out, i2 - i1), np.float32)
+        for j in range(i1, i2):
+            jj = j - i1
+            s = col_scale[:, j]
+            qj = np.clip(np.round(Wb[:, jj] / s), -7, 7)
+            Q[:, j] = qj
+            err = (Wb[:, jj] - qj * s) / U[j, j]
+            Eb[:, jj] = err
+            Wb[:, jj:] -= err[:, None] * U[j, j:i2][None, :]
+        if i2 < inn:
+            W[:, i2:] -= Eb @ U[i1:i2, i2:]
+    loss_gptq = weighted_err(
+        (W_orig - Q * col_scale).astype(np.float64), H_eval)
+    return Q.astype(np.int8), scales, loss_gptq, loss_rtn
+
+
+def load_safetensors_generic(path, names=None):
+    """Reads I8/F32/F16/BF16 tensors from a safetensors file."""
+    with open(path, 'rb') as f:
+        hdr_len = struct.unpack('<Q', f.read(8))[0]
+        header = json.loads(f.read(hdr_len))
+        data = f.read()
+    out = {}
+    for name, info in header.items():
+        if name == '__metadata__' or (names and name not in names):
+            continue
+        s0, s1 = info['data_offsets']
+        dt = info['dtype']
+        if dt == 'I8':
+            arr = np.frombuffer(data, np.int8, s1 - s0, s0)
+        elif dt == 'F32':
+            arr = np.frombuffer(data, np.float32, (s1 - s0) // 4, s0)
+        elif dt == 'F16':
+            arr = np.frombuffer(data, np.float16,
+                                (s1 - s0) // 2, s0).astype(np.float32)
+        elif dt == 'BF16':
+            raw = np.frombuffer(data, '<u2', (s1 - s0) // 2, s0)
+            arr = (raw.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        else:
+            raise ValueError(f'{name}: dtype {dt}')
+        out[name] = arr.reshape(info['shape']).copy()
+    return out
+
+
+def save_safetensors(path, tensors):
+    header = {}
+    blobs = []
+    offset = 0
+    for name, arr in tensors.items():
+        arr = np.ascontiguousarray(arr)
+        b = arr.tobytes()
+        dt = {'int8': 'I8', 'float32': 'F32'}[arr.dtype.name]
+        header[name] = {'dtype': dt, 'shape': list(arr.shape),
+                        'data_offsets': [offset, offset + len(b)]}
+        blobs.append(b)
+        offset += len(b)
+    hjson = json.dumps(header).encode()
+    with open(path, 'wb') as f:
+        f.write(struct.pack('<Q', len(hjson)))
+        f.write(hjson)
+        for b in blobs:
+            f.write(b)
+
+
+def apply_gptq_fakequant(w, companion_path):
+    """Overrides quantizable weights in `w` with dequantized GPTQ values
+    (q * scale, blockwise) — the numpy mirror of the C++ prequant path."""
+    comp = load_safetensors_generic(companion_path)
+    n = 0
+    for name in list(w.keys()):
+        if name not in comp:
+            continue
+        q = comp[name].astype(np.float32)
+        scale = comp[name + '.scale']
+        out, inner = q.shape
+        deq = (q.reshape(out, inner // INT4_BLOCK, INT4_BLOCK) *
+               scale[:, :, None]).reshape(out, inner)
+        w[name] = deq.astype(np.float32)
+        n += 1
+    if n == 0:
+        raise RuntimeError('no overlapping tensors found in companion')
+    return w
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--weights', required=True)
+    ap.add_argument('--out', required=True)
+    ap.add_argument('--layers', type=int, default=28)
+    ap.add_argument('--steps', type=int, default=64,
+                    help='decode frames per calibration text')
+    ap.add_argument('--damp', type=float, default=0.01)
+    ap.add_argument('--num-texts', type=int, default=len(CALIB_TEXTS),
+                    help='calibration texts to use (smoke tests)')
+    ap.add_argument('--report', help='JSON path for per-layer loss report')
+    args = ap.parse_args()
+
+    names = ref.weight_names(args.layers)
+    print(f'loading {len(names)} tensors...', file=sys.stderr)
+    w = ref.load_bf16_tensors(args.weights, names)
+
+    t0 = time.time()
+    acc = collect_hessians(args.weights, w, args.layers, args.steps,
+                           CALIB_TEXTS[:args.num_texts])
+    print(f'calibration done in {time.time() - t0:.0f}s; '
+          f'rows: {sorted(set(acc.rows.values()))}', file=sys.stderr)
+
+    out_tensors = {}
+    report = {}
+    quant_names = [n for n in names if is_quantizable(n)]
+    t0 = time.time()
+    for i, name in enumerate(quant_names):
+        H = acc.H[hkey(name)]
+        q, scales, lg, lr = gptq_layer(w[name], H, args.damp)
+        out_tensors[name] = q
+        out_tensors[name + '.scale'] = scales
+        report[name] = {'loss_gptq': lg, 'loss_rtn': lr,
+                        'ratio': lg / lr if lr > 0 else 1.0}
+        if i % 20 == 0 or lg > lr:
+            print(f'[{i + 1}/{len(quant_names)}] {name}: '
+                  f'gptq/rtn loss ratio {lg / max(lr, 1e-20):.3f}',
+                  file=sys.stderr)
+    print(f'gptq done in {time.time() - t0:.0f}s', file=sys.stderr)
+
+    save_safetensors(args.out, out_tensors)
+    ratios = [r['ratio'] for r in report.values()]
+    print(f'wrote {args.out}: {len(quant_names)} layers, '
+          f'loss ratio gptq/rtn median {np.median(ratios):.3f} '
+          f'(min {min(ratios):.3f}, max {max(ratios):.3f})')
+    if args.report:
+        with open(args.report, 'w') as f:
+            json.dump(report, f, indent=1)
+
+
+if __name__ == '__main__':
+    main()

--- a/models/qwen/qwen3_tts/tensor_api/verify/numpy_codec_ref.py
+++ b/models/qwen/qwen3_tts/tensor_api/verify/numpy_codec_ref.py
@@ -1,0 +1,317 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Independent numpy reference for the codec decoder equivalence check.
+
+Implements the Qwen3-TTS speech_tokenizer DECODER directly from
+model.safetensors (no torch), mirroring qtok12/modeling_*.py semantics:
+RVQ (EMA codebooks) -> causal pre_conv -> pre_transformer (rope 1e4,
+sliding-window-72 causal, LayerScale) -> TransConv+ConvNeXt upsampling ->
+Snake/TransConv/ResidualUnit decoder stack -> clamp. Replicates codec_main's
+production-style chunking (64-frame chunks, 25 frames left context, fixed
+89-frame window, right-zero-padded) so waveforms compare 1:1.
+
+Usage:
+  # 1. write deterministic codes for both sides
+  python3 numpy_codec_ref.py gen --out /tmp/cc --frames 128
+
+  # 2. codec_main --codes_file=/tmp/cc/codes.i32 --frames=128 \
+  #      --dump_wav=/tmp/cc/wav_cpp.f32 ...
+
+  # 3. compare
+  python3 numpy_codec_ref.py check --weights .../speech_tokenizer/model.safetensors \
+      --codes /tmp/cc/codes.i32 --dump /tmp/cc/wav_cpp.f32 --frames 128
+"""
+
+import argparse
+import json
+import math
+import struct
+import sys
+
+import numpy as np
+
+NQ, BINS, VQ_DIM, CB_DIM = 16, 2048, 256, 512
+LATENT, DEC_DIM = 1024, 1536
+TF_L, TF_H, TF_HD, TF_HID, TF_FFN = 8, 16, 64, 512, 1024
+ROPE_THETA, WINDOW, EPS = 1e4, 72, 1e-5
+UP_RATIOS, UP_RATES = [2, 2], [8, 5, 4, 3]
+CHUNK, CTX = 64, 25
+UPSAMPLE = 1920
+MASK_FLOOR = -30000.0
+
+
+def load_tensors(path):
+    with open(path, 'rb') as f:
+        n = struct.unpack('<Q', f.read(8))[0]
+        header = json.loads(f.read(n))
+        data = f.read()
+    out = {}
+    for name, info in header.items():
+        if name == '__metadata__' or not name.startswith('decoder.'):
+            continue
+        s0, s1 = info['data_offsets']
+        if info['dtype'] == 'BF16':
+            raw = np.frombuffer(data, '<u2', count=(s1 - s0) // 2, offset=s0)
+            arr = (raw.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        elif info['dtype'] == 'F32':
+            arr = np.frombuffer(data, '<f4', count=(s1 - s0) // 4, offset=s0)
+        else:
+            raise ValueError(f'{name}: {info["dtype"]}')
+        out[name] = arr.reshape(info['shape']).astype(np.float32)
+    return out
+
+
+# ---- primitives (all [C, T] channel-first like torch) ----
+
+def causal_conv(x, w, b, dilation=1):
+    """x [Cin,T], torch weight [Cout,Cin,k] -> [Cout,T]."""
+    cout, cin, k = w.shape
+    pad = (k - 1) * dilation
+    xp = np.pad(x, ((0, 0), (pad, 0)))
+    T = x.shape[1]
+    out = np.zeros((cout, T), np.float32)
+    for j in range(k):
+        out += w[:, :, j] @ xp[:, j * dilation:j * dilation + T]
+    return out + b[:, None]
+
+
+def causal_dwconv(x, w, b):
+    """x [C,T], torch weight [C,1,k] -> [C,T]."""
+    c, _, k = w.shape
+    xp = np.pad(x, ((0, 0), (k - 1, 0)))
+    T = x.shape[1]
+    out = np.zeros((c, T), np.float32)
+    for j in range(k):
+        out += w[:, 0, j:j + 1] * xp[:, j:j + T]
+    return out + b[:, None]
+
+
+def causal_transconv(x, w, b, stride):
+    """x [Cin,T], torch weight [Cin,Cout,k] -> [Cout,T*stride] (crop k-s)."""
+    cin, cout, k = w.shape
+    T = x.shape[1]
+    full = (T - 1) * stride + k
+    out = np.zeros((cout, full), np.float32)
+    for j in range(k):
+        out[:, j:j + (T - 1) * stride + 1:stride] += w[:, :, j].T @ x
+    out += b[:, None]
+    crop = k - stride
+    return out[:, :full - crop] if crop else out
+
+
+def snake(x, alpha, beta):
+    a = np.exp(alpha)[:, None]
+    bi = 1.0 / (np.exp(beta)[:, None] + 1e-9)
+    return x + bi * np.square(np.sin(x * a))
+
+
+def gelu(x):
+    from scipy.special import erf  # noqa: F401  (fallback below if absent)
+    return 0.5 * x * (1.0 + erf(x / np.sqrt(2.0)))
+
+
+try:
+    from scipy.special import erf as _erf  # noqa: F401
+except ImportError:  # exact erf via math, vectorized
+    _verf = np.vectorize(math.erf)
+
+    def gelu(x):  # noqa: F811
+        return 0.5 * x * (1.0 + _verf(x / np.sqrt(2.0)).astype(np.float32))
+
+
+def rms(x, w):
+    v = np.mean(np.square(x), axis=-1, keepdims=True, dtype=np.float32)
+    return x * (1.0 / np.sqrt(v + EPS)) * w
+
+
+def rope_tables(T):
+    half = TF_HD // 2
+    freqs = ROPE_THETA ** (-2.0 * np.arange(half) / TF_HD)
+    ang = np.arange(T, dtype=np.float64)[:, None] * freqs[None, :]
+    cos = np.concatenate([np.cos(ang), np.cos(ang)], -1).astype(np.float32)
+    sin = np.concatenate([np.sin(ang), np.sin(ang)], -1).astype(np.float32)
+    return cos, sin
+
+
+def pre_transformer(x, w, base='decoder.pre_transformer'):
+    """x [T, LATENT] -> [T, LATENT]."""
+    T = x.shape[0]
+    x = x @ w[f'{base}.input_proj.weight'].T + w[f'{base}.input_proj.bias']
+    cos, sin = rope_tables(T)
+    mask = np.full((T, T), MASK_FLOOR, np.float32)
+    for i in range(T):
+        mask[i, max(0, i - WINDOW + 1):i + 1] = 0.0
+    half = TF_HD // 2
+
+    def rope(t):  # t [H, T, hd]
+        rot = np.concatenate([-t[..., half:], t[..., :half]], -1)
+        return t * cos + rot * sin
+
+    for l in range(TF_L):
+        p = f'{base}.layers.{l}'
+        h = rms(x, w[f'{p}.input_layernorm.weight'])
+        q = (h @ w[f'{p}.self_attn.q_proj.weight'].T).reshape(T, TF_H, TF_HD)
+        k = (h @ w[f'{p}.self_attn.k_proj.weight'].T).reshape(T, TF_H, TF_HD)
+        v = (h @ w[f'{p}.self_attn.v_proj.weight'].T).reshape(T, TF_H, TF_HD)
+        q, k, v = (t.transpose(1, 0, 2) for t in (q, k, v))
+        q, k = rope(q), rope(k)
+        scores = q @ k.transpose(0, 2, 1) * np.float32(TF_HD ** -0.5) + mask
+        m = scores.max(-1, keepdims=True)
+        e = np.exp(scores - m)
+        attn = (e / e.sum(-1, keepdims=True)) @ v
+        attn = attn.transpose(1, 0, 2).reshape(T, TF_H * TF_HD)
+        attn = attn @ w[f'{p}.self_attn.o_proj.weight'].T
+        x = x + attn * w[f'{p}.self_attn_layer_scale.scale']
+
+        f = rms(x, w[f'{p}.post_attention_layernorm.weight'])
+        gate = f @ w[f'{p}.mlp.gate_proj.weight'].T
+        up = f @ w[f'{p}.mlp.up_proj.weight'].T
+        ffn = (gate / (1.0 + np.exp(-gate)) * up) @ w[
+            f'{p}.mlp.down_proj.weight'].T
+        x = x + ffn * w[f'{p}.mlp_layer_scale.scale']
+
+    x = rms(x, w[f'{base}.norm.weight'])
+    return x @ w[f'{base}.output_proj.weight'].T + w[f'{base}.output_proj.bias']
+
+
+def convnext(x, w, p):
+    """x [C,T]."""
+    h = causal_dwconv(x, w[f'{p}.dwconv.conv.weight'],
+                      w[f'{p}.dwconv.conv.bias'])
+    ht = h.T  # [T,C]
+    m = ht.mean(-1, keepdims=True)
+    d = ht - m
+    v = np.mean(d * d, axis=-1, keepdims=True)
+    ht = d / np.sqrt(v + 1e-6) * w[f'{p}.norm.weight'] + w[f'{p}.norm.bias']
+    ht = ht @ w[f'{p}.pwconv1.weight'].T + w[f'{p}.pwconv1.bias']
+    ht = gelu(ht)
+    ht = ht @ w[f'{p}.pwconv2.weight'].T + w[f'{p}.pwconv2.bias']
+    ht = ht * w[f'{p}.gamma']
+    return x + ht.T
+
+
+def decode_window(codes_win, w):
+    """codes [16, T] -> wav [T*1920]."""
+    T = codes_win.shape[1]
+    tables = []
+    for q in range(NQ):
+        base = ('decoder.quantizer.rvq_first.vq.layers.0._codebook' if q == 0
+                else f'decoder.quantizer.rvq_rest.vq.layers.{q-1}._codebook')
+        usage = np.maximum(w[f'{base}.cluster_usage'], EPS)
+        tables.append(w[f'{base}.embedding_sum'] / usage[:, None])
+    sem = tables[0][codes_win[0]]  # [T, 256]
+    sem = sem @ w['decoder.quantizer.rvq_first.output_proj.weight'][:, :, 0].T
+    aco = np.zeros((T, VQ_DIM), np.float32)
+    for q in range(1, NQ):
+        aco += tables[q][codes_win[q]]
+    aco = aco @ w['decoder.quantizer.rvq_rest.output_proj.weight'][:, :, 0].T
+    latent = (sem + aco).T  # [512, T]
+
+    h = causal_conv(latent, w['decoder.pre_conv.conv.weight'],
+                    w['decoder.pre_conv.conv.bias'])  # [1024, T]
+    h = pre_transformer(h.T, w).T  # [1024, T]
+
+    for i, r in enumerate(UP_RATIOS):
+        p = f'decoder.upsample.{i}'
+        h = causal_transconv(h, w[f'{p}.0.conv.weight'],
+                             w[f'{p}.0.conv.bias'], r)
+        h = convnext(h, w, f'{p}.1')
+
+    h = causal_conv(h, w['decoder.decoder.0.conv.weight'],
+                    w['decoder.decoder.0.conv.bias'])
+    for i, rate in enumerate(UP_RATES):
+        p = f'decoder.decoder.{i+1}.block'
+        h = snake(h, w[f'{p}.0.alpha'], w[f'{p}.0.beta'])
+        h = causal_transconv(h, w[f'{p}.1.conv.weight'],
+                             w[f'{p}.1.conv.bias'], rate)
+        for u, dil in zip((2, 3, 4), (1, 3, 9)):
+            r_ = f'{p}.{u}'
+            hh = snake(h, w[f'{r_}.act1.alpha'], w[f'{r_}.act1.beta'])
+            hh = causal_conv(hh, w[f'{r_}.conv1.conv.weight'],
+                             w[f'{r_}.conv1.conv.bias'], dil)
+            hh = snake(hh, w[f'{r_}.act2.alpha'], w[f'{r_}.act2.beta'])
+            hh = causal_conv(hh, w[f'{r_}.conv2.conv.weight'],
+                             w[f'{r_}.conv2.conv.bias'])
+            h = h + hh
+    last = len(UP_RATES) + 1
+    h = snake(h, w[f'decoder.decoder.{last}.alpha'],
+              w[f'decoder.decoder.{last}.beta'])
+    h = causal_conv(h, w[f'decoder.decoder.{last+1}.conv.weight'],
+                    w[f'decoder.decoder.{last+1}.conv.bias'])
+    return np.clip(h[0], -1.0, 1.0)
+
+
+def chunked_decode(codes, w):
+    """Mirrors codec_main: fixed window CHUNK+CTX, right-zero-pad, crop."""
+    frames = codes.shape[1]
+    window = CHUNK + CTX
+    wav = []
+    start = 0
+    while start < frames:
+        ctx = min(CTX, start)
+        end = min(start + CHUNK, frames)
+        win = np.zeros((NQ, window), np.int64)
+        n = ctx + (end - start)
+        win[:, :n] = codes[:, start - ctx:end]
+        out = decode_window(win, w)
+        wav.append(out[ctx * UPSAMPLE:(ctx + end - start) * UPSAMPLE])
+        start = end
+        print(f'  chunk -> {end}/{frames} frames', file=sys.stderr)
+    return np.concatenate(wav)
+
+
+def make_codes(frames):
+    """Same LCG as codec_main's synthetic codes."""
+    state = np.uint32(12345)
+    out = np.empty(NQ * frames, np.int32)
+    for i in range(out.size):
+        state = np.uint32(state * np.uint32(1664525) + np.uint32(1013904223))
+        out[i] = int(state >> np.uint32(8)) % BINS
+    return out.reshape(NQ, frames)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('mode', choices=['gen', 'check'])
+    ap.add_argument('--out')
+    ap.add_argument('--weights')
+    ap.add_argument('--codes')
+    ap.add_argument('--dump')
+    ap.add_argument('--frames', type=int, default=128)
+    args = ap.parse_args()
+
+    if args.mode == 'gen':
+        codes = make_codes(args.frames)
+        codes.tofile(f'{args.out}/codes.i32')
+        print(f'wrote {args.out}/codes.i32 {codes.shape}')
+        return
+
+    codes = np.fromfile(args.codes, np.int32).reshape(NQ, args.frames)
+    w = load_tensors(args.weights)
+    ref = chunked_decode(codes, w)
+    cpp = np.fromfile(args.dump, np.float32)
+    assert cpp.size == ref.size, (cpp.size, ref.size)
+    d = np.abs(ref - cpp)
+    corr = float(np.corrcoef(ref, cpp)[0, 1])
+    print(f'samples {ref.size}: corr={corr:.6f} max|d|={d.max():.4e} '
+          f'mean|d|={d.mean():.4e} ref RMS={np.sqrt(np.mean(ref**2)):.4f} '
+          f'cpp RMS={np.sqrt(np.mean(cpp**2)):.4f}')
+    ok = corr > 0.999
+    print('EQUIVALENCE: ' + ('PASS' if ok else 'FAIL'))
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/models/qwen/qwen3_tts/tensor_api/verify/numpy_talker_ref.py
+++ b/models/qwen/qwen3_tts/tensor_api/verify/numpy_talker_ref.py
@@ -1,0 +1,390 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Independent numpy reference for the talker step-graph equivalence check.
+
+Implements the Qwen3-TTS talker + code predictor forward directly from
+model.safetensors (bf16 -> fp32, no torch/qwen_tts dependency), mirroring the
+production semantics verified in hf-to-litertlm/qwen3tts_work
+(export_mtp_folded.py: rope position t per CP step, lm_head[t-1],
+codec_embedding tables 0..13 fed back; HF repeat_interleave GQA).
+
+Usage:
+  # 1. write the fixed prefill embedding input for talker_main
+  python3 numpy_talker_ref.py gen --out /tmp/talkercheck
+
+  # 2. run talker_main with --prefill_emb_file/--dump_dir (see README)
+
+  # 3. compute the reference and compare against the C++ dump
+  python3 numpy_talker_ref.py check --weights .../model.safetensors \
+      --dump /tmp/talkercheck [--layers 28] [--prefill-len 24] [--steps 8]
+"""
+
+import argparse
+import json
+import pathlib
+import struct
+import sys
+
+import numpy as np
+
+EMB = 1024
+HEADS = 16
+KV = 8
+HD = 128
+FFN = 3072
+EPS = 1e-6
+ROPE_BASE = 1e6
+TALKER_VOCAB = 3072
+CODEC_VOCAB = 2048
+GROUPS = 16  # cb0 + 15 sub groups
+CP_LAYERS = 5
+MASK_FLOOR = -30000.0  # must match kMaskFloor in the C++ graph/host loop
+TEXT_ROW = 0.01        # constant text-track row used by talker_main
+
+
+def load_bf16_tensors(path, wanted):
+    """Loads `wanted` tensor names from a safetensors file as fp32 arrays."""
+    with open(path, 'rb') as f:
+        hdr_len = struct.unpack('<Q', f.read(8))[0]
+        header = json.loads(f.read(hdr_len))
+        data = f.read()  # data section; offsets below are relative to it
+    out = {}
+    for name in wanted:
+        info = header[name]
+        assert info['dtype'] == 'BF16', (name, info['dtype'])
+        s0, s1 = info['data_offsets']
+        raw = np.frombuffer(data, dtype='<u2', count=(s1 - s0) // 2,
+                            offset=s0)
+        f32 = (raw.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        out[name] = f32.reshape(info['shape']).copy()
+    return out
+
+
+INT4_BLOCK = 32
+
+
+def quantize_weights_like_cpp(w, mode):
+    """Mirrors talker_weights.cc QuantizeFcWeight, dequantized back to fp32
+    (isolates pure weight-quant noise from backend activation quantization).
+    int8: per-channel symmetric. int4: blockwise-32 symmetric, scales rounded
+    to fp16 as the serializer does."""
+    for name, arr in w.items():
+        if not ('_proj.weight' in name or name.endswith('codec_head.weight')
+                or '.lm_head.' in name):
+            continue
+        if mode == 'int8':
+            amax = np.abs(arr).max(axis=1)
+            scale = np.where(amax > 0, amax / 127.0, 1.0).astype(np.float32)
+            q = np.clip(np.round(arr / scale[:, None]), -127, 127)
+            w[name] = (q * scale[:, None]).astype(np.float32)
+        else:  # int4 blockwise
+            out, inner = arr.shape
+            blocks = arr.reshape(out, inner // INT4_BLOCK, INT4_BLOCK)
+            amax = np.abs(blocks).max(axis=2)
+            scale = np.where(amax > 0, amax / 7.0, 1.0)
+            scale = scale.astype(np.float16).astype(np.float32)
+            q = np.clip(np.round(blocks / scale[:, :, None]), -7, 7)
+            w[name] = (q * scale[:, :, None]).reshape(out, inner).astype(
+                np.float32)
+    return w
+
+
+def weight_names(layers):
+    names = []
+
+    def backbone(base, n):
+        for i in range(n):
+            p = f'{base}.layers.{i}'
+            names.extend([
+                f'{p}.input_layernorm.weight',
+                f'{p}.self_attn.q_proj.weight',
+                f'{p}.self_attn.k_proj.weight',
+                f'{p}.self_attn.v_proj.weight',
+                f'{p}.self_attn.o_proj.weight',
+                f'{p}.self_attn.q_norm.weight',
+                f'{p}.self_attn.k_norm.weight',
+                f'{p}.post_attention_layernorm.weight',
+                f'{p}.mlp.gate_proj.weight',
+                f'{p}.mlp.up_proj.weight',
+                f'{p}.mlp.down_proj.weight',
+            ])
+        names.append(f'{base}.norm.weight')
+
+    backbone('talker.model', layers)
+    names.append('talker.model.codec_embedding.weight')
+    names.append('talker.codec_head.weight')
+    backbone('talker.code_predictor.model', CP_LAYERS)
+    for g in range(GROUPS - 1):
+        names.append(f'talker.code_predictor.model.codec_embedding.{g}.weight')
+        names.append(f'talker.code_predictor.lm_head.{g}.weight')
+    return names
+
+
+def rms(x, w):
+    v = np.mean(np.square(x), axis=-1, keepdims=True, dtype=np.float32)
+    return x * (1.0 / np.sqrt(v + EPS)) * w
+
+
+def silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def rope_tables(positions):
+    half = HD // 2
+    freqs = ROPE_BASE ** (-2.0 * np.arange(half) / HD)
+    ang = np.asarray(positions, np.float64)[:, None] * freqs[None, :]
+    cos = np.concatenate([np.cos(ang), np.cos(ang)], -1).astype(np.float32)
+    sin = np.concatenate([np.sin(ang), np.sin(ang)], -1).astype(np.float32)
+    return cos, sin  # [S, HD]
+
+
+def apply_rope(x, cos, sin):
+    half = HD // 2
+    rot = np.concatenate([-x[..., half:], x[..., :half]], -1)
+    return x * cos + rot * sin
+
+
+def softmax(x):
+    m = np.max(x, axis=-1, keepdims=True)
+    e = np.exp(x - m)
+    return e / np.sum(e, axis=-1, keepdims=True)
+
+
+def backbone_forward(x, w, base, n_layers, positions):
+    """Pre-norm GQA transformer; x [S, EMB] fp32; returns final-normed [S, EMB]."""
+    S = x.shape[0]
+    cos, sin = rope_tables(positions)
+    causal = np.full((S, S), MASK_FLOOR, np.float32)
+    causal[np.tril_indices(S)] = 0.0
+
+    for i in range(n_layers):
+        p = f'{base}.layers.{i}'
+        h = rms(x, w[f'{p}.input_layernorm.weight'])
+        q = (h @ w[f'{p}.self_attn.q_proj.weight'].T).reshape(S, HEADS, HD)
+        k = (h @ w[f'{p}.self_attn.k_proj.weight'].T).reshape(S, KV, HD)
+        v = (h @ w[f'{p}.self_attn.v_proj.weight'].T).reshape(S, KV, HD)
+        q = rms(q, w[f'{p}.self_attn.q_norm.weight']).transpose(1, 0, 2)
+        k = rms(k, w[f'{p}.self_attn.k_norm.weight']).transpose(1, 0, 2)
+        v = v.transpose(1, 0, 2)
+        q = apply_rope(q, cos, sin)
+        k = apply_rope(k, cos, sin)
+        k = np.repeat(k, HEADS // KV, axis=0)  # HF repeat_interleave
+        v = np.repeat(v, HEADS // KV, axis=0)
+        scores = q @ k.transpose(0, 2, 1) * np.float32(HD ** -0.5) + causal
+        o = softmax(scores) @ v  # [H, S, HD]
+        o = o.transpose(1, 0, 2).reshape(S, HEADS * HD)
+        x = x + o @ w[f'{p}.self_attn.o_proj.weight'].T
+
+        h2 = rms(x, w[f'{p}.post_attention_layernorm.weight'])
+        ff = (silu(h2 @ w[f'{p}.mlp.gate_proj.weight'].T) *
+              (h2 @ w[f'{p}.mlp.up_proj.weight'].T))
+        x = x + ff @ w[f'{p}.mlp.down_proj.weight'].T
+    return rms(x, w[f'{base}.norm.weight'])
+
+
+def cb0_bias():
+    bias = np.zeros(TALKER_VOCAB, np.float32)
+    bias[CODEC_VOCAB:] = MASK_FLOOR
+    return bias
+
+
+def predict_frame(h_last, logits, w):
+    """cb0 (greedy, suppressed) + CP unroll -> (ids[16], feedback[EMB])."""
+    cb0 = int(np.argmax(logits + cb0_bias()))
+    cb0_emb = w['talker.model.codec_embedding.weight'][cb0]
+    ids = [cb0]
+    tokens = [h_last, cb0_emb]
+    feedback = cb0_emb.copy()
+    for g in range(GROUPS - 1):
+        seq = np.stack(tokens)  # [S, EMB], rope positions 0..S-1
+        h = backbone_forward(seq, w, 'talker.code_predictor.model', CP_LAYERS,
+                             np.arange(len(tokens)))[-1]
+        lg = h @ w[f'talker.code_predictor.lm_head.{g}.weight'].T
+        idg = int(np.argmax(lg))
+        ids.append(idg)
+        emb = w[f'talker.code_predictor.model.codec_embedding.{g}.weight'][idg]
+        feedback = feedback + emb
+        if g < GROUPS - 2:
+            tokens.append(emb)
+    return ids, feedback
+
+
+def make_prefill_emb(prefill_len):
+    rng = np.random.RandomState(123)
+    return (rng.randn(prefill_len, EMB) * 0.02).astype(np.float32)
+
+
+# Real-prompt construction, mirroring the production host loop
+# (hf-to-litertlm/qwen3tts_work/hostloop_e2e.py): dual-track prefill of
+# text-projection rows + codec special rows. Speaker x-vector defaults to
+# zeros (numerics experiments); pass a real 1024-d enrollment vector via
+# `spk` for audio-quality runs.
+REAL_TEXT = ('Hello! This is a small test of speech synthesis running on '
+             'device.')
+EOS_ID = 2150
+THINK, THINK_BOS, THINK_EOS = 2154, 2156, 2157
+PAD_ID, BOS_ID, LANG_EN = 2148, 2149, 2050
+TTS_BOS, TTS_EOS, TTS_PAD = 151672, 151673, 151671
+
+
+def build_real_prompt(weights_path, steps, text=REAL_TEXT, spk=None):
+    """Returns (prefill [10, EMB], text_track [steps, EMB]) fp32."""
+    from transformers import AutoTokenizer
+    w = load_bf16_tensors(weights_path, [
+        'talker.model.text_embedding.weight',
+        'talker.text_projection.linear_fc1.weight',
+        'talker.text_projection.linear_fc1.bias',
+        'talker.text_projection.linear_fc2.weight',
+        'talker.text_projection.linear_fc2.bias',
+        'talker.model.codec_embedding.weight',
+    ])
+    codec_emb = w['talker.model.codec_embedding.weight']
+
+    def embed_text(ids):
+        rows = w['talker.model.text_embedding.weight'][np.asarray(ids)]
+        h = silu(rows @ w['talker.text_projection.linear_fc1.weight'].T +
+                 w['talker.text_projection.linear_fc1.bias'])
+        return (h @ w['talker.text_projection.linear_fc2.weight'].T +
+                w['talker.text_projection.linear_fc2.bias']).astype(np.float32)
+
+    tok = AutoTokenizer.from_pretrained(
+        str(pathlib.Path(weights_path).parent))
+    ids = tok(f'<|im_start|>assistant\n{text}<|im_end|>\n'
+              '<|im_start|>assistant\n', return_tensors='np')['input_ids'][0]
+
+    tts_bos, tts_eos, tts_pad = embed_text([TTS_BOS, TTS_EOS, TTS_PAD])
+    if spk is None:
+        spk = np.zeros(EMB, np.float32)
+    spk = np.asarray(spk, np.float32).reshape(EMB)
+    codec_pre = np.concatenate([
+        codec_emb[[THINK, THINK_BOS, LANG_EN, THINK_EOS]], spk[None],
+        codec_emb[[PAD_ID, BOS_ID]]], 0)                       # [7, EMB]
+    role = embed_text(ids[:3])                                 # [3, EMB]
+    body = np.concatenate([np.repeat(tts_pad[None], 5, 0),
+                           tts_bos[None]], 0) + codec_pre[:-1]  # [6, EMB]
+    first_text = embed_text(ids[3:4]) + codec_pre[-1:]         # [1, EMB]
+    prefill = np.concatenate([role, body, first_text], 0)      # [10, EMB]
+    trailing = np.concatenate([embed_text(ids[4:-5]), tts_eos[None]], 0)
+
+    track = np.stack([trailing[t] if t < len(trailing) else tts_pad
+                      for t in range(steps)])
+    return prefill.astype(np.float32), track.astype(np.float32)
+
+
+def run_reference(weights_path, layers, prefill_len, steps, quant='none',
+                  prefill_emb=None, text_track=None, gptq=None):
+    w = load_bf16_tensors(weights_path, weight_names(layers))
+    if gptq:
+        import gptq_quantize
+        w = gptq_quantize.apply_gptq_fakequant(w, gptq)
+    elif quant != 'none':
+        w = quantize_weights_like_cpp(w, quant)
+    if prefill_emb is None:
+        prefill_emb = make_prefill_emb(prefill_len)
+    seq = [row for row in prefill_emb]
+
+    frames, logits_all, feedback_all = [], [], []
+    for step in range(steps + 1):  # step 0 = prefill frame
+        if step > 0:
+            row = (text_track[step - 1] if text_track is not None
+                   else np.float32(TEXT_ROW))
+            seq.append(feedback_all[-1] + row)
+        hidden = backbone_forward(np.stack(seq), w, 'talker.model', layers,
+                                  np.arange(len(seq)))
+        h_last = hidden[-1]
+        logits = h_last @ w['talker.codec_head.weight'].T
+        ids, feedback = predict_frame(h_last, logits, w)
+        frames.append(ids)
+        logits_all.append(logits)
+        feedback_all.append(feedback)
+        print(f'ref frame {step}: cb0={ids[0]} sub={ids[1:6]}...',
+              file=sys.stderr)
+    return (np.array(frames, np.int32), np.stack(logits_all),
+            np.stack(feedback_all))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('mode', choices=['gen', 'check'])
+    ap.add_argument('--out', help='gen: directory for prefill_emb.f32')
+    ap.add_argument('--weights', help='check: model.safetensors path')
+    ap.add_argument('--dump', help='check: talker_main --dump_dir directory')
+    ap.add_argument('--layers', type=int, default=28)
+    ap.add_argument('--prefill-len', type=int, default=24)
+    ap.add_argument('--steps', type=int, default=8)
+    ap.add_argument('--quant', choices=['none', 'int8', 'int4'],
+                    default='none',
+                    help='check: quantize+dequantize FC weights like the C++ '
+                         'loader before running the reference')
+    ap.add_argument('--gptq',
+                    help='check: fake-quant FC weights from a GPTQ companion '
+                         'safetensors (gptq_quantize.py output); overrides '
+                         '--quant')
+    ap.add_argument('--real-prompt', action='store_true',
+                    help='use the production dual-track prompt (tokenizer + '
+                         'text projection from the checkpoint) instead of the '
+                         'random embedding; gen also writes text_track.f32. '
+                         'Forces prefill_len=10.')
+    args = ap.parse_args()
+
+    if args.real_prompt:
+        args.prefill_len = 10
+
+    if args.mode == 'gen':
+        if args.real_prompt:
+            emb, track = build_real_prompt(args.weights, args.steps)
+            track.tofile(f'{args.out}/text_track.f32')
+            print(f'wrote {args.out}/text_track.f32 {track.shape}')
+        else:
+            emb = make_prefill_emb(args.prefill_len)
+        path = f'{args.out}/prefill_emb.f32'
+        emb.tofile(path)
+        print(f'wrote {path} {emb.shape}')
+        return
+
+    prefill_emb, text_track = (build_real_prompt(args.weights, args.steps)
+                               if args.real_prompt else (None, None))
+    frames, logits, feedback = run_reference(
+        args.weights, args.layers, args.prefill_len, args.steps, args.quant,
+        prefill_emb, text_track, gptq=args.gptq)
+
+    n = args.steps + 1
+    c_frames = np.fromfile(f'{args.dump}/frames.i32',
+                           np.int32).reshape(n, GROUPS)
+    c_logits = np.fromfile(f'{args.dump}/cb0_logits.f32',
+                           np.float32).reshape(n, TALKER_VOCAB)
+    c_feedback = np.fromfile(f'{args.dump}/feedback.f32',
+                             np.float32).reshape(n, EMB)
+
+    ok = True
+    for t in range(n):
+        id_match = np.array_equal(frames[t], c_frames[t])
+        dl = np.abs(logits[t] - c_logits[t])
+        rel = dl.max() / (np.abs(logits[t]).max() + 1e-9)
+        df = np.abs(feedback[t] - c_feedback[t]).max()
+        status = 'OK ' if id_match else 'IDS DIFFER'
+        print(f'frame {t}: {status} logits max|d|={dl.max():.4e} '
+              f'(rel {rel:.2e}) feedback max|d|={df:.4e}')
+        if not id_match:
+            ok = False
+            bad = np.nonzero(frames[t] != c_frames[t])[0]
+            for g in bad[:4]:
+                print(f'  group {g}: ref={frames[t][g]} cpp={c_frames[t][g]}')
+    print('EQUIVALENCE: ' + ('PASS (all frame ids match)' if ok else 'FAIL'))
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Thanks for setting up the new `models/` layout (#238) and the
`models/qwen/qwen3_tts/tensor_api/` home — this PR fills that directory
with the Qwen3-TTS Tensor API reference implementation. No weights are
included, and nothing here is time-sensitive; happy to reshape any of it
to your conventions.

**What this adds**

- `talker_step/` — the talker decode-step graph authored with the C++
  Tensor API: `prefill`/`decode` signatures sharing weights, fixed-size KV
  caches as signature I/O (DynamicUpdateSlice at a runtime position,
  zero-copy output→input rebind), codebook-0 pick + 15-group code
  predictor + next-frame feedback aggregation in-graph — one signature
  call per 12.5 Hz frame. Weight paths: fp32, int8 per-channel, int4
  blockwise-32, pre-quantized (GPTQ) companion files. Host-staged additive
  bias input covers suppression, EOS gating, min-new-tokens, and exact
  temperature sampling (Gumbel noise-as-input).
- `codec_decode/` — the full speech_tokenizer decoder (RVQ + transformer
  + vocoder) as one Tensor API graph.
- `verify/` — independent numpy references for both graphs (the C++
  graphs are bit-exact against them on the real checkpoint), the GPTQ
  quantizer emitting the exact blockwise-32 layout the loader consumes,
  speaker x-vector enrollment, and an end-to-end text→wav smoke driver.
- `talker_step/attn_bench.cc` — attention micro-benchmark: raw ops vs
  `odml.scaled_dot_product_attention` vs the `odml.runtime_bmm` +
  `odml.cache_update` composite pair, with CPU decompositions as the
  numeric reference; includes multi-step feedback-loop runs (LiteRT
  PR #8796).
- The models adopt `odml.runtime_bmm` and `odml.rms_norm` via build flags.

**Build**

BUILD files target this repository's `@litert_archive` workspace; the one
helper whose `select()` keys don't survive a cross-repository load
(`commandline_flag_copts`) is inlined. One dependency is adapted to
current `main`: the binaries no longer depend on
`litert/cc:litert_api_with_dynamic_runtime` (matching the current gemma3
example) — with it, the runtime gets linked twice on `main` (duplicate
`GetLiteRtRuntimeBuiltin` at the Android link). From the repo root:

```
bazel build --config=macos_arm64 //models/qwen/qwen3_tts/tensor_api/talker_step:talker_main
bazel build --config=macos_arm64 //models/qwen/qwen3_tts/tensor_api/codec_decode:codec_main
ANDROID_NDK_HOME=<ndk> bazel build -c opt --config=android_arm64 \
  --incompatible_enable_cc_toolchain_resolution \
  --incompatible_enable_android_toolchain_resolution \
  //models/qwen/qwen3_tts/tensor_api/talker_step:talker_main
```

The Android arm64 binaries (talker_main, attn_bench, codec_main) build
and link from this workspace against current LiteRT `main`; on macOS all
sources compile, and the final link stops at a workspace-level signing
issue described below.

**Provenance and verification**

- Sources are the same as
  [john-rocky/litert-tensor-audio-examples](https://github.com/john-rocky/litert-tensor-audio-examples),
  adapted to this layout. Validated at LiteRT `a19d8fa` + the PR #8796
  runner change; if anything drifts against current `main`, tell us and
  we will chase it.
- Measured highlights are in the README (Pixel 8a CPU GPTQ int4 99.6
  ms/frame = RTF 1.24; M4 Max Metal GPTQ int4 + composite stack 17.3
  ms/frame = RTF 0.216; two-window measurement protocol).
- We kept the standalone bug-repro tools (the int4 two-signature Metal
  repro, the delegate-init OOM logger) in the external repo to keep this
  sample user-facing — happy to add them here too if you'd rather have
  everything in one place.

**Three build observations on the current workspace (independent of this
PR — sharing them since a reviewer will hit them before reaching this
code)**

- The checked-in `.bazelrc.user` overrides the Apple toolchain config
  with a crosstool target that doesn't exist in the pinned apple_support
  (plus a machine-local Xcode path and an iPhoneSimulator SDKROOT), so
  any `--config=macos*` build fails in analysis until that file is
  removed — it may have been committed unintentionally.
- With it removed, LiteRT `main` compiles from source end-to-end here,
  but the `SignBinary` action for `litert_runtime_c_api` fails: the
  rules_apple `codesigningtool` py stub comes out with unsubstituted
  rules_python placeholders (`%interpreter_args%` …) under the hermetic
  Python setup; same result with rules_apple 4.5.0 and 3.22.0. All our
  translation units compile cleanly against LiteRT `main`; the dylib
  signing step is where a macOS build currently stops.
- `build:android_arm64` in this repository's `.bazelrc` is missing the
  two toolchain-resolution lines LiteRT's own `.bazelrc` has
  (`--incompatible_enable_cc_toolchain_resolution` and
  `--incompatible_enable_android_toolchain_resolution`); since the NDK
  is wired via rules_android_ndk (resolution-style only), plain
  `--config=android_arm64` fails analysis. Passing both flags on the
  command line works — the READMEs note this until the config carries
  them.

Happy to send a small separate PR for any of these if that's welcome —
otherwise just flagging what we saw.
