### PR TITLE
Propose utilities/common: vendored Kotlin helpers + a drift checker

### DIFF
--- a/utilities/common/README.md
+++ b/utilities/common/README.md
@@ -73,6 +73,35 @@ Planned next, not included: `MelSpectrogram.kt`, unifying the four diverged
 copies behind explicit mel parameters. That one needs per-sample device
 re-verification before any switch, so it should not be extracted on paper.
 
+## Sanctioned divergence
+
+A sample is sometimes right to differ, so the checker does not treat all drift
+as a defect. `sync_common.py` carries a `KNOWN_DIVERGENCES` set: those paths are
+reported but never rewritten by `--apply` and never fail `--check`. It is empty
+here because nothing is vendored yet.
+
+The case that motivated it: in the zoo, the `yolox` module carries a trimmed
+238-line `RealtimeCameraPipeline` variant that predates the canonical. It is
+left alone, because re-unifying it means re-verifying that sample on device —
+worth doing deliberately, not as a side effect of a sync. That is also the
+honest counterweight to the reuse claim below: even the one utility with real
+production use has a module that needed its own version.
+
+## How much reuse is actually proven
+
+Two different claims are worth separating.
+
+- **General by construction** — true of all five. Every model-specific value is
+  a constructor argument (`ImageTensor` takes size, mean/std, NCHW vs NHWC,
+  RGB vs BGR, 0–1 vs 0–255, stretch vs letterbox; `AudioCapture` takes sample
+  rate and chunk size; `MathOps` is stateless).
+- **Demonstrated across models** — true only of `RealtimeCameraPipeline.kt`.
+
+An API that has never had a second caller is usually wrong in small ways: the
+missing parameter shows up on the second adoption, not the first. That is why
+the right way to land the other four is alongside two samples that consume
+them, not one.
+
 ## Known gap
 
 `sync_common.py` was written against a flat zoo layout and its file search has

--- a/utilities/common/README.md
+++ b/utilities/common/README.md
@@ -1,0 +1,84 @@
+# common/ — canonical shared Kotlin utilities
+
+**Status: proposal.** The files here are extracted from patterns that recur
+across the sample apps, but only `RealtimeCameraPipeline.kt` has been in
+production use (in a separate model zoo). The other four have not been vendored
+into any sample yet, here or elsewhere — the first sample that adopts one is its
+compile and device verification. Nothing in this directory is wired into a build
+today, so merging it changes no existing sample.
+
+## The problem
+
+The same helpers are re-written per sample. Counted across the sample apps in
+this repository plus a ~40-app zoo built on the same APIs:
+
+- CameraX realtime capture pipeline (~250 lines): 22 near-identical copies
+- Bitmap → normalized float tensor (mean/std, NCHW/NHWC, letterbox): ~40 copies
+- 16 kHz `AudioRecord` capture loop: ~10 copies; mel spectrogram: 4 copies that
+  have already drifted apart
+- softmax / argmax / NMS / IoU: ~10 copies each
+- In this repository, `ModelDownloader.kt` exists 5 times and all five have
+  diverged
+
+CompiledModel GPU lifecycle boilerplate is the worst case, because its sharp
+edges are not written down anywhere: named-signature `run`, reusing an output
+buffer as the next step's input for stateful models, `TensorBuffer` being
+`AutoCloseable`. Every sample re-discovers them.
+
+## The proposal: vendored copies, not a shared module
+
+Each sample stays an independent Gradle project. Shared utilities are
+distributed as **vendored copies** — the canonical source lives here, every
+sample keeps its own physical copy with a `// Vendored from ...` provenance
+line, and `utilities/tools/sync_common.py` keeps the copies byte-identical
+(only the `package` line differs; the canonical carries the
+`package __MODULE_PACKAGE__` placeholder).
+
+```bash
+python utilities/tools/sync_common.py --check   # drift check, exit 1 on divergence
+python utilities/tools/sync_common.py --apply   # push the canonical out to all copies
+```
+
+Copies rather than a Gradle module or a published artifact, because:
+
+- every sample stays standalone — a reader can copy one directory and build it;
+- these are teaching material, so the helper code should stay readable inside
+  the sample rather than hidden behind a dependency;
+- there is zero build coupling between samples today, and this keeps it that way.
+
+If the team later wants a real `com.google.ai.edge:…-utils` artifact, this
+directory is the source it would be built from, so graduating is mechanical.
+
+## Rules if this is adopted
+
+1. **Fix bugs in the canonical first**, then `--apply`. Never patch one
+   sample's copy in place — that is how the four diverged `MelSpectrogram.kt`
+   variants happened.
+2. **Model-specific parameters go in constructor arguments**, not edits to the
+   copy (normalization mean/std, mel bin count, and so on).
+3. Task-specific visualization (overlay views) is deliberately not shared. That
+   is the part of a sample readers most want to see whole.
+
+## Files
+
+| File | What it provides | Adopted |
+|---|---|---|
+| `kotlin/RealtimeCameraPipeline.kt` | CameraX two-thread capture loop, RGBA `ImageProxy` → pooled `Bitmap` including rotation, FPS counter | in ~22 zoo modules; none here yet |
+| `kotlin/CompiledModelRunner.kt` | CompiledModel GPU lifecycle — create from assets or file, buffers, run, close-all including `TensorBuffer`s. KDoc records the undocumented behaviour above | not yet |
+| `kotlin/ImageTensor.kt` | Bitmap → NCHW/NHWC float tensor; parameterized mean/std, RGB/BGR, 0–1 vs 0–255; stretch and letterbox with a coordinate `Mapping` back to the source | not yet |
+| `kotlin/AudioCapture.kt` | 16 kHz mono `AudioRecord` daemon loop delivering normalized float chunks | not yet |
+| `kotlin/MathOps.kt` | sigmoid, in-place softmax, argmax, IoU, greedy NMS over flat xyxy arrays | not yet |
+
+Planned next, not included: `MelSpectrogram.kt`, unifying the four diverged
+copies behind explicit mel parameters. That one needs per-sample device
+re-verification before any switch, so it should not be extracted on paper.
+
+## Known gap
+
+`sync_common.py` was written against a flat zoo layout and its file search has
+been re-pointed at this repository's variable-depth sample paths
+(`**/src/main/java/**`, `**/src/main/kotlin/**`); the comparison logic is
+unchanged. `--check` runs here and correctly picks up all five canonical files,
+but with no vendored copies yet it reports `0 copies` for each and exits 0 — so
+the drift comparison itself has not been exercised in this repository. The first
+sample that adopts a utility is also this tool's first real run.

