### PR TITLE
docs: index all merged skills and utilities in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The samples demonstrate different API paradigms (LiteRT CompiledModel API and le
 * 📸 **PhotoTalk Sample App**: Added multimodal sample app combining LiteRT vision processing with LiteRT-LM audio/text generation ([`samples/litert/phototalk_sample_app/`](samples/litert/phototalk_sample_app/)).
 * 🗣️ **Qwen3-TTS & Qwen3 ASR**: Added model recipes, conversion scripts, and Tensor API implementations for [Qwen3-TTS](models/qwen/qwen3_tts/) and [Qwen3 ASR](models/qwen/qwen_asr/).
 * 🎨 **Bonsai Image 4B**: Added text-to-image diffusion model sample with Python inference and conversion tools ([`models/bonsai/bonsai_image_4b/`](models/bonsai/bonsai_image_4b/)).
-* 🤖 **Agent Skills & Utilities**: Added custom agent skills ([`skills/gpu-clean-conversion/`](skills/gpu-clean-conversion/)) and shared Kotlin helpers ([`utilities/common/`](utilities/common/)).
+* 🤖 **Agent Skills & Utilities**: Added four lifecycle agent skills ([`skills/`](skills/): conversion, quantization, on-device verification, app scaffolding), a GPU conversion toolkit ([`utilities/litert_gpu_toolkit/`](utilities/litert_gpu_toolkit/)), and shared Kotlin helpers ([`utilities/common/`](utilities/common/)).
 
 ---
 
@@ -38,11 +38,17 @@ Contains standalone model conversion scripts, export recipes, and model-specific
 
 ### **3. `utilities/` — Shared Tools & Helper Scripts**
 
-Common utilities and tools WIP.
+* **`utilities/common/`**: Shared Kotlin helpers for Android samples (camera pipeline, audio capture, CompiledModel runner, image/tensor and math helpers).
+* **`utilities/litert_gpu_toolkit/`**: Pre-conversion patches that rewrite common PyTorch patterns into forms the LiteRT GPU delegate accepts, plus a post-conversion checker.
 
 ### **4. `skills/` — Agent Automation & Skills**
 
-* Custom AI Agent skills and interactive workflows to streamline model deployment for LiteRT. WIP.
+Custom AI agent skills that carry a model through the LiteRT deployment lifecycle, in order — see [`skills/README.md`](skills/README.md) for the full index:
+
+* [`gpu-clean-conversion/`](skills/gpu-clean-conversion/): PyTorch / Hugging Face model → GPU-resident LiteRT model.
+* [`accuracy-safe-quantization/`](skills/accuracy-safe-quantization/): Quantize (fp16 / int8 / int4) without losing accuracy.
+* [`on-device-verification/`](skills/on-device-verification/): Prove the converted model on the actual device.
+* [`compiled-model-app-scaffolding/`](skills/compiled-model-app-scaffolding/): Build an Android app around the verified model.
 
 ---
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,3 +1,12 @@
 # Agent Skills
 
 Custom skills, interactive demos, and automation workflow extensions for AI agents.
+
+Each skill is a self-contained `SKILL.md` playbook covering one stage of taking a model to LiteRT on device. They chain in lifecycle order: convert → quantize → verify → build the app.
+
+## Available skills
+
+* [`gpu-clean-conversion/`](gpu-clean-conversion/) — Convert a PyTorch or Hugging Face model into a LiteRT model that runs fully on the GPU via the CompiledModel API, with verified-correct output, laid out as a model recipe.
+* [`accuracy-safe-quantization/`](accuracy-safe-quantization/) — Shrink a converted LiteRT model with ai-edge-quantizer (fp16 / int8 / int4) without losing accuracy, verifying parity against the float source after every step.
+* [`on-device-verification/`](on-device-verification/) — Prove a converted or quantized model on the actual device via the CompiledModel API: confirm GPU residency, compare device output against the source model, and diagnose device-only failures.
+* [`compiled-model-app-scaffolding/`](compiled-model-app-scaffolding/) — Build an Android app (Kotlin, Compose) around a verified LiteRT model using the CompiledModel API: app architecture, inference-layer lifecycle rules, model delivery, and UI traps.


### PR DESCRIPTION
The skills and utilities indexes had fallen behind what is on main: skills/README.md was still a three-line stub, and the root README listed only one of the four merged skills and did not mention utilities/litert_gpu_toolkit. This PR brings both files up to date with the directories as they exist today. Docs-only, no code changes.

Details, if useful:

- skills/README.md now lists all four merged skills with one-line descriptions, in lifecycle order (gpu-clean-conversion, accuracy-safe-quantization, on-device-verification, compiled-model-app-scaffolding).
- Root README: the What's New bullet covers the four skills plus the GPU toolkit, and the utilities/ and skills/ structure sections list their actual contents (utilities/common, utilities/litert_gpu_toolkit).
- This overlaps in intent with the index refresh discussed on #252 — if you would rather fold the index into that PR once it is refreshed, happy to close this one; whichever is easiest for you.