### PR TITLE
speech_recognition: add Parakeet TDT-CTC 0.6B (ja) as a supported model

### DIFF
--- a/samples/litert/speech_recognition/AndroidApp/app/src/main/assets/model_metadata.json
+++ b/samples/litert/speech_recognition/AndroidApp/app/src/main/assets/model_metadata.json
@@ -23,6 +23,17 @@
       "preemphasis": 0.97
     }
   },
+  "parakeet-tdt_ctc-0.6b-ja": {
+    "modelRemoteUrl": "https://huggingface.co/litert-community/parakeet-tdt_ctc-0.6b-ja/resolve/main/parakeet_tdt_ctc_0.6b_ja_5s_i8.tflite",
+    "tokenizerUrl": "https://huggingface.co/litert-community/parakeet-tdt_ctc-0.6b-ja/resolve/main/tokenizer.json",
+    "inputMilliseconds": 5000,
+    "logMelSpectro": {
+      "nFFT": 512,
+      "nFrames": 500,
+      "preemphasis": 0.97
+    },
+    "decodeStartTokenId": 3072
+  },
   "moonshine-tiny": {
     "modelRemoteUrl": "https://huggingface.co/litert-community/moonshine-tiny/resolve/main/moonshine_tiny_5s_i8.tflite",
     "npuModelRemoteUrlPattern": "https://huggingface.co/litert-community/moonshine-tiny/resolve/main/moonshine_tiny_5s_f32_<target>.tflite",

--- a/samples/litert/speech_recognition/AndroidApp/app/src/main/java/com/google/ai/edge/examples/asr/MainActivity.kt
+++ b/samples/litert/speech_recognition/AndroidApp/app/src/main/java/com/google/ai/edge/examples/asr/MainActivity.kt
@@ -260,7 +260,7 @@ class MainActivity : AppCompatActivity() {
               modelKey.contains("-ctc-") -> { _, _ ->
                 CtcDecoder(tokenizer!!.vocabSize)
               }
-              modelKey.contains("-tdt-") -> { model, config ->
+              modelKey.contains("-tdt") -> { model, config ->
                 TdtDecoder(model, config)
               }
               else -> { model, config ->

--- a/samples/litert/speech_recognition/README.md
+++ b/samples/litert/speech_recognition/README.md
@@ -14,6 +14,7 @@ open-weight ASR models. The table below outlines the supported backends for each
 | :--: | :--: | :--: | :--: | :-- |
 | [**Parakeet TDT**](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) | ✅ | ✅ | Pixel 10 | Nvidia's Transducer-Duration-Transducer model |
 | [**Parakeet CTC**](https://huggingface.co/nvidia/parakeet-ctc-0.6b) | ✅ | ✅ | Galaxy S23/24 | Nvidia's Connectionist-Temporal-Classification model |
+| [**Parakeet TDT-CTC (ja)**](https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja) | ✅ | ✅ | | Japanese ASR with punctuation (hybrid model, TDT branch) |
 | [**Moonshine**](https://huggingface.co/UsefulSensors/moonshine-tiny) | ✅ | ✅ | | A lightweight, low-latency autoregressive ASR model |
 | [**Whisper**](https://huggingface.co/openai/whisper-tiny) | ✅ | ✅ | | OpenAI's robust multilingual ASR and translation model |
 | [**Qwen3-ASR**](https://huggingface.co/Qwen/Qwen3-ASR-0.6B) | ✅ | | | Robust multimodal/speech language model capability |

--- a/samples/litert/speech_recognition/convert/parakeet_tdt.py
+++ b/samples/litert/speech_recognition/convert/parakeet_tdt.py
@@ -192,3 +192,22 @@ class ParakeetTDT(asr_model.AsrModel):
         tokens=out[0].y_sequence.unsqueeze(0).long()
         # timestamps=out[0].timestamp.unsqueeze(0),
     )
+
+
+class ParakeetTDTCTCJa(ParakeetTDT):
+  """Wrapper for the Japanese hybrid TDT-CTC Parakeet, using the TDT branch.
+
+  nvidia/parakeet-tdt_ctc-0.6b-ja is an EncDecHybridRNNTCTCBPE model whose
+  encoder, prediction network and joint mirror parakeet-tdt-0.6b-v3 (1024-d
+  FastConformer encoder, 2-layer 640-d LSTM, TDT durations [0, 1, 2, 3, 4]);
+  only the tokenizer (Japanese SentencePiece, vocab 3072, so the blank token
+  is 3072) and the mel features (80 bins instead of 128) differ.
+  """
+
+  HF_MODEL_ID = 'nvidia/parakeet-tdt_ctc-0.6b-ja'
+  BLANK_TOKEN_ID = 3072  # joint outputs 3072 tokens + blank + 5 durations
+
+  def __init__(
+      self, model_id: str = HF_MODEL_ID, override_transformers: bool = False
+  ):
+    super().__init__(model_id, override_transformers)

--- a/samples/litert/speech_recognition/convert/supported_models.py
+++ b/samples/litert/speech_recognition/convert/supported_models.py
@@ -24,6 +24,7 @@ from samples.litert.speech_recognition.convert import whisper
 SUPPORTED_MODELS = {
     parakeet_ctc.ParakeetCTC.HF_MODEL_ID: parakeet_ctc.ParakeetCTC,
     parakeet_tdt.ParakeetTDT.HF_MODEL_ID: parakeet_tdt.ParakeetTDT,
+    parakeet_tdt.ParakeetTDTCTCJa.HF_MODEL_ID: parakeet_tdt.ParakeetTDTCTCJa,
     moonshine.Moonshine.HF_MODEL_ID: moonshine.Moonshine,
     whisper.Whisper.HF_MODEL_ID: whisper.Whisper,
     qwen3_asr.Qwen3Asr.HF_MODEL_ID: qwen3_asr.Qwen3Asr,


### PR DESCRIPTION
## Summary

This adds Japanese speech recognition to the `speech_recognition` sample: [`nvidia/parakeet-tdt_ctc-0.6b-ja`](https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja) (CC-BY-4.0, hybrid FastConformer TDT-CTC, punctuated output) as a new supported model. The registry-driven design made this a small addition — the hybrid loads through the existing `ParakeetTDT` NeMo path, so the diff is a constants-only subclass, a registry entry, a `model_metadata.json` entry, and one substring in the decoder factory. Converted artifacts are published at [litert-community/parakeet-tdt_ctc-0.6b-ja](https://huggingface.co/litert-community/parakeet-tdt_ctc-0.6b-ja).

## What's included

- `convert/parakeet_tdt.py` — `ParakeetTDTCTCJa(ParakeetTDT)`: only `HF_MODEL_ID` and `BLANK_TOKEN_ID` (3072; the ja tokenizer has 3072 tokens) change. Encoder width (1024), prediction net (2×640 LSTM) and TDT durations ([0..4]) match v3, so `TdtDecoder.kt` and its constants needed no changes.
- `convert/supported_models.py` — registry entry.
- `AndroidApp` `model_metadata.json` — the ja entry: 80 mel bins (the config default; v3 uses 128), `decodeStartTokenId` 3072. The HF repo also hosts a `tokenizer.json` for the app's tokenizer, converted from the NeMo SentencePiece model (the nvidia repo ships only the `.nemo`); decode parity vs SentencePiece verified on 200 random id sequences plus real Japanese text.
- `MainActivity.kt` — the decoder factory now matches `"-tdt"` so the hybrid's `-tdt_ctc-` key reaches `TdtDecoder`; existing keys resolve as before.
- README — one row in the supported-models table.

## Verification

- Desktop (CompiledModel Python API, CPU): the f32 export reproduces NeMo `transcribe()` **exactly on all 28 five-second windows** of a 137 s CC0 Japanese test read (joined CER 0.0000). The i8 DRQ export matches on 14/28 windows, joined CER 6.1% against the fp32 output.
- On device (Pixel 8a, LiteRT 2.1.5): f32 on GPU — both signatures fully delegated (1862/1862 and 2083/2083 nodes on `LITERT_CL`), greedy TDT ids identical to the desktop/NeMo decode; encode 239 ms per 5 s window, decode 95 ms per stateless call. i8 verified on the CPU backend (1157 ms / 380 ms).
- One limitation: the i8 file does not compile on the Pixel 8a's Mali GPU (`Unable to parse bc coord for BATCH axis`, reproduced on 2.1.3 and 2.1.5). It uses the same graph layout and DRQ recipe as v3, so Adreno/Tensor devices from the v3 validation list should behave as they do for v3, but I don't have one to confirm on. The metadata entry defaults to the i8 file like the other models; on Mali devices the app's CPU backend runs it, and the f32 file runs on the Mali GPU.
- Environment note: on macOS, importing litert-torch and then loading a NeMo model in one process crashes sentencepiece's model loader. I produced the artifacts by running the identical class wiring split across two processes (NeMo load+save, then wrap+convert). The committed code is the straight single-process path used by the other supported models; flagging it in case anyone converts on a Mac.

## Links

- Published artifacts + measurements: https://huggingface.co/litert-community/parakeet-tdt_ctc-0.6b-ja (f32 2.4 GB, i8 608 MB, tokenizer.json; card carries the full device numbers)
- Base model: https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja (CER 6.4 JSUT / 7.1 CV8 / 9.0 TEDxJP per the upstream card)

Happy to reshape any of this — splitting the app wiring from the convert change, a different default file in the metadata, or hosting changes — whatever fits the sample best.
