### PR TITLE
fix(reachy-voice-robot): auto-download Inflect TTS weights from HF

### DIFF
--- a/samples/litert_lm/reachy-voice-robot/README.md
+++ b/samples/litert_lm/reachy-voice-robot/README.md
@@ -36,7 +36,7 @@ latency.*
 - **Reference hardware** (what the numbers below were measured on): Raspberry Pi 5, 8 GB · quad-core Arm Cortex-A76 · Debian 12 · Python 3.12
 - **Runtimes:** LiteRT (`ai-edge-litert`) 2.1.6 (+ ML Drift GPU backend) · LiteRT-LM 0.15.0
 - **Footprint:** ~2.6 GB of model files, ~2.4 GB resident (of 8 GB)
-- **GPU path (optional):** Mesa built from `main` with `V3D_WEBGPU_OVERRIDE` set (see Quickstart)
+- **GPU path (optional):** a recent `v3dv` Vulkan driver with `V3D_WEBGPU_OVERRIDE` set (see Quickstart) — Raspberry Pi OS **Trixie+**, or Mesa from `main` on Bookworm.
 - **Robot (optional):** a [Reachy Mini](https://www.pollen-robotics.com/) — or its MuJoCo
   simulator on a Mac (no hardware needed)
 
@@ -111,13 +111,13 @@ the CPU) is roughly 2×. The reply keeps streaming after that first sentence —
 pip install -r requirements.txt      # or, with uv:  uv sync
 ```
 
-The **speech-to-text** model auto-downloads from Hugging Face on first use. The **detector**
-(Ultralytics YOLO26) and the **synthesizer** (Inflect-Nano-v2) are local assets — their model
-files are produced/fetched once and placed under `assets/` (git-ignored): see
-`assets/yolo/README.md` for the detector and `assets/inflect/RUN.md` for the synthesizer. The
-**language model must be imported into LiteRT-LM once** (see step 2) — `litert-lm serve` only serves already-imported models. The GPU
-detector additionally needs a Mesa `v3dv` build with `V3D_WEBGPU_OVERRIDE` set; without it, skip
-the detector service (see step 2).
+The **speech-to-text** and the **synthesizer** (Inflect-Nano-v2) models auto-download from
+Hugging Face on first use (the `assets/` weights are git-ignored; see `assets/inflect/RUN.md`
+for the synthesizer). The **detector** (Ultralytics YOLO26) is exported once into `assets/yolo/`
+— see `assets/yolo/README.md`. The **language model must be imported into LiteRT-LM once** (see
+step 2) — `litert-lm serve` only serves already-imported models. The GPU
+detector additionally needs a recent v3dv Vulkan driver with `V3D_WEBGPU_OVERRIDE` set — Raspberry
+Pi OS Trixie+, or Mesa from `main` on Bookworm. Without it, skip the detector service (see step 2).
 
 ### 2. Run standalone on the robot's Pi
 
@@ -134,9 +134,11 @@ litert-lm import --from-huggingface-repo litert-community/gemma-4-E2B-it-litert-
 litert-lm serve --host 127.0.0.1 --port 9379
 python -m demo.serve --host 127.0.0.1 --port 9500
 
-# The GPU detector runs the detector on the GPU and needs the Mesa v3dv env
-# (point VK_ICD_FILENAMES at your v3dv ICD json); without it it cannot init.
-VK_ICD_FILENAMES=/path/to/v3dv_icd.json V3D_WEBGPU_OVERRIDE=1 \
+# The GPU detector runs the detector on the GPU and needs a recent v3dv driver.
+# Point VK_ICD_FILENAMES at its ICD json — on Raspberry Pi OS the stock driver is
+# /usr/share/vulkan/icd.d/broadcom_icd.aarch64.json (Trixie+; on Bookworm build
+# Mesa from main). Without a working v3dv driver, gpu_detect cannot init.
+VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/broadcom_icd.aarch64.json V3D_WEBGPU_OVERRIDE=1 \
   python -m demo.gpu_detect --host 127.0.0.1 --port 9600
 
 # Then the voice loop, using the robot as the I/O platform. Drop --gpu-detect-port

--- a/samples/litert_lm/reachy-voice-robot/emulator/inflect_tts.py
+++ b/samples/litert_lm/reachy-voice-robot/emulator/inflect_tts.py
@@ -31,25 +31,76 @@ Same interface as the other synthesizers: `speak(text) -> np.ndarray` plus a
 
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 
 import numpy as np
+from huggingface_hub import hf_hub_download
 
-# Bundled package location on the board (models + the Apache-2.0 text
-# frontend, which calls espeak-ng/GPL-3.0 in-process at runtime).
+# Bundled package location on the board: the runtime (say.py) and the Apache-2.0
+# text frontend, which calls espeak-ng/GPL-3.0 in-process at runtime. The LiteRT
+# weights (*.tflite) are gitignored, not shipped here — they are fetched from
+# Hugging Face into this directory on first use (see _ensure_weights), like the
+# sample's other models.
 DEFAULT_MODELS_DIR = Path(__file__).resolve().parent.parent / "assets" / "inflect"
 DEFAULT_FRONTEND_DIR = DEFAULT_MODELS_DIR / "frontend"
 SAMPLE_RATE = 24000
 
 
+def _ensure_weights(models_dir: Path, repo: str, precision: str) -> None:
+    """Fetch the encoder + decoder LiteRT weights from Hugging Face on first use.
+
+    ``*.tflite`` is gitignored, so the weights are not committed — only the
+    runtime (``say.py``) and the espeak frontend are. The two graphs for the
+    requested precision are downloaded next to ``say.py`` (where ``InflectTTS``
+    reads them by directory), mirroring how the speech-to-text model
+    auto-downloads. A file already present is left untouched, so this is a no-op
+    after the first run at a given precision (and for a manually populated dir).
+    """
+    if precision not in ("fp32", "fp16"):
+        raise ValueError(f"unknown precision {precision!r}; expected fp32 or fp16")
+    suffix = "" if precision == "fp32" else "_fp16"
+    for stem in ("inflect_text_encoder", "inflect_decoder"):
+        name = f"{stem}{suffix}.tflite"
+        dest = models_dir / name
+        if dest.exists():
+            continue
+        try:
+            cached = hf_hub_download(repo_id=repo, filename=name)
+        except Exception as exc:  # offline, missing repo/file, network error
+            raise SystemExit(
+                f"could not fetch the Inflect TTS weight {name!r} from Hugging "
+                f"Face repo {repo!r}: {type(exc).__name__}: {exc}. Check your "
+                f"network, or place the .tflite files in {models_dir} manually "
+                "(see assets/inflect/RUN.md).") from exc
+        models_dir.mkdir(parents=True, exist_ok=True)
+        # Copy into place atomically: a copy interrupted by a crash, a full disk,
+        # or a second process would otherwise leave a truncated .tflite that the
+        # dest.exists() check trusts forever (every later run then fails at model
+        # open). Write a per-process temp file, then os.replace() — an atomic
+        # rename on the same filesystem.
+        tmp = dest.with_name(f"{name}.{os.getpid()}.tmp")
+        try:
+            shutil.copyfile(cached, tmp)
+            os.replace(tmp, dest)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
 class InflectSynthesizer:
     def __init__(self, models_dir: Path | None = None,
                  frontend_dir: Path | None = None,
-                 precision: str = "fp32", threads: int = 4) -> None:
+                 precision: str = "fp32", threads: int = 4,
+                 repo: str | None = None) -> None:
         # say.py lives inside the package dir; import it from there.
         import sys
 
         models_dir = Path(models_dir or DEFAULT_MODELS_DIR)
+        # Pull the LiteRT weights from Hugging Face the first time (they are
+        # gitignored, so a fresh checkout has only say.py + the frontend).
+        if repo:
+            _ensure_weights(models_dir, repo, precision)
         # Derive the frontend from models_dir when not given explicitly, so an
         # injected models_dir carries its own frontend/ with it (for the default
         # models_dir this equals DEFAULT_FRONTEND_DIR — no behavior change).
@@ -73,6 +124,9 @@ class InflectSynthesizer:
 
 
 def load_inflect(models_dir: Path | None = None,
-                 frontend_dir: Path | None = None) -> InflectSynthesizer:
-    """Build the Inflect synthesizer from the bundled package."""
-    return InflectSynthesizer(models_dir=models_dir, frontend_dir=frontend_dir)
+                 frontend_dir: Path | None = None,
+                 repo: str | None = None) -> InflectSynthesizer:
+    """Build the Inflect synthesizer; fetch the LiteRT weights from ``repo`` on
+    first use if they are not already present in ``models_dir``."""
+    return InflectSynthesizer(models_dir=models_dir, frontend_dir=frontend_dir,
+                              repo=repo)

--- a/samples/litert_lm/reachy-voice-robot/emulator/models.py
+++ b/samples/litert_lm/reachy-voice-robot/emulator/models.py
@@ -35,6 +35,8 @@ class Model:
     """One model, described by whichever fields its stage needs:
 
     - Hugging Face download: ``repo`` + ``file``
+    - HF weights into a bundled dir: ``repo`` + ``dir`` — weights fetched from
+      HF next to a runtime that ships in the repo (e.g. the Inflect TTS)
     - bundled repo asset:    ``dir`` (a directory), or ``dir`` + ``file`` (one file)
     - served over HTTP (the LLM): ``endpoint`` + ``model``
     """
@@ -50,13 +52,14 @@ class Model:
         # This turns a typo in the registry below into a loud failure at import
         # time rather than a confusing error deep inside a loader — and unlike a
         # simple "exactly one kind is set" count, it also rejects a stray extra
-        # field (e.g. a repo left on a bundled dir, or a bare file with no repo or dir).
+        # field (e.g. an endpoint left on a bundled dir, or a bare file with no repo or dir).
         populated = frozenset(
             name for name in ("repo", "file", "dir", "endpoint", "model")
             if getattr(self, name) is not None
         )
         kinds = {
             frozenset({"repo", "file"}),        # HF download
+            frozenset({"repo", "dir"}),         # HF weights + bundled runtime dir
             frozenset({"dir"}),                 # bundled asset directory
             frozenset({"dir", "file"}),         # bundled single file
             frozenset({"endpoint", "model"}),   # served over HTTP
@@ -64,24 +67,28 @@ class Model:
         if populated not in kinds:
             raise ValueError(
                 "a Model must populate exactly one kind and nothing else — HF "
-                "(repo+file), bundled (dir, or dir+file), or served "
-                "(endpoint+model); "
+                "(repo+file), HF weights into a bundled dir (repo+dir), bundled "
+                "(dir, or dir+file), or served (endpoint+model); "
                 f"got {self!r}")
 
 
 # Every model, current values, in ONE place. Change a line to swap a model.
 MODELS: dict[str, Model] = {
-    # Ultralytics YOLO26 (yolo26n), exported to LiteRT and bundled in the repo
-    # (assets/yolo) rather than fetched from HF — it's ~10 MB and keeps the
-    # sample self-contained. Exported with the raw head (end2end=False) so the
+    # Ultralytics YOLO26 (yolo26n), exported to LiteRT once into assets/yolo
+    # (git-ignored, like the other weights — see assets/yolo/README.md) rather
+    # than fetched from HF. Exported with the raw head (end2end=False) so the
     # graph runs fully on the GPU delegate; postprocessing (decode + NMS) is on
     # the CPU. Swap it for another Ultralytics export by pointing this here.
     "yolo26n": Model(dir=_ASSETS / "yolo", file="yolo26n.tflite"),
     "moonshine-tiny": Model(
         repo="litert-community/moonshine-tiny",
         file="moonshine_tiny_5s_f32.tflite"),
-    # Bundled in the repo (assets/inflect), not fetched from HF — the default TTS.
-    "inflect-nano-v2": Model(dir=_ASSETS / "inflect"),
+    # Default TTS. The runtime (say.py) and espeak frontend ship in the repo
+    # (assets/inflect); the LiteRT weights are fetched from HF on first use (like
+    # the other models) because *.tflite is gitignored. Hosted in the LiteRT
+    # community org — a LiteRT export of owensong/Inflect-Nano-v2 (Apache-2.0).
+    "inflect-nano-v2": Model(repo="litert-community/Inflect-Nano-v2",
+                             dir=_ASSETS / "inflect"),
     "gemma-4-e2b": Model(
         endpoint="http://127.0.0.1:9379/v1/chat/completions", model="e2b"),
 }

--- a/samples/litert_lm/reachy-voice-robot/emulator/run.py
+++ b/samples/litert_lm/reachy-voice-robot/emulator/run.py
@@ -52,14 +52,15 @@ from emulator.timeline import Timeline
 
 
 def _download(m: models.Model) -> Path:
-    """Local path to a model file: a bundled asset if it ships in the repo
-    (``dir`` + ``file``), otherwise a Hugging Face download (``repo`` +
-    ``file``)."""
+    """Local path to a single model file: a bundled asset if it ships in the
+    repo (``dir`` + ``file``), otherwise a Hugging Face download (``repo`` +
+    ``file``). Models that fetch several files into a directory (``repo`` +
+    ``dir``, e.g. the Inflect TTS) load through their own loader, not here."""
     if m.dir is not None:
         if m.file is None:
             raise ValueError(
-                f"{m!r} is a bundled directory — load it via its own loader, "
-                "not _download")
+                f"{m!r} has no single file — a dir-based model loads via its "
+                "own loader, not _download")
         path = m.dir / m.file
         if not path.exists():
             raise SystemExit(
@@ -99,7 +100,8 @@ def build_synthesizer(kind: str = "inflect"):
     name from the catalog (emulator/models.py).
     """
     from emulator.inflect_tts import load_inflect
-    return load_inflect(models_dir=models.get(models.TTS["inflect"]).dir)
+    m = models.get(models.TTS["inflect"])
+    return load_inflect(models_dir=m.dir, repo=m.repo)
 
 
 def build_pipeline(tokenizer_path: Path, skip_llm: bool,

--- a/samples/litert_lm/reachy-voice-robot/tests/test_inflect_tts.py
+++ b/samples/litert_lm/reachy-voice-robot/tests/test_inflect_tts.py
@@ -50,3 +50,93 @@ def test_speak_whitespace_only_text_is_also_short_circuited():
 
 def test_sample_rate_matches_measured_inflect_output():
     assert SAMPLE_RATE == 24000
+
+
+def test_ensure_weights_downloads_missing_then_skips_present(tmp_path, monkeypatch):
+    # Regression guard for the fresh-clone crash: the *.tflite weights are
+    # gitignored, so a checkout has none and they must be fetched from HF before
+    # the model is opened. Missing weights are downloaded; a warm dir is a no-op.
+    import emulator.inflect_tts as it
+
+    fetched = []
+
+    def fake_download(repo_id, filename):
+        fetched.append(filename)
+        src = tmp_path / f"cache__{filename}"
+        src.write_bytes(b"stub")
+        return str(src)
+
+    monkeypatch.setattr(it, "hf_hub_download", fake_download)
+    dest = tmp_path / "inflect"
+    it._ensure_weights(dest, "some/repo", "fp32")
+    assert sorted(fetched) == ["inflect_decoder.tflite", "inflect_text_encoder.tflite"]
+    assert (dest / "inflect_text_encoder.tflite").exists()
+    assert (dest / "inflect_decoder.tflite").exists()
+
+    fetched.clear()
+    it._ensure_weights(dest, "some/repo", "fp32")
+    assert fetched == []  # already present -> no re-download
+
+
+def test_init_wires_the_weight_fetch(tmp_path, monkeypatch):
+    # The regression that shipped was the call SITE doing nothing, not the helper.
+    # Guard against InflectSynthesizer.__init__ ever dropping the `_ensure_weights`
+    # call: spy on the helper and stub `say` so __init__ runs without the model.
+    import sys
+    import types
+    import emulator.inflect_tts as it
+
+    calls = []
+    monkeypatch.setattr(it, "_ensure_weights",
+                        lambda md, repo, prec: calls.append((md, repo, prec)))
+    fake_say = types.ModuleType("say")
+    fake_say.InflectTTS = lambda **kw: types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "say", fake_say)
+
+    it.InflectSynthesizer(models_dir=tmp_path, repo="some/repo")
+    assert calls == [(tmp_path, "some/repo", "fp32")]  # fetch fired with the repo
+
+    calls.clear()
+    it.InflectSynthesizer(models_dir=tmp_path, repo=None)
+    assert calls == []  # repo=None (manually populated dir) -> no fetch
+
+
+def test_ensure_weights_fetches_only_the_missing_file(tmp_path, monkeypatch):
+    # Each file is checked independently, so a half-populated dir (an interrupted
+    # first download) fetches only what is missing, not both.
+    import emulator.inflect_tts as it
+
+    fetched = []
+
+    def fake_download(repo_id, filename):
+        fetched.append(filename)
+        src = tmp_path / f"cache__{filename}"
+        src.write_bytes(b"stub")
+        return str(src)
+
+    monkeypatch.setattr(it, "hf_hub_download", fake_download)
+    dest = tmp_path / "inflect"
+    dest.mkdir()
+    (dest / "inflect_text_encoder.tflite").write_bytes(b"already here")
+    it._ensure_weights(dest, "some/repo", "fp32")
+    assert fetched == ["inflect_decoder.tflite"]  # only the missing graph
+    assert (dest / "inflect_decoder.tflite").exists()
+
+
+def test_ensure_weights_fp16_uses_the_fp16_filenames(tmp_path, monkeypatch):
+    # The _fp16 suffix must match the names say.py reads (say.py builds the same
+    # `{stem}{suffix}.tflite`); a mismatch would fetch names the runtime never loads.
+    import emulator.inflect_tts as it
+
+    fetched = []
+
+    def fake_download(repo_id, filename):
+        fetched.append(filename)
+        src = tmp_path / f"cache__{filename}"
+        src.write_bytes(b"stub")
+        return str(src)
+
+    monkeypatch.setattr(it, "hf_hub_download", fake_download)
+    it._ensure_weights(tmp_path / "inflect", "some/repo", "fp16")
+    assert sorted(fetched) == [
+        "inflect_decoder_fp16.tflite", "inflect_text_encoder_fp16.tflite"]

--- a/samples/litert_lm/reachy-voice-robot/tests/test_models.py
+++ b/samples/litert_lm/reachy-voice-robot/tests/test_models.py
@@ -108,24 +108,28 @@ def test_llm_is_a_served_endpoint_not_an_hf_download():
     assert m.repo is None and m.file is None
 
 
-def test_inflect_is_a_bundled_dir():
+def test_inflect_fetches_weights_into_a_bundled_dir():
+    # Inflect ships its runtime (say.py + frontend) in assets/inflect but fetches
+    # the LiteRT weights from HF on first use — repo + dir populated together.
     m = models.get(models.TTS["inflect"])
     assert m.dir is not None and m.dir.name == "inflect"
-    assert m.repo is None
+    assert m.repo is not None
 
 
 def test_build_synthesizer_selects_the_backend_model_by_name(monkeypatch):
     # The point of the catalog: build_synthesizer resolves the synthesizer by
-    # name (no network for the bundled inflect default), so swapping the name
-    # swaps the backend with no other code change.
+    # name, so swapping the name swaps the backend with no other code change.
+    # It also passes the model's HF repo through so the weights can auto-download.
     from emulator import run
 
     seen = {}
 
-    def fake_load_inflect(models_dir=None):
+    def fake_load_inflect(models_dir=None, repo=None):
         seen["models_dir"] = models_dir
+        seen["repo"] = repo
         return "INFLECT"
 
     monkeypatch.setattr("emulator.inflect_tts.load_inflect", fake_load_inflect)
     assert run.build_synthesizer("inflect") == "INFLECT"
     assert seen["models_dir"] == models.get("inflect-nano-v2").dir
+    assert seen["repo"] == models.get("inflect-nano-v2").repo


### PR DESCRIPTION
## What & why

Fixes a fresh-clone startup crash in the `reachy-voice-robot` sample.

The default TTS (Inflect-Nano-v2) LiteRT weights (`assets/inflect/*.tflite`) are git-ignored by the repo-wide `*.tflite` rule and were never downloaded from anywhere, so a fresh clone crashed while building the synthesizer:

```
ValueError: Could not open '.../assets/inflect/inflect_text_encoder.tflite'
```

## Fix

Auto-download the weights from the official [`litert-community/Inflect-Nano-v2`](https://huggingface.co/litert-community/Inflect-Nano-v2) HF repo on first use, the same way the moonshine STT model is already fetched — so `clone → run` works out of the box, no manual step.

- **models.py** — the inflect entry gains a `repo` (`litert-community/Inflect-Nano-v2`); the `Model` validator accepts a new `repo + dir` kind (weights fetched from HF into a bundled runtime dir).
- **inflect_tts.py** — `_ensure_weights` fetches the encoder + decoder for the requested precision, copies each into place **atomically** (temp file + `os.replace`, so an interrupted copy can't leave a truncated `.tflite` that later runs trust), and raises a clear error on a network/404 failure.
- **run.py** — pass the model's repo through; clarify the `_download` docstring for the new kind.
- **README** — STT and the synthesizer both auto-download; the detector (YOLO26) is still exported once locally. Also recommends the stock `/usr/share/vulkan/icd.d/broadcom_icd.aarch64.json` v3dv ICD by default, with a Mesa `main` build only as a fallback.
- **tests** — guard the fresh-clone path that had no coverage: the `__init__` call site actually triggers the fetch, a partial dir fetches only the missing graph, and the fp16 filename contract matches the runtime.

## Verification

- Full suite green (316 tests).
- Clean-clone smoke: wiped `assets/inflect/*.tflite`, ran first-use → both graphs auto-downloaded from `litert-community/Inflect-Nano-v2` and opened in LiteRT (byte-identical to the reference weights), no temp residue.
