### PR TITLE
speech_recognition: fix two stateful-decode defects in TdtDecoder (blank-step state adoption, early decode_1 switch)

### DIFF
--- a/samples/litert/speech_recognition/AndroidApp/app/src/main/java/com/google/ai/edge/examples/asr/TdtDecoder.kt
+++ b/samples/litert/speech_recognition/AndroidApp/app/src/main/java/com/google/ai/edge/examples/asr/TdtDecoder.kt
@@ -102,8 +102,10 @@ class TdtDecoder(private val compiledModel: CompiledModel, private val modelConf
           yield(Pair(tokenId, timeIndex))
           if (numOfInferenceTokenIds > 1) {
             tokenIndex++
-            if (tokenIndex < numOfInferenceTokenIds - 1) {
-              // No-op.
+            if (tokenIndex < numOfInferenceTokenIds) {
+              // Still room in the stateless token array: keep filling it, so the
+              // LSTM states handed to decode_1 below are computed from real
+              // tokens only (an unfilled zero slot skews them).
             } else if (hasDecode1) { // Switch to decode_1 for stateful decoding.
               inferenceSignature = DECODE_1_SIGNATURE
               numOfInferenceTokenIds = 1
@@ -123,8 +125,12 @@ class TdtDecoder(private val compiledModel: CompiledModel, private val modelConf
             ?: endIndexOfTokenId) - endIndexOfTokenId
         timeIndex += if (duration == 0 && tokenId == blankTokenId) 1 else duration
 
-        if (numOfInferenceTokenIds == 1) {
-          // Stateful RNN decoder: Swap input and output state buffers for the next decode.
+        if (numOfInferenceTokenIds == 1 && tokenId != blankTokenId) {
+          // Stateful RNN decoder: adopt the new LSTM states by swapping the
+          // input and output state buffers — but only on a non-blank emission.
+          // In RNN-T greedy decoding the prediction network advances only when
+          // a token is emitted; adopting the state on blank steps re-consumes
+          // the last token once per blank and degrades the transcript.
           inputStatesBuffersIndex = 1 - inputStatesBuffersIndex
         }
       }


### PR DESCRIPTION
## Summary

Two small fixes to `TdtDecoder.kt`'s stateful (`decode_1`) path. With them, the stateful decode reproduces the reference NeMo `transcribe()` output exactly in my tests; today it loses accuracy relative to the same model's stateless path. The stateless path is untouched. The whole diff is one condition change plus one condition, with comments.

## The two defects

1. **The state buffers swap on every `decode_1` call, including blank emissions.** In RNN-T/TDT greedy decoding the prediction network advances only when a token is emitted; on a blank, the decoder state must stay put while the time index moves. Swapping unconditionally adopts an LSTM step that re-consumed the last token, once per blank step — and blanks dominate the loop.
2. **The decode → decode_1 switch happens one token early.** `tokenIndex < numOfInferenceTokenIds - 1` switches while the last slot of the stateless token array is still zero, so the LSTM states handed to `decode_1` were computed with a trailing garbage token. Filling the array completely first (`< numOfInferenceTokenIds`) hands over states computed from real tokens only. This also lets stateless-only models use their full token capacity.

## Measurements

Method: a Python mirror of `TdtDecoder.kt`'s exact loop (CompiledModel API, CPU), run over 28 five-second windows of a 137 s CC0 Japanese test read, compared against NeMo `transcribe()` on the same audio. Model: the published [litert-community/parakeet-tdt_ctc-0.6b-ja](https://huggingface.co/litert-community/parakeet-tdt_ctc-0.6b-ja) f32 stateful file (N=4 `decode` + `decode_1`, the same signature layout as `parakeet-tdt-0.6b-v3`'s stateful files).

| Decoder semantics | Windows exactly matching NeMo | joined CER vs NeMo |
|---|---|---|
| current `TdtDecoder.kt` | 16 / 28 | 6.25% |
| + fix 1 (non-blank-only state adoption) | 25 / 28 | 0.74% |
| + fix 2 (fill the array before switching) | **28 / 28** | **0.0000** |

For reference, the same model's stateless 64-token file already scores 28/28 through the current decoder — the gap is specific to the stateful path. `parakeet-tdt-0.6b-v3`'s stateful files go through the same code path, so I would expect some effect there too, but I have only measured Japanese; I'm happy to run the same A/B on v3 if that would help.

## Testing

- `:app:compileDebugKotlin` green.
- Fix semantics validated end-to-end on desktop (table above) and the same model's `decode`/`decode_1` signatures verified on a Pixel 8a GPU (both fully delegated; decode_1 logits match desktop CPU, token argmax identical).

Happy to reshape anything — split the two fixes, different comment wording, or additional validation on v3.
