### PR TITLE
Add LLaDA-8B diffusion-LM Tensor API implementation (in-graph denoise step)

### DIFF
--- a/models/llada/llada_8b/tensor_api/BUILD
+++ b/models/llada/llada_8b/tensor_api/BUILD
@@ -1,0 +1,83 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(
+    "@litert_archive//litert/build_common:special_rule.bzl",
+    "litert_android_linkopts",
+    "litert_gpu_accelerator_prebuilts",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "diffusion_graph",
+    srcs = ["diffusion_graph.cc"],
+    hdrs = ["diffusion_graph.h"],
+    deps = [
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/strings",
+        "@flatbuffers",
+    ],
+)
+
+cc_library(
+    name = "diffusion_weights",
+    srcs = ["diffusion_weights.cc"],
+    hdrs = ["diffusion_weights.h"],
+    deps = [
+        ":diffusion_graph",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/examples/gemma3:safetensor_loader",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_binary(
+    name = "diffusion_main",
+    srcs = ["diffusion_main.cc"],
+    copts = ["-DGOOGLE_COMMANDLINEFLAGS_FULL_API=1"] + select({
+        "@litert_archive//litert:android": ["-DABSL_FLAGS_STRIP_NAMES=0"],
+        "//conditions:default": [],
+    }),
+    data = litert_gpu_accelerator_prebuilts(),
+    linkopts = litert_android_linkopts(),
+    deps = [
+        ":diffusion_graph",
+        ":diffusion_weights",
+        "@litert_archive//litert/cc:litert_common",
+        "@litert_archive//litert/cc:litert_environment",
+        "@litert_archive//litert/cc:litert_options",
+        "@litert_archive//litert/cc/options:litert_gpu_options",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:tflite_flatbuffer_conversion",
+        "@litert_archive//tensor/runners/litert:litert_dynamic_runner",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)

--- a/models/llada/llada_8b/tensor_api/README.md
+++ b/models/llada/llada_8b/tensor_api/README.md
@@ -1,0 +1,91 @@
+# LLaDA-8B Tensor API Implementation
+
+Diffusion-LM denoise step for LLaDA-8B-Base, authored directly with the
+[LiteRT Tensor API](https://github.com/google-ai-edge/LiteRT/tree/main/tensor)
+(C++, no converter).
+
+## This project demonstrates:
+
+1.  One in-graph denoise step for a masked-diffusion LM: bidirectional
+    backbone + ScatterNd-free top-k remasking (TopK → OneHot → Sum →
+    SelectV2); the host only feeds ids back between steps.
+2.  Loading the real LLaDA-8B-Base checkpoint: `--llada` selects the 8B
+    architecture (32L, MHA 32/32, d_model 4096, rope 5e5, no qk-norm) and
+    the sharded-safetensors loader maps the OLMo-style checkpoint names.
+    Without `--llada`, a Qwen3-shaped GQA config runs smaller probes, and
+    without `--weights` the step runs on synthetic weights.
+3.  Composite options in an authored graph: `--attention=raw|sdpa`
+    (`sdpa` keeps MHA shapes plain BSND and pre-folds GQA into batched
+    MHA) and `--norms=raw|composite` (`odml.rms_norm`). For CPU-parity
+    verification use `--attention=raw --norms=raw`.
+4.  In-process weight quantization (`--weight_quant=int8|int4`; int4 =
+    blockwise-32 with fp16 scales) and `--reuse_tflite` for on-device
+    runs without the checkpoint.
+5.  Explicit GPU precision control (`--gpu_precision=default|fp16|fp32`)
+    — the Metal delegate default is fp16; label numbers accordingly.
+
+## Prerequisites
+
+1.  **Bazel**: installed via bazelisk (version pinned by `.bazelversion`).
+2.  **Android NDK** 26+ for Android builds (tested with r27) and **ADB**
+    for on-device runs.
+3.  **Weights**: the GSAI-ML/LLaDA-8B-Base checkpoint (sharded
+    safetensors) from Hugging Face, passed as a directory via `--weights`
+    — not included in this repository. Synthetic-weight runs need no
+    checkpoint.
+
+## Build Instructions
+
+All commands are run from the repository root (the workspace pulls LiteRT
+`main` as `@litert_archive`).
+
+```bash
+# macOS (Apple silicon)
+bazel build --config=macos_arm64 //models/llada/llada_8b/tensor_api:diffusion_main
+
+# Android (the two extra flags mirror LiteRT's own android_arm64 config;
+# needed until this repository's .bazelrc carries them)
+ANDROID_NDK_HOME=<ndk> bazel build -c opt --config=android_arm64 \
+  --incompatible_enable_cc_toolchain_resolution \
+  --incompatible_enable_android_toolchain_resolution \
+  //models/llada/llada_8b/tensor_api:diffusion_main
+```
+
+Runtime behavior was validated at LiteRT commit `a19d8fa` plus the
+PR #8796 runner change; against current `main`, all sources compile and
+the Android arm64 binary builds and links from this workspace. Please
+tell us if anything else drifts and we will chase it.
+
+## Run
+
+```bash
+# Synthetic smoke (no checkpoint needed)
+diffusion_main --layers=4 --seq_len=256 --unmask_k=8 --accelerator=cpu
+
+# Real LLaDA-8B weights
+diffusion_main --llada --weights=<ckpt_dir> --accelerator=gpu \
+  --gpu_precision=fp32
+```
+
+GPU runs on macOS need `libLiteRtMetalAccelerator.dylib` (shipped in the
+target's runfiles) in the working directory.
+
+## Measured highlights
+
+*   Correctness: the C++ graph and an independent numpy reference produce
+    identical per-step id trajectories over the full denoise schedule
+    (real weights); int4 ids identical to fp32.
+*   Full 32L LLaDA-8B runs on-device: Pixel 8a CPU int4 (6.29 GB model,
+    memory-mapped) completes the schedule with ids identical to desktop.
+*   M4 Max, 8L/vocab-4096 probe, ms/step: int8 81.6 vs int4 791.5 —
+    XNNPACK blockwise-int4 fast kernels are GEMV-shape-only today, so
+    full-sequence diffusion steps (M=64 GEMM) want per-channel int8 on
+    CPU; int4 wins only for autoregressive decode shapes.
+*   Metal fp32, S=1024: `--attention=sdpa` −3.8%/step (fp16 −2.5%),
+    neutral at S=256.
+
+## Findings ledger and evidence notes
+
+The living findings ledger and per-campaign evidence notes are maintained
+at
+[john-rocky/litert-tensor-audio-examples](https://github.com/john-rocky/litert-tensor-audio-examples).

--- a/models/llada/llada_8b/tensor_api/diffusion_graph.cc
+++ b/models/llada/llada_8b/tensor_api/diffusion_graph.cc
@@ -1,0 +1,414 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Diffusion-LM denoise-step scaffold — Stage 0. See diffusion_graph.h.
+
+#include "models/llada/llada_8b/tensor_api/diffusion_graph.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/log/absl_check.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+#include "tensor/arithmetic.h"
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::diffusion {
+
+namespace {
+
+TfTensor ConstF(float value) {
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>({value})});
+}
+
+TfTensor ConstI(int32_t value) {
+  return TfTensor({.type = Type::kI32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kI32>({value})});
+}
+
+std::vector<float> SyntheticData(size_t count, unsigned& state, float scale) {
+  std::vector<float> data(count);
+  for (size_t i = 0; i < count; ++i) {
+    state = state * 1664525u + 1013904223u;
+    data[i] = scale * (static_cast<float>(state >> 8) /
+                           static_cast<float>(1u << 24) * 2.0f -
+                       1.0f);
+  }
+  return data;
+}
+
+TfTensor SyntheticWeight(const std::string& name, const std::vector<int>& shape,
+                         unsigned& state, float scale = 0.02f) {
+  size_t count = 1;
+  for (int d : shape) count *= static_cast<size_t>(d);
+  return TfTensor({.name = name,
+                   .type = Type::kFP32,
+                   .shape = shape,
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>(
+                       SyntheticData(count, state, scale))});
+}
+
+const TfTensor& GetWeight(const WeightMap& weights, const std::string& name) {
+  auto it = weights.find(name);
+  ABSL_CHECK(it != weights.end()) << "missing weight: " << name;
+  return it->second;
+}
+
+bool g_rms_norm_composite = false;
+
+TfTensor RmsNormRaw(const TfTensor& input, const TfTensor& scale, float eps) {
+
+  TfTensor x_squared = Mul(input, input);
+  int last_axis = static_cast<int>(input.GetShape().size()) - 1;
+  TfTensor mean_squared = Mean(x_squared, {last_axis}, /*keep_dims=*/true);
+  TfTensor inv_rms = Rsqrt(Add(mean_squared, ConstF(eps)));
+  return Mul(Mul(input, inv_rms), scale);
+}
+
+std::vector<uint8_t> RmsNormAttributes(float eps) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() { fbb.Float("epsilon", eps); });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// RMS norm, optionally as the odml.rms_norm composite (fused ML Drift
+// kernels; the decomposition is the raw math).
+TfTensor RmsNorm(const TfTensor& input, const TfTensor& scale, float eps) {
+  if (!g_rms_norm_composite) return RmsNormRaw(input, scale, eps);
+  StableHLOCompositeOptions opts{.name = "odml.rms_norm",
+                                 .composite_attributes =
+                                     RmsNormAttributes(eps)};
+  return StableHLOComposite(
+      opts,
+      [eps](TfTensor x, TfTensor s) { return RmsNormRaw(x, s, eps); }, input,
+      scale);
+}
+
+TfTensor Silu(const TfTensor& x) { return Mul(x, Logistic(x)); }
+
+TfTensor ApplyRope(const TfTensor& x, const TfTensor& cos,
+                   const TfTensor& sin) {
+  const auto& s = x.GetShape();
+  int half = s[3] / 2;
+  TfTensor x1 = Slice(x, {0, 0, 0, 0}, {s[0], s[1], s[2], half});
+  TfTensor x2 = Slice(x, {0, 0, 0, half}, {s[0], s[1], s[2], half});
+  TfTensor rotated = Concatenation({Mul(x2, ConstF(-1.0f)), x1}, /*axis=*/3);
+  return Add(Mul(x, cos), Mul(rotated, sin));
+}
+
+// HF-pairing GQA attention core without materializing repeated K/V: fold the
+// kv groups into the batch axis and each group's q heads into the sequence
+// axis, so q head h reads kv group h / (heads/kv) — repeat_interleave
+// semantics. (A plain Tile pairs head h with group h % kv instead — wrong
+// whenever 1 < kv < heads; Gather-axis-1 repeat is rejected by the Metal
+// delegate.) Bidirectional: no mask. q [1, heads, S, hd], k/v [1, kv, S, hd].
+TfTensor GqaAttention(const TfTensor& q, const TfTensor& k, const TfTensor& v,
+                      int n_heads, int n_kv_groups, int head_dim) {
+  int g = n_heads / n_kv_groups;
+  int S = q.GetShape()[2];
+  float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+
+  TfTensor qg = Reshape(q, {n_kv_groups, 1, g * S, head_dim});
+  TfTensor kg = Reshape(k, {n_kv_groups, 1, S, head_dim});
+  TfTensor vg = Reshape(v, {n_kv_groups, 1, S, head_dim});
+
+  TfTensor scores = BatchMatMul(qg, kg, /*adj_x=*/false, /*adj_y=*/true);
+  scores = Reshape(scores, {1, n_heads, S, S});
+  scores = Mul(scores, ConstF(scale));
+  TfTensor attn = Softmax(scores);
+  attn = Reshape(attn, {n_kv_groups, 1, g * S, S});
+  TfTensor out = BatchMatMul(attn, vg);
+  return Reshape(out, {1, n_heads, S, head_dim});
+}
+
+std::vector<uint8_t> SdpaAttributes(float scale) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() { fbb.Float("scale", scale); });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// Plain-BSND sdpa applies to MHA shapes (and to GQA only as the
+// sdpa_nofold wrong-result repro); folded GQA runs BNSD like raw.
+bool UseBsndSdpa(const DiffusionConfig& config) {
+  return config.use_sdpa_composite &&
+         (config.n_kv_groups == config.n_heads || config.sdpa_skip_gqa_fold);
+}
+
+// Full-sequence bidirectional attention as the odml.scaled_dot_product_
+// attention composite. Inputs stay BSND ([1, S, heads, dim] — the delegate
+// contract; no mask input, the model is bidirectional). The decomposition
+// transposes to BNSD and runs the same GqaAttention fold as the raw path,
+// so CPU execution matches raw exactly.
+TfTensor SdpaAttention(const DiffusionConfig& config, const TfTensor& q,
+                       const TfTensor& k, const TfTensor& v) {
+  const float scale = 1.0f / std::sqrt(static_cast<float>(config.head_dim));
+  StableHLOCompositeOptions opts{
+      .name = "odml.scaled_dot_product_attention",
+      .composite_attributes = SdpaAttributes(scale)};
+  const int n_heads = config.n_heads;
+  const int n_kv_groups = config.n_kv_groups;
+  const int head_dim = config.head_dim;
+  return StableHLOComposite(
+      opts,
+      [n_heads, n_kv_groups, head_dim](TfTensor dq, TfTensor dk, TfTensor dv) {
+        TfTensor qt = Transpose(dq, {0, 2, 1, 3});  // [1,H,S,D]
+        TfTensor kt = Transpose(dk, {0, 2, 1, 3});
+        TfTensor vt = Transpose(dv, {0, 2, 1, 3});
+        TfTensor o = GqaAttention(qt, kt, vt, n_heads, n_kv_groups, head_dim);
+        return Transpose(o, {0, 2, 1, 3});  // back to [1,S,H,D]
+      },
+      q, k, v);
+}
+
+// GQA-folded sdpa: fold groups into the batch axis OUTSIDE the composite
+// and present each group as single-head MHA over g*S query rows —
+// [G, g*S, 1, D] q vs [G, S, 1, D] k/v in BSND terms. Semantically this is
+// exactly the raw GqaAttention fold, so the kernel only ever sees an MHA
+// shape (the form Metal computes correctly). Operands arrive BNSD
+// ([1,H,S,D] / [1,G,S,D]) since the fold needs head-major memory order.
+TfTensor SdpaAttentionGqaFolded(const DiffusionConfig& config,
+                                const TfTensor& q, const TfTensor& k,
+                                const TfTensor& v) {
+  const float scale = 1.0f / std::sqrt(static_cast<float>(config.head_dim));
+  const int G = config.n_kv_groups;
+  const int g = config.n_heads / G;
+  const int S = config.seq_len;
+  const int D = config.head_dim;
+  TfTensor qf = Reshape(q, {G, g * S, 1, D});
+  TfTensor kf = Reshape(k, {G, S, 1, D});
+  TfTensor vf = Reshape(v, {G, S, 1, D});
+  StableHLOCompositeOptions opts{
+      .name = "odml.scaled_dot_product_attention",
+      .composite_attributes = SdpaAttributes(scale)};
+  const int H = config.n_heads;
+  auto body = [scale, G, g, S, D, H](TfTensor dq, TfTensor dk, TfTensor dv) {
+        // Axis-1<->2 swaps with a size-1 axis preserve linear order, so
+        // Reshape (a view) stands in for Transpose here. That keeps the
+        // decomposition op-for-op identical to the raw GqaAttention fold
+        // (same shapes into BMM/Softmax, no transpose->BMM fusion
+        // ambiguity), so CPU execution matches raw bit-for-bit.
+        TfTensor qt = Reshape(dq, {G, 1, g * S, D});
+        TfTensor kt = Reshape(dk, {G, 1, S, D});
+        TfTensor vt = Reshape(dv, {G, 1, S, D});
+        TfTensor scores = BatchMatMul(qt, kt, /*adj_x=*/false, /*adj_y=*/true);
+        scores = Reshape(scores, {1, H, S, S});
+        scores = Mul(scores, ConstF(scale));
+        TfTensor attn = Softmax(scores);
+        attn = Reshape(attn, {G, 1, g * S, S});
+        TfTensor o = BatchMatMul(attn, vt);          // [G,1,g*S,D]
+        return Reshape(o, {G, g * S, 1, D});
+      };
+  TfTensor out = config.sdpa_fold_direct
+                     ? body(qf, kf, vf)
+                     : StableHLOComposite(opts, body, qf, kf, vf);
+  return Reshape(out, {1, H, S, D});                 // back to BNSD
+}
+
+// Bidirectional GQA attention over the full sequence — no causal mask, no
+// cache. This is the structural difference from the talker step graph.
+// sdpa mode keeps everything BSND (the two BNSD transposes move inside the
+// composite decomposition, off the delegate graph); qk-norm and rope act on
+// the last axis only, so they run identically in either layout.
+TfTensor BidirectionalAttention(const DiffusionConfig& config,
+                                const TfTensor& input, const std::string& prefix,
+                                const DiffusionInputs& inputs,
+                                const WeightMap& weights) {
+  int S = config.seq_len;
+  const bool bsnd = UseBsndSdpa(config);
+
+  TfTensor q = FullyConnected(input, GetWeight(weights, prefix + ".q_proj.weight"));
+  TfTensor k = FullyConnected(input, GetWeight(weights, prefix + ".k_proj.weight"));
+  TfTensor v = FullyConnected(input, GetWeight(weights, prefix + ".v_proj.weight"));
+
+  q = Reshape(q, {1, S, config.n_heads, config.head_dim});
+  k = Reshape(k, {1, S, config.n_kv_groups, config.head_dim});
+  v = Reshape(v, {1, S, config.n_kv_groups, config.head_dim});
+  if (!bsnd) {
+    q = Transpose(q, {0, 2, 1, 3});
+    k = Transpose(k, {0, 2, 1, 3});
+    v = Transpose(v, {0, 2, 1, 3});
+  }
+
+  if (config.use_qk_norm) {
+    q = RmsNorm(q, GetWeight(weights, prefix + ".q_norm.weight"),
+                config.rms_norm_eps);
+    k = RmsNorm(k, GetWeight(weights, prefix + ".k_norm.weight"),
+                config.rms_norm_eps);
+  }
+
+  // BuildDenoiseStep hands rope tables pre-transposed to [1,S,1,D] in BSND
+  // mode, so ApplyRope broadcasts correctly in both layouts.
+  q = ApplyRope(q, inputs.rope_cos, inputs.rope_sin);
+  k = ApplyRope(k, inputs.rope_cos, inputs.rope_sin);
+
+  TfTensor out;
+  if (bsnd) {
+    out = SdpaAttention(config, q, k, v);  // [1,S,H,D]
+  } else if (config.use_sdpa_composite) {
+    out = SdpaAttentionGqaFolded(config, q, k, v);  // BNSD in/out
+    out = Transpose(out, {0, 2, 1, 3});
+  } else {
+    out = GqaAttention(q, k, v, config.n_heads, config.n_kv_groups,
+                       config.head_dim);
+    out = Transpose(out, {0, 2, 1, 3});
+  }
+  out = Reshape(out, {1, S, config.qkv_out_dim()});
+  return FullyConnected(out, GetWeight(weights, prefix + ".o_proj.weight"));
+}
+
+TfTensor FeedForward(const TfTensor& input, const std::string& prefix,
+                     const WeightMap& weights) {
+  TfTensor gate = FullyConnected(input, GetWeight(weights, prefix + ".gate_proj.weight"));
+  TfTensor up = FullyConnected(input, GetWeight(weights, prefix + ".up_proj.weight"));
+  return FullyConnected(Mul(Silu(gate), up),
+                        GetWeight(weights, prefix + ".down_proj.weight"));
+}
+
+}  // namespace
+
+std::vector<TfTensor> DiffusionInputs::AsList() const {
+  return {token_ids, rope_cos, rope_sin};
+}
+
+std::vector<TfTensor> DiffusionOutputs::AsList() const {
+  return {new_token_ids, masked_count};
+}
+
+DiffusionInputs MakeDiffusionInputs(const DiffusionConfig& config) {
+  DiffusionInputs inputs;
+  inputs.token_ids = TfTensor({.name = "token_ids",
+                               .type = Type::kI32,
+                               .shape = {1, config.seq_len}});
+  inputs.rope_cos = TfTensor({.name = "rope_cos",
+                              .type = Type::kFP32,
+                              .shape = {1, 1, config.seq_len, config.head_dim}});
+  inputs.rope_sin = TfTensor({.name = "rope_sin",
+                              .type = Type::kFP32,
+                              .shape = {1, 1, config.seq_len, config.head_dim}});
+  return inputs;
+}
+
+WeightMap MakeSyntheticWeights(const DiffusionConfig& config, unsigned seed) {
+  WeightMap weights;
+  unsigned state = seed;
+  auto add = [&](const std::string& name, const std::vector<int>& shape,
+                 float scale = 0.02f) {
+    weights[name] = SyntheticWeight(name, shape, state, scale);
+  };
+
+  add("model.embed_tokens.weight", {config.vocab, config.emb_dim});
+  for (int i = 0; i < config.n_layers; ++i) {
+    std::string p = absl::StrCat("model.layers.", i);
+    add(p + ".input_layernorm.weight", {config.emb_dim}, 1.0f);
+    add(p + ".self_attn.q_proj.weight", {config.qkv_out_dim(), config.emb_dim});
+    add(p + ".self_attn.k_proj.weight", {config.kv_out_dim(), config.emb_dim});
+    add(p + ".self_attn.v_proj.weight", {config.kv_out_dim(), config.emb_dim});
+    add(p + ".self_attn.o_proj.weight", {config.emb_dim, config.qkv_out_dim()});
+    if (config.use_qk_norm) {
+      add(p + ".self_attn.q_norm.weight", {config.head_dim}, 1.0f);
+      add(p + ".self_attn.k_norm.weight", {config.head_dim}, 1.0f);
+    }
+    add(p + ".post_attention_layernorm.weight", {config.emb_dim}, 1.0f);
+    add(p + ".mlp.gate_proj.weight", {config.hidden_dim, config.emb_dim});
+    add(p + ".mlp.up_proj.weight", {config.hidden_dim, config.emb_dim});
+    add(p + ".mlp.down_proj.weight", {config.emb_dim, config.hidden_dim});
+  }
+  add("model.norm.weight", {config.emb_dim}, 1.0f);
+  add("lm_head.weight", {config.vocab, config.emb_dim});
+  return weights;
+}
+
+DiffusionOutputs BuildDenoiseStep(const DiffusionConfig& config,
+                                  const DiffusionInputs& inputs,
+                                  const WeightMap& weights) {
+  g_rms_norm_composite = config.use_rms_norm_composite;
+  int S = config.seq_len;
+
+  // BSND sdpa keeps attention tensors BSND; transpose the rope tables once
+  // ([1,1,S,D] -> [1,S,1,D]) so ApplyRope broadcasts on the heads axis.
+  DiffusionInputs attn_inputs = inputs;
+  if (UseBsndSdpa(config)) {
+    attn_inputs.rope_cos = Transpose(inputs.rope_cos, {0, 2, 1, 3});
+    attn_inputs.rope_sin = Transpose(inputs.rope_sin, {0, 2, 1, 3});
+  }
+
+  // --- Embedding (1-D Gather indices for the Metal delegate) ---
+  TfTensor ids_flat = Reshape(inputs.token_ids, {S});  // [S]
+  TfTensor hidden = Gather(GetWeight(weights, "model.embed_tokens.weight"),
+                           ids_flat, /*axis=*/0);      // [S, emb]
+  hidden = Reshape(hidden, {1, S, config.emb_dim});
+
+  // --- Bidirectional backbone ---
+  for (int i = 0; i < config.n_layers; ++i) {
+    std::string p = absl::StrCat("model.layers.", i);
+    TfTensor attn_in = RmsNorm(
+        hidden, GetWeight(weights, p + ".input_layernorm.weight"),
+        config.rms_norm_eps);
+    hidden = Add(hidden, BidirectionalAttention(config, attn_in,
+                                                p + ".self_attn", attn_inputs,
+                                                weights));
+    TfTensor ffn_in = RmsNorm(
+        hidden, GetWeight(weights, p + ".post_attention_layernorm.weight"),
+        config.rms_norm_eps);
+    hidden = Add(hidden, FeedForward(ffn_in, p + ".mlp", weights));
+  }
+  hidden = RmsNorm(hidden, GetWeight(weights, "model.norm.weight"),
+                   config.rms_norm_eps);
+
+  // --- In-graph remasking schedule ---
+  TfTensor logits = FullyConnected(hidden, GetWeight(weights, "lm_head.weight"));
+  // [1, S, vocab]
+  TfTensor probs = Softmax(logits);
+  TfTensor pred_ids = ArgMax(logits, -1, Type::kI32);        // [1, S]
+  TfTensor conf = ReduceMax(probs, {2}, /*keep_dims=*/false);  // [1, S]
+
+  // Only still-masked positions compete for unmasking.
+  TfTensor is_masked = Equal(inputs.token_ids, ConstI(config.mask_id));  // bool
+  TfTensor conf_masked = Mul(conf, Cast(is_masked, Type::kFP32));
+
+  // Top-k most confident masked positions -> a 0/1 update mask via OneHot+Sum
+  // (ScatterNd-free — Phase 0 noted ScatterNd is absent from the op set).
+  std::vector<TfTensor> topk = TopK(conf_masked, config.unmask_k);
+  TfTensor topk_indices = topk[1];                            // [1, k] kI32
+  TfTensor onehot = OneHot(topk_indices, ConstI(S), ConstF(1.0f), ConstF(0.0f),
+                           /*axis=*/-1);                      // [1, k, S]
+  TfTensor update_mask = Sum(onehot, {1}, /*keep_dims=*/false);  // [1, S]
+  TfTensor do_update = Greater(update_mask, ConstF(0.5f));       // bool [1, S]
+
+  TfTensor new_ids = SelectV2(do_update, pred_ids, inputs.token_ids);
+  new_ids.SetName("new_token_ids");
+
+  // Remaining masked count (after this update) for the host stop condition.
+  TfTensor still_masked = Equal(new_ids, ConstI(config.mask_id));
+  TfTensor masked_count =
+      Sum(Cast(still_masked, Type::kI32), {1}, /*keep_dims=*/false);  // [1]
+  masked_count.SetName("masked_count");
+
+  DiffusionOutputs outputs;
+  outputs.new_token_ids = new_ids;
+  outputs.masked_count = masked_count;
+  return outputs;
+}
+
+}  // namespace litert::tensor::examples::diffusion

--- a/models/llada/llada_8b/tensor_api/diffusion_graph.h
+++ b/models/llada/llada_8b/tensor_api/diffusion_graph.h
@@ -1,0 +1,109 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Diffusion-LM denoise-step scaffold — Stage 0 (synthetic weights).
+//
+// One masked-diffusion denoise step (LLaDA-style) authored on the LiteRT
+// Tensor API TfLite backend. The whole per-step schedule is IN-GRAPH:
+// bidirectional transformer over the full sequence (no causal mask, no KV
+// cache) -> logits -> greedy predictions + confidence -> pick the top-k most
+// confident still-masked positions (TopK + OneHot + SelectV2 — no ScatterNd
+// needed) -> emit the updated token ids. The host loop only feeds ids back
+// for T = masked/k steps.
+//
+// Everything uses ops with tflite emission today; no Custom().
+
+#ifndef SPEECHLM_STAGE1_DIFFUSION_STEP_DIFFUSION_GRAPH_H_
+#define SPEECHLM_STAGE1_DIFFUSION_STEP_DIFFUSION_GRAPH_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "tensor/backends/tflite/arithmetic_tflite.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::diffusion {
+
+using TfTensor = ::litert::tensor::Tensor<::litert::tensor::TfLiteMixinTag>;
+using WeightMap = absl::flat_hash_map<std::string, TfTensor>;
+
+struct DiffusionConfig {
+  // Backbone (Qwen3-0.6B-shaped placeholder; LLaDA-style models are larger —
+  // Stage 1 aligns dims with the chosen checkpoint).
+  int emb_dim = 1024;
+  int n_layers = 28;
+  int n_heads = 16;
+  int n_kv_groups = 8;
+  int head_dim = 128;
+  int hidden_dim = 3072;
+  float rms_norm_eps = 1e-6f;
+  float rope_base = 1000000.0f;
+  // Qwen3 applies per-head RMSNorm to q/k; LLaMA/OLMo-family (LLaDA) does not.
+  bool use_qk_norm = true;
+  // Emit RMS norms as the odml.rms_norm composite (fused ML Drift kernels;
+  // decomposition = the raw math, so CPU execution is unchanged).
+  bool use_rms_norm_composite = false;
+  // Emit the attention core as odml.scaled_dot_product_attention (BSND
+  // inputs, no mask — bidirectional). Decomposition = the same GqaAttention
+  // fold as the raw path, so CPU execution is numerically identical.
+  // MHA (n_kv_groups == n_heads) presents plain BSND. GQA presents the
+  // group-fold as batched MHA ([G, g*S, 1, D] q vs [G, S, 1, D] k/v):
+  // Metal CLAIMS un-folded grouped K/V at q_seq>1 but computes wrong
+  // results (2026-07-22 probe: every generated id differs from the CPU
+  // reference while raw GPU matches it exactly), so the un-folded form is
+  // kept only behind sdpa_nofold as the repro.
+  bool use_sdpa_composite = false;
+  // Repro switch for the wrong-result claim above: emit GQA sdpa WITHOUT
+  // the pre-fold. Ignored for MHA shapes (identical to use_sdpa_composite).
+  bool sdpa_skip_gqa_fold = false;
+  // Debug: run the folded-sdpa body as plain ops (no composite wrapper).
+  bool sdpa_fold_direct = false;
+
+  int seq_len = 256;    // full (fixed) generation window
+  int vocab = 32000;    // placeholder vocab
+  int mask_id = 31999;  // [MASK] token id (placeholder)
+  int unmask_k = 8;     // tokens revealed per step (static per signature)
+
+  int qkv_out_dim() const { return n_heads * head_dim; }
+  int kv_out_dim() const { return n_kv_groups * head_dim; }
+};
+
+struct DiffusionInputs {
+  TfTensor token_ids;  // [1, seq_len] kI32, mask_id at still-masked positions
+  TfTensor rope_cos;   // [1, 1, seq_len, head_dim]
+  TfTensor rope_sin;   // [1, 1, seq_len, head_dim]
+
+  std::vector<TfTensor> AsList() const;
+};
+
+struct DiffusionOutputs {
+  TfTensor new_token_ids;  // [1, seq_len] kI32, k more positions revealed
+  TfTensor masked_count;   // [1] kI32 — remaining masked positions (host stop)
+
+  std::vector<TfTensor> AsList() const;
+};
+
+DiffusionInputs MakeDiffusionInputs(const DiffusionConfig& config);
+
+WeightMap MakeSyntheticWeights(const DiffusionConfig& config, unsigned seed);
+
+// Traces one denoise step over `inputs`.
+DiffusionOutputs BuildDenoiseStep(const DiffusionConfig& config,
+                                  const DiffusionInputs& inputs,
+                                  const WeightMap& weights);
+
+}  // namespace litert::tensor::examples::diffusion
+
+#endif  // SPEECHLM_STAGE1_DIFFUSION_STEP_DIFFUSION_GRAPH_H_