--- a/utilities/common/kotlin/AudioCapture.kt
+++ b/utilities/common/kotlin/AudioCapture.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __MODULE_PACKAGE__
+// Vendored from common/kotlin/AudioCapture.kt — edit the canonical and run tools/sync_common.py --apply.
+
+import android.annotation.SuppressLint
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import kotlin.concurrent.thread
+
+/**
+ * Microphone capture loop for speech/audio models (16 kHz mono PCM by default).
+ *
+ * [start] spawns a daemon thread that delivers normalized float chunks in [-1, 1]
+ * to the callback; [stop] ends the loop and releases the recorder. The caller is
+ * responsible for holding the `RECORD_AUDIO` runtime permission — constructing
+ * [AudioRecord] without it throws [SecurityException].
+ */
+class AudioCapture(
+    private val sampleRate: Int = DEFAULT_SAMPLE_RATE,
+    private val chunkSize: Int = DEFAULT_CHUNK_SIZE,
+) : AutoCloseable {
+
+    companion object {
+        /** The sample rate expected by Whisper/Parakeet/wav2vec2-style models. */
+        const val DEFAULT_SAMPLE_RATE = 16_000
+
+        /** 100 ms at 16 kHz — small enough for streaming, large enough to amortize reads. */
+        const val DEFAULT_CHUNK_SIZE = 1_600
+
+        private const val PCM_SHORT_SCALE = 32_768f
+    }
+
+    private var audioRecord: AudioRecord? = null
+
+    @Volatile
+    private var recording = false
+
+    /** True while the capture thread is running. */
+    val isRecording: Boolean
+        get() = recording
+
+    /**
+     * Starts capturing; [onChunk] is invoked on the capture thread with a chunk of
+     * normalized samples (the array is only valid inside the callback — copy it if
+     * accumulating). No-op if already recording.
+     *
+     * @throws SecurityException when the RECORD_AUDIO permission is missing
+     */
+    @SuppressLint("MissingPermission")
+    fun start(onChunk: (FloatArray) -> Unit) {
+        if (recording) {
+            return
+        }
+        val minBufferSize = AudioRecord.getMinBufferSize(
+            sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT
+        )
+        val record = AudioRecord(
+            MediaRecorder.AudioSource.MIC,
+            sampleRate,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+            maxOf(minBufferSize, chunkSize * 2) * 2,
+        )
+        audioRecord = record
+        record.startRecording()
+        recording = true
+        thread(name = "AudioCapture", isDaemon = true) {
+            val shorts = ShortArray(chunkSize)
+            val floats = FloatArray(chunkSize)
+            while (recording) {
+                val read = record.read(shorts, 0, chunkSize)
+                if (read <= 0) {
+                    continue
+                }
+                for (i in 0 until read) {
+                    floats[i] = shorts[i] / PCM_SHORT_SCALE
+                }
+                onChunk(if (read == chunkSize) floats else floats.copyOf(read))
+            }
+            // Release on the capture thread so a blocked read() never races release().
+            record.stop()
+            record.release()
+        }
+    }
+
+    /** Stops the capture loop; the capture thread releases the recorder on exit. */
+    fun stop() {
+        recording = false
+        audioRecord = null
+    }
+
+    override fun close() = stop()
+}

