### PR TITLE
utilities/common: reference the androidResources DSL in CompiledModelRunner KDoc

### DIFF
--- a/utilities/common/kotlin/CompiledModelRunner.kt
+++ b/utilities/common/kotlin/CompiledModelRunner.kt
@@ -50,7 +50,7 @@ class CompiledModelRunner private constructor(private val model: CompiledModel) 
     companion object {
         /**
          * Compiles a model bundled in `assets/`. The module's Gradle config must set
-         * `aaptOptions { noCompress += "tflite" }` so the asset stays mmappable.
+         * `androidResources { noCompress += "tflite" }` so the asset stays mmappable.
          */
         fun fromAssets(
             context: Context,


### PR DESCRIPTION
One-line doc fix in `CompiledModelRunner.kt` (#247): the `fromAssets` KDoc pointed at `aaptOptions { noCompress += "tflite" }`, which is the deprecated name for the block — current AGP spells it `androidResources { noCompress += "tflite" }`, and that is the form already used in this repo (`samples/litert/qualcomm/object_detection/efficientdet/kotlin_npu`). No code change.