--- a/models/llada/llada_8b/tensor_api/diffusion_main.cc
+++ b/models/llada/llada_8b/tensor_api/diffusion_main.cc
@@ -1,0 +1,353 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Diffusion-LM denoise-step scaffold — Stage 0 host reference loop.
+//
+// Builds the denoise-step signature with synthetic weights, then runs the
+// full masked-diffusion schedule: start from a prompt + all-[MASK] tail,
+// call the step signature until masked_count reaches zero. Everything per
+// step (predict, confidence, top-k unmask, id update) is in-graph; the host
+// only feeds ids back.
+//
+// Usage (from the litert-samples repository root):
+//   bazel build //models/llada/llada_8b/tensor_api:diffusion_main
+//   diffusion_main --layers=4 --seq_len=256 --unmask_k=8 --accelerator=cpu
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "tensor/backends/tflite/tflite_flatbuffer_conversion.h"
+#include "tensor/datatypes.h"
+#include "models/llada/llada_8b/tensor_api/diffusion_graph.h"
+#include "models/llada/llada_8b/tensor_api/diffusion_weights.h"
+#include "tensor/runners/litert/litert_dynamic_runner.h"
+#include "tensor/tensor.h"
+
+ABSL_FLAG(int, layers, 4, "Backbone layers (28 = full 0.6B shape)");
+ABSL_FLAG(bool, llada, false,
+          "Use the LLaDA-8B-Base shape (d_model 4096, MHA 32/32, head 128, "
+          "ffn 12288, rope 5e5, eps 1e-5, no QK norm, vocab 126464)");
+ABSL_FLAG(int, vocab, 0,
+          "Override vocab size (mask_id = vocab-1) for lightweight synthetic "
+          "smokes; 0 = config default. With --weights, slices the first N "
+          "rows of the embedding/head (equivalence runs).");
+ABSL_FLAG(std::string, weights, "",
+          "LLaDA-8B-Base checkpoint dir (sharded safetensors); empty = "
+          "synthetic weights");
+ABSL_FLAG(bool, trace_ids, false,
+          "Print full token ids after every step (numpy equivalence)");
+ABSL_FLAG(std::string, prompt_ids, "",
+          "Comma-separated token ids for the prompt prefix (real tokenizer); "
+          "overrides --prompt_len/LCG when set");
+ABSL_FLAG(std::string, weight_quant, "none",
+          "none|int4|int8 — blockwise-32 int4 / per-channel int8 RTN on the matmul weights "
+          "(real weights only)");
+ABSL_FLAG(int, seq_len, 256, "Generation window");
+ABSL_FLAG(int, prompt_len, 32, "Unmasked prompt prefix length");
+ABSL_FLAG(int, unmask_k, 8, "Tokens revealed per step");
+ABSL_FLAG(int, warmup, 2, "Warmup steps excluded from stats");
+ABSL_FLAG(std::string, accelerator, "cpu", "cpu|gpu");
+ABSL_FLAG(std::string, gpu_precision, "default",
+          "default|fp16|fp32 - GPU compute precision (delegate default = "
+          "fp16 on Apple silicon)");
+ABSL_FLAG(std::string, norms, "raw",
+          "raw|composite - emit RMS norms as raw ops or as the "
+          "odml.rms_norm composite (fused ML Drift kernels)");
+ABSL_FLAG(std::string, attention, "raw",
+          "raw|sdpa|sdpa_nofold - emit the attention core as raw fold ops or "
+          "as the odml.scaled_dot_product_attention composite (no mask; MHA "
+          "= plain BSND, GQA = group-fold presented as batched MHA). "
+          "sdpa_nofold skips the GQA fold — the Metal wrong-result repro");
+ABSL_FLAG(std::string, tflite_path, "/tmp/diffusion_step.tflite",
+          "Where to write the serialized model");
+ABSL_FLAG(bool, reuse_tflite, false,
+          "Load tflite_path directly and skip weight loading + graph build "
+          "(for device runs without the checkpoint)");
+
+namespace {
+
+using ::litert::tensor::Create;
+using ::litert::tensor::LitertDynamicRunner;
+using ::litert::tensor::ModelFactory;
+using ::litert::tensor::Type;
+namespace diffusion = ::litert::tensor::examples::diffusion;
+
+void BuildRopeCosSin(int seq, int head_dim, float base,
+                     std::vector<float>& cos_out, std::vector<float>& sin_out) {
+  cos_out.resize(static_cast<size_t>(seq) * head_dim);
+  sin_out.resize(static_cast<size_t>(seq) * head_dim);
+  int half = head_dim / 2;
+  for (int s = 0; s < seq; ++s) {
+    for (int i = 0; i < half; ++i) {
+      float freq = std::pow(base, -2.0f * static_cast<float>(i) / head_dim);
+      float angle = static_cast<float>(s) * freq;
+      cos_out[s * head_dim + i] = std::cos(angle);
+      cos_out[s * head_dim + half + i] = std::cos(angle);
+      sin_out[s * head_dim + i] = std::sin(angle);
+      sin_out[s * head_dim + half + i] = std::sin(angle);
+    }
+  }
+}
+
+absl::Status RunDiffusion() {
+  if (const std::string n = absl::GetFlag(FLAGS_norms);
+      n != "raw" && n != "composite") {
+    return absl::InvalidArgumentError("--norms must be raw|composite");
+  }
+  if (const std::string a = absl::GetFlag(FLAGS_attention);
+      a != "raw" && a != "sdpa" && a != "sdpa_nofold" &&
+      a != "sdpa_folddirect") {
+    return absl::InvalidArgumentError(
+        "--attention must be raw|sdpa|sdpa_nofold|sdpa_folddirect");
+  }
+  diffusion::DiffusionConfig config;
+  if (absl::GetFlag(FLAGS_llada)) {
+    // LLaDA-8B-Base (confirmed against the checkpoint config.json 2026-07-21).
+    config.emb_dim = 4096;
+    config.n_layers = 32;
+    config.n_heads = 32;
+    config.n_kv_groups = 32;  // MHA
+    config.head_dim = 128;
+    config.hidden_dim = 12288;
+    config.rms_norm_eps = 1e-5f;
+    config.rope_base = 500000.0f;
+    config.use_qk_norm = false;
+    config.vocab = 126464;
+    config.mask_id = 126336;
+  }
+  // NOTE: this assignment used to sit inside the --llada branch, so
+  // --norms=composite was silently ignored for the default (1024-dim GQA)
+  // shape — the 7/22 "1024-dim neutral" data point was raw-vs-raw.
+  config.use_rms_norm_composite = absl::GetFlag(FLAGS_norms) == "composite";
+  if (config.use_rms_norm_composite) {
+    std::cout << "norms: odml.rms_norm composite" << std::endl;
+  }
+  const std::string attention_flag = absl::GetFlag(FLAGS_attention);
+  config.use_sdpa_composite = attention_flag != "raw";
+  config.sdpa_skip_gqa_fold = attention_flag == "sdpa_nofold";
+  config.sdpa_fold_direct = attention_flag == "sdpa_folddirect";
+  if (config.use_sdpa_composite) {
+    std::cout << "attention: odml.scaled_dot_product_attention composite "
+                 "(no mask"
+              << (config.sdpa_skip_gqa_fold ? ", GQA FOLD SKIPPED — repro mode"
+                                            : "")
+              << ")" << std::endl;
+  }
+  config.n_layers = absl::GetFlag(FLAGS_layers);
+  config.seq_len = absl::GetFlag(FLAGS_seq_len);
+  config.unmask_k = absl::GetFlag(FLAGS_unmask_k);
+  if (int v = absl::GetFlag(FLAGS_vocab); v > 0) {
+    config.vocab = v;
+    config.mask_id = v - 1;
+  }
+  const int prompt_len = absl::GetFlag(FLAGS_prompt_len);
+  const int warmup = absl::GetFlag(FLAGS_warmup);
+  const std::string tflite_path = absl::GetFlag(FLAGS_tflite_path);
+
+  std::cout << "arch: " << (absl::GetFlag(FLAGS_llada) ? "LLaDA-8B" : "Qwen3")
+            << " d_model " << config.emb_dim << " heads " << config.n_heads
+            << " kv " << config.n_kv_groups << " ffn " << config.hidden_dim
+            << " qk_norm " << config.use_qk_norm << " rope "
+            << config.rope_base << " vocab " << config.vocab << " mask_id "
+            << config.mask_id << std::endl;
+
+  diffusion::WeightMap weights;
+  const bool reuse_tflite = absl::GetFlag(FLAGS_reuse_tflite);
+  if (reuse_tflite) {
+    std::cout << "reusing serialized model: " << tflite_path << std::endl;
+  } else if (const std::string dir = absl::GetFlag(FLAGS_weights);
+             !dir.empty()) {
+    const std::string qm = absl::GetFlag(FLAGS_weight_quant);
+    const auto quant_mode =
+        qm == "int4" ? diffusion::WeightQuantMode::kInt4
+        : qm == "int8" ? diffusion::WeightQuantMode::kInt8
+                       : diffusion::WeightQuantMode::kNone;
+    auto weights_or = diffusion::LoadLladaWeights(config, dir, quant_mode);
+    if (!weights_or.ok()) return weights_or.status();
+    weights = std::move(*weights_or);
+    std::cout << "loaded " << weights.size() << " real tensors from " << dir
+              << std::endl;
+  } else {
+    weights = diffusion::MakeSyntheticWeights(config, /*seed=*/42);
+  }
+  if (!reuse_tflite) {
+    diffusion::DiffusionInputs step_in = diffusion::MakeDiffusionInputs(config);
+    diffusion::DiffusionOutputs step_out =
+        diffusion::BuildDenoiseStep(config, step_in, weights);
+
+    ModelFactory factory;
+    std::vector<::litert::tensor::TensorHandle> ins, outs;
+    for (auto& t : step_in.AsList()) ins.push_back(t);
+    for (auto& t : step_out.AsList()) outs.push_back(t);
+    auto status = factory.AddSignature(ins, outs, "denoise");
+    if (!status.ok()) return status;
+    auto save_status = factory.Save(tflite_path);
+    if (!save_status.ok()) return save_status;
+    std::cout << "Serialized: " << tflite_path << std::endl;
+  }
+
+  auto env = ::litert::Environment::Create({});
+  if (!env) return absl::InternalError("Environment::Create failed");
+  auto options = ::litert::Options::Create();
+  if (!options) return absl::InternalError("Options::Create failed");
+  options->SetHardwareAccelerators(absl::GetFlag(FLAGS_accelerator) == "gpu"
+                                       ? ::litert::HwAccelerators::kGpu
+                                       : ::litert::HwAccelerators::kCpu);
+  if (const std::string prec = absl::GetFlag(FLAGS_gpu_precision);
+      prec != "default") {
+    auto gpu_options = options->GetGpuOptions();
+    if (gpu_options.HasValue()) {
+      auto st = gpu_options->SetPrecision(
+          prec == "fp32" ? ::litert::GpuOptions::Precision::kFp32
+                         : ::litert::GpuOptions::Precision::kFp16);
+      if (!st) return absl::InternalError("SetPrecision failed");
+      std::cout << "gpu precision: " << prec << std::endl;
+    }
+  }
+  auto runner_or = LitertDynamicRunner::Create(*env, tflite_path, *options);
+  if (!runner_or.ok()) return runner_or.status();
+  auto runner = std::move(*runner_or);
+
+  // Static rope tables (positions never move — full-window bidirectional).
+  std::vector<float> cos_v, sin_v;
+  BuildRopeCosSin(config.seq_len, config.head_dim, config.rope_base, cos_v,
+                  sin_v);
+  auto st = runner.SetInput(
+      "denoise", "rope_cos",
+      Create("rope_cos", Type::kFP32, {1, 1, config.seq_len, config.head_dim},
+             std::vector<float>(cos_v)));
+  if (!st.ok()) return st;
+  st = runner.SetInput(
+      "denoise", "rope_sin",
+      Create("rope_sin", Type::kFP32, {1, 1, config.seq_len, config.head_dim},
+             std::vector<float>(sin_v)));
+  if (!st.ok()) return st;
+
+  // Initial ids: real-tokenizer prompt if given, else pseudo-random prefix;
+  // [MASK] tail either way.
+  std::vector<int32_t> ids(config.seq_len, config.mask_id);
+  int effective_prompt_len = prompt_len;
+  if (const std::string prompt_ids_flag = absl::GetFlag(FLAGS_prompt_ids);
+      !prompt_ids_flag.empty()) {
+    std::vector<int32_t> parsed;
+    size_t pos = 0;
+    while (pos < prompt_ids_flag.size()) {
+      size_t comma = prompt_ids_flag.find(',', pos);
+      if (comma == std::string::npos) comma = prompt_ids_flag.size();
+      parsed.push_back(std::stoi(prompt_ids_flag.substr(pos, comma - pos)));
+      pos = comma + 1;
+    }
+    if (static_cast<int>(parsed.size()) >= config.seq_len) {
+      return absl::InvalidArgumentError("prompt_ids longer than seq_len");
+    }
+    effective_prompt_len = static_cast<int>(parsed.size());
+    std::copy(parsed.begin(), parsed.end(), ids.begin());
+  } else {
+    unsigned state = 7u;
+    for (int i = 0; i < prompt_len; ++i) {
+      state = state * 1664525u + 1013904223u;
+      ids[i] = static_cast<int32_t>(state % (config.vocab - 1));
+    }
+  }
+
+  int masked = config.seq_len - effective_prompt_len;
+  int max_steps = (masked + config.unmask_k - 1) / config.unmask_k + 4;
+  std::vector<double> step_ms;
+  int step = 0;
+  auto wall0 = std::chrono::steady_clock::now();
+  while (masked > 0 && step < max_steps) {
+    st = runner.SetInput("denoise", "token_ids",
+                         Create("token_ids", Type::kI32, {1, config.seq_len},
+                                std::vector<int32_t>(ids)));
+    if (!st.ok()) return st;
+
+    auto t0 = std::chrono::steady_clock::now();
+    st = runner.Run("denoise");
+    auto t1 = std::chrono::steady_clock::now();
+    if (!st.ok()) return st;
+    if (step >= warmup) {
+      step_ms.push_back(
+          std::chrono::duration<double, std::milli>(t1 - t0).count());
+    }
+
+    auto ids_out = runner.GetOutput("denoise", "new_token_ids");
+    if (!ids_out.ok()) return ids_out.status();
+    auto buffer = ids_out->GetBuffer();
+    if (!buffer.ok()) return buffer.status();
+    {
+      auto lock = buffer->Lock();
+      const int32_t* data = reinterpret_cast<const int32_t*>(lock.data());
+      ids.assign(data, data + config.seq_len);
+    }
+    if (absl::GetFlag(FLAGS_trace_ids)) {
+      std::cout << "step " << step << " ids:";
+      for (int32_t id : ids) std::cout << " " << id;
+      std::cout << std::endl;
+    }
+    auto count_out = runner.GetOutput("denoise", "masked_count");
+    if (!count_out.ok()) return count_out.status();
+    auto count_buffer = count_out->GetBuffer();
+    if (!count_buffer.ok()) return count_buffer.status();
+    {
+      auto lock = count_buffer->Lock();
+      masked = reinterpret_cast<const int32_t*>(lock.data())[0];
+    }
+    ++step;
+  }
+  auto wall1 = std::chrono::steady_clock::now();
+
+  if (step_ms.empty()) return absl::InternalError("no timed steps");
+  std::sort(step_ms.begin(), step_ms.end());
+  double median = step_ms[step_ms.size() / 2];
+  double wall_s = std::chrono::duration<double>(wall1 - wall0).count();
+  int generated = config.seq_len - effective_prompt_len - masked;
+  std::cout << "layers=" << config.n_layers << " seq_len=" << config.seq_len
+            << " unmask_k=" << config.unmask_k
+            << " accelerator=" << absl::GetFlag(FLAGS_accelerator) << std::endl;
+  std::cout << "steps=" << step << " (remaining masked=" << masked
+            << "), median " << median << " ms/step" << std::endl;
+  std::cout << "generated " << generated << " tokens in " << wall_s
+            << " s => " << (generated / wall_s)
+            << " tok/s effective (parallel decode, " << config.unmask_k
+            << "/step in-graph)" << std::endl;
+  std::cout << "first generated ids:";
+  for (int i = effective_prompt_len;
+       i < std::min(effective_prompt_len + 8, config.seq_len); ++i)
+    std::cout << " " << ids[i];
+  std::cout << std::endl;
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  absl::Status status = RunDiffusion();
+  if (!status.ok()) {
+    std::cerr << "FAILED: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/models/llada/llada_8b/tensor_api/diffusion_weights.cc
+++ b/models/llada/llada_8b/tensor_api/diffusion_weights.cc
@@ -1,0 +1,312 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// LLaDA-8B-Base checkpoint loading. See diffusion_weights.h.
+
+#include "models/llada/llada_8b/tensor_api/diffusion_weights.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/strings/match.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/str_join.h"  // from @com_google_absl
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/examples/gemma3/safetensor_loader.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::diffusion {
+
+namespace {
+
+struct WeightSpec {
+  std::string graph_name;   // name BuildDenoiseStep looks up
+  std::string source_name;  // name in the checkpoint
+  std::vector<int> shape;   // expected shape after any vocab slice
+  int full_rows = 0;        // checkpoint dim-0 when slicing (0 = no slice)
+};
+
+std::vector<WeightSpec> GetWeightSpecs(const DiffusionConfig& config,
+                                       int checkpoint_vocab) {
+  const int emb = config.emb_dim;
+  const int qkv = config.qkv_out_dim();
+  const int kv = config.kv_out_dim();
+  const int ffn = config.hidden_dim;
+  const bool slice = config.vocab < checkpoint_vocab;
+
+  std::vector<WeightSpec> specs;
+  specs.push_back({"model.embed_tokens.weight", "model.transformer.wte.weight",
+                   {config.vocab, emb}, slice ? checkpoint_vocab : 0});
+  for (int i = 0; i < config.n_layers; ++i) {
+    const std::string g = absl::StrCat("model.layers.", i);
+    const std::string s = absl::StrCat("model.transformer.blocks.", i);
+    specs.push_back({g + ".input_layernorm.weight", s + ".attn_norm.weight",
+                     {emb}});
+    specs.push_back({g + ".self_attn.q_proj.weight", s + ".q_proj.weight",
+                     {qkv, emb}});
+    specs.push_back({g + ".self_attn.k_proj.weight", s + ".k_proj.weight",
+                     {kv, emb}});
+    specs.push_back({g + ".self_attn.v_proj.weight", s + ".v_proj.weight",
+                     {kv, emb}});
+    specs.push_back({g + ".self_attn.o_proj.weight", s + ".attn_out.weight",
+                     {emb, qkv}});
+    specs.push_back({g + ".post_attention_layernorm.weight",
+                     s + ".ff_norm.weight", {emb}});
+    specs.push_back({g + ".mlp.gate_proj.weight", s + ".ff_proj.weight",
+                     {ffn, emb}});
+    specs.push_back({g + ".mlp.up_proj.weight", s + ".up_proj.weight",
+                     {ffn, emb}});
+    specs.push_back({g + ".mlp.down_proj.weight", s + ".ff_out.weight",
+                     {emb, ffn}});
+  }
+  specs.push_back({"model.norm.weight", "model.transformer.ln_f.weight",
+                   {emb}});
+  // Untied head: the MODEL-level ff_out (weight_tying=false in config.json).
+  specs.push_back({"lm_head.weight", "model.transformer.ff_out.weight",
+                   {config.vocab, emb}, slice ? checkpoint_vocab : 0});
+  return specs;
+}
+
+// The gemma3 loader adds +1.0 to anything matching its is_layernorm
+// predicate (contains "layernorm" or ends with "norm.weight"). LLaDA's RMS
+// norms carry plain affine weights, so undo it. Source names attn_norm/
+// ff_norm match the predicate; ln_f does not.
+bool LoaderAddsGemmaNormOffset(const std::string& name) {
+  return absl::StrContains(name, "layernorm") ||
+         absl::EndsWith(name, "norm.weight");
+}
+
+// Blockwise-32 int4 RTN with fp16-rounded scales — same layout as
+// talker_weights.cc so gptq_quantize.py companions stay compatible later.
+constexpr int kInt4BlockSize = 32;
+
+bool IsQuantizableFcWeight(const std::string& graph_name) {
+  return absl::StrContains(graph_name, "_proj.weight") ||
+         graph_name == "lm_head.weight";
+}
+
+absl::StatusOr<TfTensor> QuantizeFcWeightInt4(const TfTensor& tensor,
+                                              const std::string& name) {
+  const auto& shape = tensor.GetShape();
+  if (shape.size() != 2) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(name, ": expected 2-D weight for quantization"));
+  }
+  const int out_channels = shape[0];
+  const int in_dim = shape[1];
+  if (in_dim % kInt4BlockSize != 0) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(name, ": in_dim not divisible by block"));
+  }
+  auto buffer = tensor.GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->Lock();
+  const float* w = reinterpret_cast<const float*>(lock.data());
+
+  const int blocks_per_row = in_dim / kInt4BlockSize;
+  std::vector<float> scales(static_cast<size_t>(out_channels) *
+                            blocks_per_row);
+  const size_t count = static_cast<size_t>(out_channels) * in_dim;
+  std::vector<char> packed((count + 1) / 2, 0);
+  for (int c = 0; c < out_channels; ++c) {
+    const float* row = w + static_cast<size_t>(c) * in_dim;
+    for (int b = 0; b < blocks_per_row; ++b) {
+      float amax = 0.0f;
+      for (int i = b * kInt4BlockSize; i < (b + 1) * kInt4BlockSize; ++i)
+        amax = std::max(amax, std::fabs(row[i]));
+      float scale = amax > 0.0f ? amax / 7.0f : 1.0f;
+      scale = static_cast<float>(fp16_t(scale));
+      scales[static_cast<size_t>(c) * blocks_per_row + b] = scale;
+      for (int i = b * kInt4BlockSize; i < (b + 1) * kInt4BlockSize; ++i) {
+        float v = std::round(row[i] / scale);
+        int8_t q = static_cast<int8_t>(std::min(7.0f, std::max(-7.0f, v)));
+        const size_t flat = static_cast<size_t>(c) * in_dim + i;
+        char nib = static_cast<char>(q & 0xF);
+        packed[flat / 2] |= (flat % 2 == 0) ? nib : static_cast<char>(nib << 4);
+      }
+    }
+  }
+
+  auto q_buffer = OwningCpuBuffer::Copy(packed.data(), packed.size());
+  TfTensor quantized({.name = name,
+                      .type = Type::kI4,
+                      .shape = {out_channels, in_dim},
+                      .buffer = std::move(q_buffer)});
+  quantized.SetQuantization(std::make_shared<BlockwiseQuantization>(
+      std::move(scales), std::vector<int64_t>(), kInt4BlockSize,
+      /*quantized_dimension=*/0));
+  return quantized;
+}
+
+absl::StatusOr<TfTensor> QuantizeFcWeightInt8(const TfTensor& tensor,
+                                              const std::string& name) {
+  const auto& shape = tensor.GetShape();
+  if (shape.size() != 2) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(name, ": expected 2-D weight for quantization"));
+  }
+  const int out_channels = shape[0];
+  const int in_dim = shape[1];
+  auto buffer = tensor.GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->Lock();
+  const float* w = reinterpret_cast<const float*>(lock.data());
+
+  std::vector<float> scales(out_channels);
+  std::vector<int8_t> q(static_cast<size_t>(out_channels) * in_dim);
+  for (int c = 0; c < out_channels; ++c) {
+    const float* row = w + static_cast<size_t>(c) * in_dim;
+    float amax = 0.0f;
+    for (int i = 0; i < in_dim; ++i) amax = std::max(amax, std::fabs(row[i]));
+    float scale = amax > 0.0f ? amax / 127.0f : 1.0f;
+    scales[c] = scale;
+    int8_t* q_row = q.data() + static_cast<size_t>(c) * in_dim;
+    for (int i = 0; i < in_dim; ++i) {
+      float v = std::round(row[i] / scale);
+      q_row[i] = static_cast<int8_t>(std::min(127.0f, std::max(-127.0f, v)));
+    }
+  }
+  auto q_buffer = OwningCpuBuffer::Copy(
+      reinterpret_cast<const char*>(q.data()), q.size());
+  TfTensor quantized({.name = name,
+                      .type = Type::kI8,
+                      .shape = {out_channels, in_dim},
+                      .buffer = std::move(q_buffer)});
+  quantized.SetQuantization(std::make_shared<PerChannelAffineQuantization>(
+      std::move(scales), std::vector<int64_t>(out_channels, 0),
+      /*quantized_dimension=*/0));
+  return quantized;
+}
+
+absl::Status SubtractOne(TfTensor& tensor) {
+  auto buffer = tensor.GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->LockMutable();
+  float* data = reinterpret_cast<float*>(lock.data());
+  size_t count = lock.size() / sizeof(float);
+  for (size_t i = 0; i < count; ++i) data[i] -= 1.0f;
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+absl::StatusOr<WeightMap> LoadLladaWeights(const DiffusionConfig& config,
+                                           const std::string& checkpoint_dir,
+                                           WeightQuantMode quant_mode) {
+  std::vector<std::string> shard_paths;
+  for (const auto& entry :
+       std::filesystem::directory_iterator(checkpoint_dir)) {
+    const std::string p = entry.path().string();
+    if (absl::EndsWith(p, ".safetensors")) shard_paths.push_back(p);
+  }
+  std::sort(shard_paths.begin(), shard_paths.end());
+  if (shard_paths.empty()) {
+    return absl::NotFoundError(
+        absl::StrCat("no .safetensors shards in ", checkpoint_dir));
+  }
+  std::vector<SafetensorLoader> shards;
+  for (const auto& p : shard_paths) {
+    auto loader_or = SafetensorLoader::Load(p);
+    if (!loader_or.ok()) return loader_or.status();
+    shards.push_back(std::move(*loader_or));
+  }
+
+  // Checkpoint vocab (untied head rows) for the optional slice.
+  int checkpoint_vocab = 0;
+  for (const auto& shard : shards) {
+    auto info_or = shard.GetTensorInfo("model.transformer.ff_out.weight");
+    if (info_or.ok()) {
+      checkpoint_vocab = static_cast<int>(info_or->shape[0]);
+      break;
+    }
+  }
+  if (checkpoint_vocab == 0) {
+    return absl::NotFoundError(
+        "model.transformer.ff_out.weight (untied head) not found in shards");
+  }
+
+  WeightMap weights;
+  for (const WeightSpec& spec : GetWeightSpecs(config, checkpoint_vocab)) {
+    const SafetensorLoader* shard = nullptr;
+    for (const auto& candidate : shards) {
+      if (candidate.GetTensorInfo(spec.source_name).ok()) {
+        shard = &candidate;
+        break;
+      }
+    }
+    if (shard == nullptr) {
+      return absl::NotFoundError(
+          absl::StrCat("checkpoint missing ", spec.source_name));
+    }
+    auto handle_or = shard->LoadTensor(
+        spec.source_name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
+    if (!handle_or.ok()) return handle_or.status();
+    TfTensor tensor(*handle_or);
+
+    if (spec.full_rows > 0) {
+      // Vocab slice: keep the first shape[0] rows of [full_rows, emb].
+      const int rows = spec.shape[0];
+      const int cols = spec.shape[1];
+      auto buffer = tensor.GetBuffer();
+      if (!buffer.ok()) return buffer.status();
+      auto lock = buffer->Lock();
+      const float* src = reinterpret_cast<const float*>(lock.data());
+      const size_t count = static_cast<size_t>(rows) * cols;
+      std::vector<float> sliced(src, src + count);
+      tensor = TfTensor({.name = spec.graph_name,
+                         .type = Type::kFP32,
+                         .shape = spec.shape,
+                         .buffer = OwningCpuBuffer::Copy<Type::kFP32>(
+                             std::move(sliced))});
+    }
+
+    const auto& loaded_shape = tensor.GetShape();
+    std::vector<int> loaded(loaded_shape.begin(), loaded_shape.end());
+    if (loaded != spec.shape) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          spec.source_name, ": checkpoint shape [",
+          absl::StrJoin(loaded, ","), "] != expected [",
+          absl::StrJoin(spec.shape, ","), "]"));
+    }
+
+    if (LoaderAddsGemmaNormOffset(spec.source_name)) {
+      auto status = SubtractOne(tensor);
+      if (!status.ok()) return status;
+    }
+
+    if (quant_mode != WeightQuantMode::kNone &&
+        IsQuantizableFcWeight(spec.graph_name)) {
+      auto quantized_or = quant_mode == WeightQuantMode::kInt4
+                              ? QuantizeFcWeightInt4(tensor, spec.graph_name)
+                              : QuantizeFcWeightInt8(tensor, spec.graph_name);
+      if (!quantized_or.ok()) return quantized_or.status();
+      weights[spec.graph_name] = std::move(*quantized_or);
+      continue;
+    }
+
+    tensor.SetName(spec.graph_name);
+    weights[spec.graph_name] = std::move(tensor);
+  }
+  return weights;
+}
+
+}  // namespace litert::tensor::examples::diffusion