--- a/utilities/common/kotlin/CompiledModelRunner.kt
+++ b/utilities/common/kotlin/CompiledModelRunner.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __MODULE_PACKAGE__
+// Vendored from common/kotlin/CompiledModelRunner.kt — edit the canonical and run tools/sync_common.py --apply.
+
+import android.content.Context
+import com.google.ai.edge.litert.Accelerator
+import com.google.ai.edge.litert.CompiledModel
+import com.google.ai.edge.litert.TensorBuffer
+
+/**
+ * Thin lifecycle wrapper around LiteRT [CompiledModel] for GPU inference.
+ *
+ * Owns the compiled model plus one pre-allocated set of input/output buffers and
+ * releases all of them in [close]. [TensorBuffer] is `AutoCloseable` too — forgetting
+ * to close the buffers leaks native memory even when the model itself is closed.
+ *
+ * API notes that are easy to miss:
+ * - `CompiledModel` with [Accelerator.GPU] requires every op in the graph to be
+ *   GPU-compatible. There is no CPU fallback — an unsupported op fails compilation.
+ * - [run] enqueues work on the GPU and may return before the computation has
+ *   finished; the readback ([readOutput]) is the call that waits. Always benchmark
+ *   run + readback together, never run() alone.
+ * - For stateful/recurrent models, create a second buffer set and feed step N's
+ *   output buffers as step N+1's inputs via [run] (buffer ping-pong) instead of
+ *   copying state through the host each step.
+ */
+class CompiledModelRunner private constructor(private val model: CompiledModel) : AutoCloseable {
+
+    /** Pre-allocated input buffers, index-aligned with the model's input tensors. */
+    val inputBuffers: List<TensorBuffer> = model.createInputBuffers()
+
+    /** Pre-allocated output buffers, index-aligned with the model's output tensors. */
+    val outputBuffers: List<TensorBuffer> = model.createOutputBuffers()
+
+    companion object {
+        /**
+         * Compiles a model bundled in `assets/`. The module's Gradle config must set
+         * `aaptOptions { noCompress += "tflite" }` so the asset stays mmappable.
+         */
+        fun fromAssets(
+            context: Context,
+            fileName: String,
+            vararg accelerators: Accelerator = arrayOf(Accelerator.GPU),
+        ): CompiledModelRunner = CompiledModelRunner(
+            CompiledModel.create(context.assets, fileName, CompiledModel.Options(*accelerators), null)
+        )
+
+        /**
+         * Compiles a model from an absolute file path — the pattern for large models
+         * staged into the app's `filesDir` by an install script.
+         */
+        fun fromFile(
+            path: String,
+            vararg accelerators: Accelerator = arrayOf(Accelerator.GPU),
+        ): CompiledModelRunner = CompiledModelRunner(
+            CompiledModel.create(path, CompiledModel.Options(*accelerators), null)
+        )
+    }
+
+    /** Writes [data] into input tensor [index]. */
+    fun writeInput(index: Int, data: FloatArray) {
+        inputBuffers[index].writeFloat(data)
+    }
+
+    /** Runs the model on the pre-allocated buffer sets (asynchronous — see class KDoc). */
+    fun run() {
+        model.run(inputBuffers, outputBuffers)
+    }
+
+    /** Runs the model on caller-provided buffers (buffer ping-pong, multi-graph pipelines). */
+    fun run(inputs: List<TensorBuffer>, outputs: List<TensorBuffer>) {
+        model.run(inputs, outputs)
+    }
+
+    /** Reads output tensor [index] back to the host. This is the call that waits for the GPU. */
+    fun readOutput(index: Int): FloatArray = outputBuffers[index].readFloat()
+
+    override fun close() {
+        inputBuffers.forEach { it.close() }
+        outputBuffers.forEach { it.close() }
+        model.close()
+    }
+}

