### PR TITLE
gpu-clean-conversion skill: align with the CompiledModel checker, make it portable outside the repo

### DIFF
--- a/skills/gpu-clean-conversion/SKILL.md
+++ b/skills/gpu-clean-conversion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gpu-clean-conversion
-description: Convert a PyTorch or Hugging Face model into a LiteRT model that runs fully on the GPU delegate with verified-correct output, and lay it out as a model recipe. Use when converting a new model, or when a converted model is rejected by the delegate, falls back to CPU, or returns wrong numbers on device.
+description: Convert a PyTorch or Hugging Face model into a LiteRT model that runs fully on the GPU via the CompiledModel API with verified-correct output, and lay it out as a model recipe. Use when converting a new model, or when a converted model is rejected by the GPU, falls back to CPU, or returns wrong numbers on device.
 ---
 
 # GPU-clean conversion
@@ -8,7 +8,7 @@ description: Convert a PyTorch or Hugging Face model into a LiteRT model that ru
 A conversion is done when three things hold, in this order:
 
 1. it converts,
-2. every node runs on the GPU delegate,
+2. every node runs on the GPU,
 3. **the on-device output matches the source model.**
 
 Step 3 is not implied by step 2. The delegate can report full residency and
@@ -21,29 +21,36 @@ CPU or PyTorch on the actual device.
 **1. Convert plain first.** No patches. This tells you what the model
 actually needs rather than what you assumed.
 
-**2. Check the flatbuffer before touching a device.**
+**2. Verify through the CompiledModel API before touching a device.**
 
 ```python
 from litert_gpu_toolkit import check_gpu_compatibility, print_report
 print_report(check_gpu_compatibility("model.tflite"))
 ```
 
-It reports GPU-incompatible ops, delegate-only ops, Flex ops, and tensors
-above rank 4. Fix everything it lists before spending a device run.
+It compiles the model for the GPU accelerator, runs every signature on
+random inputs, and compares the outputs against a CPU-compiled reference.
+A failed GPU compile names the offending op — route it through the table
+below. A pass with a CPU-fallback warning means some ops fell back to the
+CPU; treat them the same way if you need full residency. This exercises the
+host GPU, so step 5 on the actual device is still required.
 
-**3. Map each symptom to a rewrite.** From `utilities/litert_gpu_toolkit`:
+**3. Map each symptom to a rewrite.** The rewrites live in
+`utilities/litert_gpu_toolkit` — plain Python, no build step. Outside this
+repo, clone litert-samples and put `utilities/` on `PYTHONPATH`, or vendor
+the directory:
 
 | What you see | Rewrite |
 |---|---|
-| `GATHER_ND` in the op list | Find its source. Stride-2 slicing (`x[:, ::2]`, Focus stems, patch merging), `grid_sample`, `MaxPool` padding, bicubic `interpolate`, and reflect-mode `F.pad` all lower to it. `patch_grid_sample`, `patch_maxpool_zeropad`, `patch_interpolate`, `patch_patch_merging` |
-| Tensors above rank 4 | `PixelShuffle` (rank-6 reshape), windowed attention, `einops.rearrange`, packed-QKV attention head splits. `pixelshuffle_to_conv_transpose`, `patch_window_attention`, `patch_einops` |
+| `GATHER_ND` named in the compile error | Find its source. Stride-2 slicing (`x[:, ::2]`, Focus stems, patch merging), `grid_sample`, `MaxPool` padding, bicubic `interpolate`, and reflect-mode `F.pad` all lower to it. `patch_grid_sample`, `patch_maxpool_zeropad`, `patch_interpolate`, `patch_patch_merging` |
+| A rank-5+ tensor named in the compile error | `PixelShuffle` (rank-6 reshape), windowed attention, `einops.rearrange`, packed-QKV attention head splits. `pixelshuffle_to_conv_transpose`, `patch_window_attention`, `patch_einops` |
 | `TRANSPOSE_CONV` rejected | Version skew, not a missing op. `ZeroStuffConvT1d` / `ZeroStuffConvT2d` — zero-stuff plus a plain conv, exact to ~1e-7 |
 | `SELECT` / `SELECT_V2` | `PReLU`, `ELU`, in-place index assignment, and `torch.where` masking. Replace with arithmetic: `x*(1-m) + v*m` |
 | `BROADCAST_TO` | An outer product or `.expand` on compile-time constants that did not fold. Bake the result as a constant at its target shape |
 | Compiles, runs, output is wrong or NaN | The fp16 reduction family. `patch_safe_layernorm`, `patch_rmsnorm`, `patch_instance_norm`, `hierarchical_mean`. Two caveats worth knowing before you apply them: `patch_safe_layernorm`'s default mode is not bit-faithful to stock LayerNorm (use `scale="adaptive"` when you need that), and `hierarchical_mean` is exact only for power-of-two spatial dims |
 | Head outputs exactly zero | RMSNorm `Σx²` overflowed fp16 to `inf`. `patch_rmsnorm` |
 
-**4. Re-convert and re-check.** Repeat 2–3 until the checker is clean.
+**4. Re-convert and re-verify.** Repeat 2–3 until the check passes.
 
 **5. Verify on device, numerically.** Run the same input through the source
 model and the on-device graph and compare. Correlation on the output tensor,
@@ -87,6 +94,10 @@ models/<family>/<model>/
 Keep the export, the reference dump, and the verification separate so each
 can be re-run alone. State the verification numbers in the README with the
 device they came from. Weights are not committed.
+
+The tree above is this repo's convention. In your own project the directory
+names matter less than the split — keep the same three separately-runnable
+pieces wherever your models live.
 
 Do the model first. A demo can follow, and reusable inference code matters
 more in it than a full UI.


### PR DESCRIPTION
Follow-up to #246 — this commit was pushed to that branch just after it merged, so it carries over here unchanged. It applies the intent from the review there (the skill serves other tools and people's own models/workflows, not just this repo) and syncs the skill with the CompiledModel-based checker from #245.

Details:
- Step 2 now describes the checker as it is after the #245 update: compile for the GPU accelerator via the CompiledModel API, run every signature, compare against a CPU reference — and the symptom table routes on the compile error rather than on an op list.
- Adds how to use the toolkit from outside this repo: plain Python with no build step — clone litert-samples and put `utilities/` on `PYTHONPATH`, or vendor the directory.
- Frames the `models/<family>/<model>/` layout as this repo's convention; the portable rule is the three separately-runnable pieces (export / reference dump / verify) wherever the models live.