--- a/models/llada/llada_8b/tensor_api/diffusion_weights.h
+++ b/models/llada/llada_8b/tensor_api/diffusion_weights.h
@@ -1,0 +1,51 @@
+// Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Real-checkpoint weight loading for the diffusion denoise-step graph —
+// Stage 2 (LLaDA-8B-Base).
+//
+// Maps the checkpoint's OLMo-style tensor names
+// (model.transformer.blocks.N.{q,k,v}_proj / attn_out / ff_proj / up_proj /
+// ff_out, wte, ln_f, untied model-level ff_out head) onto the graph's
+// LLaMA-style names (model.layers.N.self_attn.* / mlp.*, embed_tokens,
+// lm_head). Handles a sharded checkpoint directory (model-XXXXX-of-XXXXX
+// .safetensors) by probing each shard per tensor.
+//
+// config.n_layers may be smaller than the checkpoint's 32 (loads a prefix of
+// the stack) and config.vocab smaller than 126464 (loads the first vocab rows
+// of wte / the head) — both for cheap loader/graph equivalence runs against
+// the numpy reference before committing to the full model.
+
+#ifndef SPEECHLM_STAGE1_DIFFUSION_STEP_DIFFUSION_WEIGHTS_H_
+#define SPEECHLM_STAGE1_DIFFUSION_STEP_DIFFUSION_WEIGHTS_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "models/llada/llada_8b/tensor_api/diffusion_graph.h"
+
+namespace litert::tensor::examples::diffusion {
+
+// kInt4 quantizes the 2-D matmul weights (q/k/v/o, SwiGLU, lm_head) to
+// blockwise-32 int4 with fp16 scales — the same layout as the talker; the
+// embedding (Gather source) and norms stay fp32.
+enum class WeightQuantMode { kNone, kInt4, kInt8 };
+
+absl::StatusOr<WeightMap> LoadLladaWeights(
+    const DiffusionConfig& config, const std::string& checkpoint_dir,
+    WeightQuantMode quant_mode = WeightQuantMode::kNone);
+
+}  // namespace litert::tensor::examples::diffusion
+
+#endif  // SPEECHLM_STAGE1_DIFFUSION_STEP_DIFFUSION_WEIGHTS_H_