--- a/utilities/common/kotlin/ImageTensor.kt
+++ b/utilities/common/kotlin/ImageTensor.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __MODULE_PACKAGE__
+// Vendored from common/kotlin/ImageTensor.kt — edit the canonical and run tools/sync_common.py --apply.
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Matrix
+import android.graphics.Paint
+
+/**
+ * Bitmap → normalized float tensor conversion with zero per-frame allocation.
+ *
+ * Configure once with the model's input geometry and normalization, then call [load]
+ * per frame. The returned array is owned by this instance and overwritten by the next
+ * call. Model-specific parameters (mean/std, layout, channel order) are constructor
+ * arguments — do not edit a vendored copy to change them.
+ *
+ * Normalization applied per channel c: `value = (pixel[c] / 255 - mean[c]) / std[c]`
+ * (skip the `/ 255` with `scaleTo01 = false` for raw 0–255 models such as YOLOX).
+ */
+class ImageTensor(
+    private val width: Int,
+    private val height: Int,
+    private val mean: FloatArray = floatArrayOf(0f, 0f, 0f),
+    private val std: FloatArray = floatArrayOf(1f, 1f, 1f),
+    private val layout: Layout = Layout.NCHW,
+    private val channelOrder: ChannelOrder = ChannelOrder.RGB,
+    private val scaleTo01: Boolean = true,
+) {
+    /** Tensor memory layout: channels-first (PyTorch exports) or channels-last. */
+    enum class Layout { NCHW, NHWC }
+
+    /** Channel order expected by the model ([mean]/[std] are indexed in this order). */
+    enum class ChannelOrder { RGB, BGR }
+
+    /** Aspect-ratio policy applied by [load]. */
+    enum class Fit { STRETCH, LETTERBOX }
+
+    /**
+     * Geometry of the last [load]: `model_x = source_x * scaleX + padX` (and same for y).
+     * Use it to map detections back to source-image coordinates.
+     */
+    data class Mapping(val scaleX: Float, val scaleY: Float, val padX: Float, val padY: Float)
+
+    companion object {
+        val IMAGENET_MEAN = floatArrayOf(0.485f, 0.456f, 0.406f)
+        val IMAGENET_STD = floatArrayOf(0.229f, 0.224f, 0.225f)
+    }
+
+    /** Destination tensor, reused across [load] calls. */
+    val floats = FloatArray(3 * width * height)
+
+    private val pixels = IntArray(width * height)
+    private val scaled = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    private val canvas = Canvas(scaled)
+    private val matrix = Matrix()
+    private val paint = Paint(Paint.FILTER_BITMAP_FLAG)
+
+    /** Geometry of the last [load]. */
+    var mapping = Mapping(1f, 1f, 0f, 0f)
+        private set
+
+    /**
+     * Converts [bitmap] into the configured float layout and returns [floats].
+     *
+     * @param padColor letterbox padding color (e.g. `0xFF727272.toInt()` for YOLOX gray 114)
+     */
+    fun load(bitmap: Bitmap, fit: Fit = Fit.STRETCH, padColor: Int = Color.BLACK): FloatArray {
+        when (fit) {
+            Fit.STRETCH -> {
+                val scaleX = width.toFloat() / bitmap.width
+                val scaleY = height.toFloat() / bitmap.height
+                matrix.setScale(scaleX, scaleY)
+                mapping = Mapping(scaleX, scaleY, 0f, 0f)
+            }
+            Fit.LETTERBOX -> {
+                val scale = minOf(width.toFloat() / bitmap.width, height.toFloat() / bitmap.height)
+                val padX = (width - bitmap.width * scale) / 2f
+                val padY = (height - bitmap.height * scale) / 2f
+                canvas.drawColor(padColor)
+                matrix.setScale(scale, scale)
+                matrix.postTranslate(padX, padY)
+                mapping = Mapping(scale, scale, padX, padY)
+            }
+        }
+        canvas.drawBitmap(bitmap, matrix, paint)
+        scaled.getPixels(pixels, 0, width, 0, 0, width, height)
+
+        val plane = width * height
+        for (i in 0 until plane) {
+            val p = pixels[i]
+            var c0 = ((p shr 16) and 0xFF).toFloat()
+            var c1 = ((p shr 8) and 0xFF).toFloat()
+            var c2 = (p and 0xFF).toFloat()
+            if (channelOrder == ChannelOrder.BGR) {
+                val swap = c0
+                c0 = c2
+                c2 = swap
+            }
+            if (scaleTo01) {
+                c0 /= 255f
+                c1 /= 255f
+                c2 /= 255f
+            }
+            c0 = (c0 - mean[0]) / std[0]
+            c1 = (c1 - mean[1]) / std[1]
+            c2 = (c2 - mean[2]) / std[2]
+            if (layout == Layout.NCHW) {
+                floats[i] = c0
+                floats[plane + i] = c1
+                floats[2 * plane + i] = c2
+            } else {
+                val j = i * 3
+                floats[j] = c0
+                floats[j + 1] = c1
+                floats[j + 2] = c2
+            }
+        }
+        return floats
+    }
+
+    /** Releases the internal scratch bitmap. */
+    fun release() {
+        if (!scaled.isRecycled) {
+            scaled.recycle()
+        }
+    }
+}

