### PR TITLE
Zizmor fixes - security findings in GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: Zizmor Security Scan
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  zizmor:
+    name: Zizmor Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        run: zizmor .github/workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,15 @@ just getting started, Github has a [howto](https://help.github.com/articles/usin
 Edge AI team members will be assigned to review your pull requests. Once the pull requests are approved and pass continuous integration checks, we will merge the pull requests.
 For some pull requests, we will apply the patch for each pull request to our internal version control system first, and export the change out as a new commit later, at which point the original pull request will be closed. The commits in the pull request will be squashed into a single commit with the pull request creator as the author. These pull requests will be labeled as pending merge internally.
 
+### Security Requirements
+
+To maintain the security of our CI/CD pipelines, we use [Zizmor](https://github.com/woodruffw/zizmor) to statically analyze GitHub Actions workflows.
+
+If your pull request includes changes to GitHub Actions workflows (`.github/workflows/**`):
+* Your changes will be automatically scanned by Zizmor during the continuous integration checks.
+* All Zizmor checks must pass before the pull request can be approved and merged.
+* Please review and resolve any security issues flagged by Zizmor in your workflow changes.
+
 #### License
 
 Include a license at the top of new files.


### PR DESCRIPTION
This PR introduces [Zizmor](https://github.com/woodruffw/zizmor) to the repository to statically analyze and secure our GitHub Actions workflows against common misconfigurations and vulnerabilities.

* **New CI Workflow (`zizmor.yml`):** Added a workflow that automatically runs Zizmor on pull requests and pushes that modify the `.github/workflows/ `directory.
* **Strict Action Pinning:** Pinned the `actions/checkout` step in the new workflow to a specific commit SHA to adhere to Zizmor's recommended security policies against malicious tag modifications.
* **Documentation Updates (`CONTRIBUTING.md`):** Added a new "Security Requirements" section informing developers that any future workflow modifications will be strictly validated by Zizmor and must pass before merging.