### PR DESCRIPTION
Following the invitation to create new model directories: this adds
`models/llada/llada_8b/tensor_api/` — a diffusion-LM denoise step for
LLaDA-8B-Base authored with the C++ Tensor API. Small PR (7 files), no
weights included.

- One in-graph denoise step: bidirectional backbone + ScatterNd-free
  top-k remasking (TopK → OneHot → Sum → SelectV2); the host only feeds
  ids back between steps. `--llada` selects the 8B architecture and the
  sharded-safetensors loader; composite options `--attention=raw|sdpa`
  and `--norms=raw|composite`; in-process int8/int4 weight quantization;
  `--reuse_tflite` for on-device runs without the checkpoint.
- Correctness: identical per-step id trajectories vs an independent numpy
  reference on real weights, full schedule; int4 ids identical to fp32.
  The full 32L model runs on a Pixel 8a CPU (memory-mapped 6.29 GB
  model) with ids identical to desktop.
- Same build story as the Qwen3-TTS tensor_api PR (BUILD targets
  `@litert_archive`, inlined copts helper, one dependency adapted to
  current `main`); runtime behavior validated at LiteRT `a19d8fa` + PR
  #8796, and the Android arm64 binary builds and links from this
  workspace against current `main` — we will chase anything else that
  drifts.
- Kernel-shape note in the README that may interest the XNNPACK side:
  blockwise-int4 fast kernels are GEMV-only today, so full-sequence
  diffusion steps land on a slow path — per-channel int8 is the right
  CPU default for this model class (measured 8L probe: int8 81.6 vs int4
  791.5 ms/step on M4 Max).