--- a/utilities/common/kotlin/MathOps.kt
+++ b/utilities/common/kotlin/MathOps.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __MODULE_PACKAGE__
+// Vendored from common/kotlin/MathOps.kt — edit the canonical and run tools/sync_common.py --apply.
+
+import kotlin.math.exp
+import kotlin.math.max
+import kotlin.math.min
+
+/** Small post-processing math shared across model heads. */
+object MathOps {
+
+    private const val IOU_EPS = 1e-6f
+
+    /** Numerically stable sigmoid. */
+    fun sigmoid(x: Float): Float = 1f / (1f + exp(-x))
+
+    /** In-place, max-subtracted softmax over [logits]. Returns the same array. */
+    fun softmaxInPlace(logits: FloatArray): FloatArray {
+        var maxLogit = Float.NEGATIVE_INFINITY
+        for (v in logits) {
+            maxLogit = max(maxLogit, v)
+        }
+        var sum = 0f
+        for (i in logits.indices) {
+            logits[i] = exp(logits[i] - maxLogit)
+            sum += logits[i]
+        }
+        for (i in logits.indices) {
+            logits[i] /= sum
+        }
+        return logits
+    }
+
+    /** Index of the largest value, or -1 for an empty array. */
+    fun argmax(values: FloatArray): Int {
+        var best = -1
+        var bestValue = Float.NEGATIVE_INFINITY
+        for (i in values.indices) {
+            if (values[i] > bestValue) {
+                bestValue = values[i]
+                best = i
+            }
+        }
+        return best
+    }
+
+    /** Intersection-over-union of two xyxy boxes. */
+    fun iou(
+        ax1: Float, ay1: Float, ax2: Float, ay2: Float,
+        bx1: Float, by1: Float, bx2: Float, by2: Float,
+    ): Float {
+        val interWidth = max(0f, min(ax2, bx2) - max(ax1, bx1))
+        val interHeight = max(0f, min(ay2, by2) - max(ay1, by1))
+        val inter = interWidth * interHeight
+        val areaA = (ax2 - ax1) * (ay2 - ay1)
+        val areaB = (bx2 - bx1) * (by2 - by1)
+        return inter / (areaA + areaB - inter + IOU_EPS)
+    }
+
+    /**
+     * Greedy non-maximum suppression.
+     *
+     * @param boxes flat xyxy boxes, `boxes[4 * i .. 4 * i + 3]` for detection i
+     * @param scores one score per detection
+     * @return indices of the kept detections, sorted by descending score
+     */
+    fun nms(
+        boxes: FloatArray,
+        scores: FloatArray,
+        iouThreshold: Float,
+        scoreThreshold: Float = 0f,
+    ): IntArray {
+        val order = scores.indices
+            .filter { scores[it] >= scoreThreshold }
+            .sortedByDescending { scores[it] }
+        val kept = mutableListOf<Int>()
+        val suppressed = BooleanArray(scores.size)
+        for (position in order.indices) {
+            val i = order[position]
+            if (suppressed[i]) {
+                continue
+            }
+            kept.add(i)
+            for (lower in position + 1 until order.size) {
+                val j = order[lower]
+                if (suppressed[j]) {
+                    continue
+                }
+                val overlap = iou(
+                    boxes[4 * i], boxes[4 * i + 1], boxes[4 * i + 2], boxes[4 * i + 3],
+                    boxes[4 * j], boxes[4 * j + 1], boxes[4 * j + 2], boxes[4 * j + 3],
+                )
+                if (overlap > iouThreshold) {
+                    suppressed[j] = true
+                }
+            }
+        }
+        return kept.toIntArray()
+    }
+}

--- a/utilities/common/kotlin/RealtimeCameraPipeline.kt
+++ b/utilities/common/kotlin/RealtimeCameraPipeline.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __MODULE_PACKAGE__
+// Vendored from common/kotlin/RealtimeCameraPipeline.kt — edit the canonical and run tools/sync_common.py --apply.
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.util.Log
+import android.util.Size
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reusable two-thread realtime camera + ML inference pipeline.
+ *
+ * Architecture:
+ *   Camera thread:    proxyToBitmap → frameChannel
+ *   Inference thread: poll frame → onFrame callback → return bitmap to free pool
+ *
+ * Benefits over single-threaded pipeline:
+ *   - bmp conversion is hidden behind GPU inference time
+ *   - Always processes the latest available frame (drops stale ones)
+ *   - Bitmap pool eliminates per-frame allocation
+ *
+ * Usage:
+ *   val pipeline = RealtimeCameraPipeline(activity, previewView) { bmp ->
+ *       val results = detector.detect(bmp)
+ *       runOnUiThread { overlayView.setResults(results, bmp.width, bmp.height) }
+ *   }
+ *   pipeline.start(this)  // call from onCreate
+ *   // ...
+ *   pipeline.close()  // call from onDestroy
+ *
+ * The [onFrame] callback runs on the inference thread. Post UI updates with
+ * `runOnUiThread { ... }` or `view.post { ... }`.
+ *
+ * To gate inference (e.g. while loading models), set [enabled] to false.
+ */
+class RealtimeCameraPipeline(
+    private val activity: androidx.activity.ComponentActivity,
+    private val previewView: PreviewView? = null,
+    private val analysisResolution: Size = Size(384, 288),
+    private val previewResolution: Size = Size(640, 480),
+    private val cameraSelector: CameraSelector = CameraSelector.DEFAULT_BACK_CAMERA,
+    private val onFrame: (Bitmap) -> Unit,
+) : AutoCloseable {
+
+    companion object {
+        private const val TAG = "CameraPipeline"
+    }
+
+    @Volatile
+    var enabled: Boolean = true
+
+    private val cameraExecutor = Executors.newSingleThreadExecutor()
+    private val inferenceExecutor = Executors.newSingleThreadExecutor()
+
+    private val freePool = ArrayBlockingQueue<Bitmap>(2)
+    private val frameChannel = ArrayBlockingQueue<Bitmap>(1)
+
+    @Volatile
+    private var inferenceRunning = false
+
+    // Camera-thread local state
+    private val mat = Matrix()
+    private val pnt = Paint(Paint.FILTER_BITMAP_FLAG)
+    private var srcBitmap: Bitmap? = null
+    private var canvas1Bmp: Bitmap? = null
+    private var canvas1: Canvas? = null
+    private var canvas2Bmp: Bitmap? = null
+    private var canvas2: Canvas? = null
+
+    // FPS tracking (inference thread → main thread reads)
+    @Volatile
+    var fps: Int = 0
+        private set
+    private var frameCount = 0
+    private var lastFpsTime = System.currentTimeMillis()
+
+    /**
+     * Start the camera pipeline. Call from onCreate after layout is ready.
+     * The inference loop starts immediately and runs until [close].
+     */
+    fun start(lifecycleOwner: LifecycleOwner) {
+        startInferenceLoop()
+        bindCamera(lifecycleOwner)
+    }
+
+    private fun startInferenceLoop() {
+        inferenceRunning = true
+        inferenceExecutor.execute {
+            while (inferenceRunning) {
+                val bmp = try {
+                    frameChannel.poll(100, TimeUnit.MILLISECONDS)
+                } catch (e: InterruptedException) {
+                    break
+                } ?: continue
+
+                try {
+                    if (bmp.isRecycled) continue
+                    onFrame(bmp)
+
+                    frameCount++
+                    val now = System.currentTimeMillis()
+                    if (now - lastFpsTime >= 1000) {
+                        fps = frameCount
+                        frameCount = 0
+                        lastFpsTime = now
+                    }
+                } catch (e: Throwable) {
+                    Log.e(TAG, "Inference error: ${e.message}", e)
+                } finally {
+                    if (!bmp.isRecycled) freePool.offer(bmp)
+                }
+            }
+        }
+    }
+
+    private fun bindCamera(lifecycleOwner: LifecycleOwner) {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(activity)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+
+            @Suppress("DEPRECATION")
+            val analysis = ImageAnalysis.Builder()
+                .setTargetResolution(analysisResolution)
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
+                .build()
+
+            analysis.setAnalyzer(cameraExecutor) { proxy ->
+                if (!enabled) {
+                    proxy.close()
+                    return@setAnalyzer
+                }
+                try {
+                    handleProxy(proxy)
+                } catch (e: Throwable) {
+                    Log.e(TAG, "Camera thread error: ${e.message}", e)
+                    try { proxy.close() } catch (_: Exception) {}
+                }
+            }
+
+            cameraProvider.unbindAll()
+            if (previewView != null) {
+                @Suppress("DEPRECATION")
+                val preview = Preview.Builder()
+                    .setTargetResolution(previewResolution)
+                    .build().also {
+                        it.surfaceProvider = previewView.surfaceProvider
+                    }
+                cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, analysis)
+            } else {
+                cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, analysis)
+            }
+        }, ContextCompat.getMainExecutor(activity))
+    }
+
+    private fun handleProxy(proxy: ImageProxy) {
+        // Lazy init pool on first frame (need rotation info)
+        if (canvas1Bmp == null && canvas2Bmp == null) {
+            val rot = proxy.imageInfo.rotationDegrees
+            val w = if (rot == 90 || rot == 270) proxy.height else proxy.width
+            val h = if (rot == 90 || rot == 270) proxy.width else proxy.height
+            freePool.offer(Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888))
+            freePool.offer(Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888))
+        }
+
+        // Get a bitmap to write to (prefer free, fall back to displacing stale)
+        val bmp = freePool.poll() ?: frameChannel.poll() ?: run {
+            proxy.close()
+            return
+        }
+
+        proxyToBitmapInto(proxy, bmp)
+        proxy.close()
+
+        // Replace any frame currently in channel with the new (latest) one
+        val displaced = frameChannel.poll()
+        if (!frameChannel.offer(bmp)) {
+            freePool.offer(bmp)
+        }
+        if (displaced != null) freePool.offer(displaced)
+    }
+
+    /**
+     * Convert ImageProxy into the supplied destination bitmap (camera-thread only).
+     * Uses pre-allocated src bitmap and per-dst Canvas cache to avoid allocations.
+     */
+    private fun proxyToBitmapInto(proxy: ImageProxy, dst: Bitmap) {
+        val plane = proxy.planes[0]
+        val buf = plane.buffer
+        val sw = proxy.width + (plane.rowStride - plane.pixelStride * proxy.width) / plane.pixelStride
+
+        var src = srcBitmap
+        if (src == null || src.width != sw || src.height != proxy.height) {
+            src?.recycle()
+            src = Bitmap.createBitmap(sw, proxy.height, Bitmap.Config.ARGB_8888)
+            srcBitmap = src
+        }
+        buf.rewind()
+        src.copyPixelsFromBuffer(buf)
+
+        val rot = proxy.imageInfo.rotationDegrees.toFloat()
+        val canvas = canvasFor(dst)
+
+        if (rot == 0f && sw == proxy.width) {
+            canvas.drawBitmap(src, 0f, 0f, pnt)
+            return
+        }
+
+        val rw = if (rot == 90f || rot == 270f) proxy.height else proxy.width
+        val rh = if (rot == 90f || rot == 270f) proxy.width else proxy.height
+        mat.reset()
+        mat.postRotate(rot, proxy.width / 2f, proxy.height / 2f)
+        mat.postTranslate((rw - proxy.width) / 2f, (rh - proxy.height) / 2f)
+        canvas.drawBitmap(src, mat, pnt)
+    }
+
+    private fun canvasFor(bmp: Bitmap): Canvas {
+        if (canvas1Bmp === bmp) return canvas1!!
+        if (canvas2Bmp === bmp) return canvas2!!
+        return if (canvas1Bmp == null) {
+            canvas1Bmp = bmp
+            Canvas(bmp).also { canvas1 = it }
+        } else {
+            canvas2Bmp = bmp
+            Canvas(bmp).also { canvas2 = it }
+        }
+    }
+
+    override fun close() {
+        inferenceRunning = false
+        cameraExecutor.shutdown()
+        inferenceExecutor.shutdown()
+        srcBitmap?.recycle(); srcBitmap = null
+        while (true) freePool.poll()?.recycle() ?: break
+        while (true) frameChannel.poll()?.recycle() ?: break
+        canvas1 = null; canvas1Bmp = null
+        canvas2 = null; canvas2Bmp = null
+    }
+}

--- a/utilities/tools/sync_common.py
+++ b/utilities/tools/sync_common.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Check or update vendored copies of common/kotlin utilities across modules.
+
+Every module in this repo is an independent Gradle project, so shared Kotlin
+utilities are distributed as vendored copies (one physical file per module)
+instead of a shared Gradle module — a sample must stay standalone and fully
+readable on its own. This tool keeps those copies byte-identical to the
+canonical sources in common/kotlin/ (only the `package` line may differ).
+
+Usage:
+    python tools/sync_common.py --check   # list IDENTICAL/DIVERGED copies; exit 1 on drift
+    python tools/sync_common.py --apply   # rewrite diverged copies from the canonical
+"""
+
+import argparse
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+CANONICAL_DIR = REPO_ROOT / "utilities" / "common" / "kotlin"
+PACKAGE_PLACEHOLDER = "package __MODULE_PACKAGE__"
+
+# Copies that intentionally diverge from the canonical (see common/README.md).
+# They are reported but do not fail --check and are never rewritten by --apply.
+KNOWN_DIVERGENCES: set[str] = set()
+
+
+def normalized(lines: list[str]) -> list[str]:
+    """Drop the `package` declaration and the provenance header for comparison.
+
+    Both lines legitimately differ between the canonical and a vendored copy
+    (older copies predate the provenance header).
+    """
+    return [line for line in lines
+            if not line.startswith(("package ", "// Vendored from "))]
+
+
+def find_copies(name: str) -> list[pathlib.Path]:
+    """Find every module's vendored copy of a canonical file by basename."""
+    copies = []
+    # Sample apps sit at varying depths (compiled_model_api/<task>/<variant>/
+    # [android/]app/src/main/..., samples/litert/<name>/...), so match on the
+    # source-set suffix rather than a fixed prefix.
+    for pattern in (f"**/src/main/java/**/{name}", f"**/src/main/kotlin/**/{name}"):
+      for path in REPO_ROOT.glob(pattern):
+        if CANONICAL_DIR not in path.parents:
+          copies.append(path)
+    return sorted(copies)
+
+
+def package_line(path: pathlib.Path) -> str:
+    """Return the copy's own `package` line (falls back to the placeholder)."""
+    for line in path.read_text().splitlines():
+        if line.startswith("package "):
+            return line
+    return PACKAGE_PLACEHOLDER
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="report drift, exit 1 if any")
+    mode.add_argument("--apply", action="store_true", help="rewrite diverged copies")
+    args = parser.parse_args()
+
+    canonical_files = sorted(CANONICAL_DIR.glob("*.kt"))
+    if not canonical_files:
+        print(f"No canonical files in {CANONICAL_DIR}", file=sys.stderr)
+        return 2
+
+    drifted = 0
+    for canonical in canonical_files:
+        canonical_lines = normalized(canonical.read_text().splitlines())
+        copies = find_copies(canonical.name)
+        print(f"{canonical.name}: {len(copies)} copies")
+        for copy in copies:
+            if normalized(copy.read_text().splitlines()) == canonical_lines:
+                continue
+            rel = copy.relative_to(REPO_ROOT)
+            if str(rel) in KNOWN_DIVERGENCES:
+                print(f"  KNOWN-DIVERGED (allowlisted) {rel}")
+                continue
+            drifted += 1
+            if args.apply:
+                body = canonical.read_text().replace(
+                    PACKAGE_PLACEHOLDER, package_line(copy), 1)
+                copy.write_text(body)
+                print(f"  UPDATED  {rel}")
+            else:
+                print(f"  DIVERGED {rel}")
+
+    if args.check and drifted:
+        print(f"\n{drifted} diverged copies — run with --apply to update them.")
+        return 1
+    print(f"\nAll copies in sync." if not drifted else f"\n{drifted} copies updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A proposal rather than a finished piece. It relates to the directory reorganization already in progress (#238, #239), so it seems better raised while the layout is still settling than after it hardens.

The problem, counted rather than asserted: in this repository `ModelDownloader.kt` exists five times and all five have diverged. Across the sample apps here plus a ~40-app zoo built on the same APIs, the CameraX capture pipeline has 22 near-identical copies, Bitmap-to-tensor about 40, the 16 kHz AudioRecord loop about 10, and mel spectrogram 4 that have already drifted apart. The CompiledModel GPU lifecycle is the worst case, because its sharp edges are written down nowhere — named-signature `run`, reusing an output buffer as the next step's input for stateful models, `TensorBuffer` being `AutoCloseable` — so every sample re-discovers them.

The proposal is vendored copies rather than a shared Gradle module or a published artifact: the canonical source lives in `utilities/common/kotlin/`, each sample keeps its own physical copy with a provenance line, and `utilities/tools/sync_common.py --check` fails on drift. That keeps every sample standalone and buildable on its own, keeps the helper code readable inside the sample where a reader expects it, and adds no build coupling. If a real `com.google.ai.edge:…-utils` artifact is wanted later, this directory is exactly what it would be built from.

Status is deliberately conservative, and the README says all of this too. Nothing here is wired into a build, so merging changes no existing sample. Only `RealtimeCameraPipeline.kt` has production use, in the zoo; the other four are extracted from the recurring patterns and their first adopting sample is their compile and device verification. `sync_common.py`'s file search is re-pointed at this repository's variable-depth sample paths — `--check` runs and picks up all five canonicals, but with no vendored copies yet it reports `0 copies`, so the drift comparison itself has not been exercised here.

Whether the vendoring model is the right one is an open question, and there is no urgency. If a shared module or a different location is preferred, the canonical files move as-is.