### PR TITLE
Add Granite-4.1-3B conversion recipe to models/granite/granite_4_1_3b

### DIFF
--- a/models/granite/granite_4_1_3b/README.md
+++ b/models/granite/granite_4_1_3b/README.md
@@ -1,0 +1,3 @@
+# Granite 4.1 3B Language Model
+
+Model recipes, conversion scripts, instructions, and utilities for IBM Granite 4.1 3B on-device text generation ([ibm-granite/granite-4.1-3b](https://huggingface.co/ibm-granite/granite-4.1-3b)).

--- a/models/granite/granite_4_1_3b/converted/.gitignore
+++ b/models/granite/granite_4_1_3b/converted/.gitignore
@@ -1,0 +1,4 @@
+*.litertlm
+out_*/
+__pycache__/
+.strip_start_token_tmp/

--- a/models/granite/granite_4_1_3b/converted/README.md
+++ b/models/granite/granite_4_1_3b/converted/README.md
@@ -1,0 +1,92 @@
+# Granite-4.1-3B Conversion
+
+Model recipes, instructions, scripts, and utilities for converting IBM Granite 4.1 3B to LiteRT-LM.
+
+These scripts convert [ibm-granite/granite-4.1-3b](https://huggingface.co/ibm-granite/granite-4.1-3b) (dense `GraniteForCausalLM`, 3.4B parameters, Apache-2.0) into `.litertlm` bundles for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a quality gate. The published artifacts live at [litert-community/granite-4.1-3b](https://huggingface.co/litert-community/granite-4.1-3b).
+
+The model is a 40-layer dense transformer (hidden 2560, GQA 40:8, vocab 100352, tied embeddings) with Granite's four scaling multipliers (attention / embedding / logits / residual), all handled by the plain litert-torch HF export path — no re-authoring needed. What this conversion documents instead is a **metadata trap**: a `start_token` the bundle must NOT carry, which made a healthy model look like a broken quantization.
+
+## Builds
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int4` | blockwise-32 OCTAV int4 weights, int8 embedding | 2.19 GB | the ship build: phone GPU |
+| `int8` | dynamic int8 weights, fp32 activations | 3.83 GB | quality reference / desktop |
+
+## Environment
+
+```bash
+pip install litert-torch==0.9.3 litert-converter==0.3.1 ai-edge-quantizer==0.8.0 \
+    litert-lm-builder==0.16.0 transformers==5.14.1
+pip install litert-lm   # verification CLI (>= 0.16.0)
+```
+
+## Run
+
+```bash
+python build_granite_4_1_3b.py --recipe int4 --out out_int4     # ~2.19 GB bundle
+python verify_granite_4_1_3b.py out_int4/*.litertlm --backend cpu   # 8-question gate
+python verify_granite_4_1_3b.py out_int4/*.litertlm --check-metadata  # no start_token?
+```
+
+## The start_token trap (the reason this recipe exists)
+
+granite's `tokenizer_config.json` declares `add_bos_token: False`, and its BOS is *the same token as its EOS* (`<|end_of_text|>`, id 100257). But the bundle builder sets `start_token` from `tokenizer.bos_token` unconditionally — it never consults `add_bos_token` — and the runtime prepends that token on the first turn. The model then reads the prompt as a document that has already ended: it echoes the question back, or emits a run of backticks, instead of answering. The naive export failed the 8-question gate at 5/8.
+
+**Proof it is the prompt and not the quantization** — the same rendered prompt, bf16 PyTorch, greedy, with and without the leading BOS (`verify_granite_4_1_3b.py --bos-ab` reproduces this):
+
+| question | no BOS | with BOS |
+|---|---|---|
+| How many days are in a week? | `There are 7 days in a week.` | `Answer briefly.` |
+| What is 8 times 7? | `56` | `What is 8 times 7? Answer briefly. \n``````…` |
+| What is 17 + 25? | `17 + 25 = 42` | `What is 17 + 25? Answer briefly. \n` |
+
+The bundle reproduced the with-BOS column exactly. **Fix: keep the field out of the metadata.** `build_granite_4_1_3b.py` clears `tokenizer.bos_token` before export, so the bundle carries no `start_token` at all; `strip_start_token.py` repairs an already-built bundle (~30 s, weights untouched). Result: 8Q **5/8 → 8/8** on CPU, 8/8 on GPU — same weights, same file size, only the metadata field.
+
+**The trap wears a quantization costume.** An earlier int4 measurement of this same checkpoint — with the start_token in the bundle — recorded GSM8K collapsing from 88.0% (bf16) to 61%, and per-layer int8 rescue experiments moved nothing, so the damage looked diffuse and unfixable. With the start_token removed, the same int4 recipe measures 84.0%. The bf16 baseline had gone through HF, which honours `add_bos_token: False`; only the bundle side got the extra token, so the comparison was never apples-to-apples. If a converted LLM parrots the prompt or degenerates, check the prompt path before blaming the quantization — the bf16 A/B above costs one minute.
+
+**Which models are eligible.** Any checkpoint whose tokenizer declares `add_bos_token: False` gets a token prepended that it never saw in that position at training time; bos == eos is the worst case (OLMo-2 and Phi-4-mini share the shape). But eligibility is not breakage: the published OLMo-2-1B bundle carries the same `start_token` shape and scores 8/8 both as-is and stripped. The trap is model-dependent — sweep each candidate with the A/B, do not assume.
+
+## Quantization ladder
+
+GSM8K, n=100, greedy, 0-shot CoT, 512-token budget — all with the start_token fix:
+
+| build | GSM8K | 8Q CPU | 8Q GPU |
+|---|---|---|---|
+| bf16 (HF reference) | 88.0% | 8/8 | — |
+| int8 `dynamic_wi8_afp32` | 87.0% | 8/8 | 8/8 |
+| int4 blockwise-32 OCTAV | 84.0% | 8/8 | 8/8 |
+
+The ordinary, healthy shape — int4 costs this model 4 points, not 27.
+
+## Prefill signatures and memory
+
+- The default ladder is **6 signatures** (`1024,256,64,16,4,1`). Each signature costs per-signature engine memory at init: on an iPhone 17 Pro (Metal expands weights to roughly 4× the file size) the 11-signature variant of the same build jetsams at engine init at the bundle's default 4096 context, while the 6-signature build passes 8/8 there (init 11.5 s). The two files differ by 12 MB on disk; the difference is entirely init-time memory.
+- `externalize_embedder=True` splits the tied 100352×2560 vocab table into its own bundle section, keeping the main weights section under the iOS ~2 GiB single-section mmap ceiling. No effect on weights or parity.
+- GPU weight residency (Metal, and Adreno-class Android) is ~4× the *file* size — the reason int4 (2.19 GB → ~8.2 GB resident) is the phone-GPU build and int8 (3.83 GB → ~14 GB) is the desktop build. Mali is the exception: the delegate skips GPU-side weights preparation there, and both builds complete on an 8 GB Pixel 8a.
+
+## Verification results
+
+Mac (M4 Max, `litert-lm benchmark --cache no -p 256 -d 256`, quiet machine):
+
+| build | backend | prefill tok/s | decode tok/s | TTFT | init |
+|---|---|---|---|---|---|
+| int4 | GPU (Metal) | 1241.3 | 86.3 | 0.23 s | 6.0 s |
+| int4 | CPU | 104.2 | 22.0 | 3.0 s | 12.5 s |
+| int8 | GPU (Metal) | 1221.4 | 71.8 | 0.24 s | 5.2 s |
+| int8 | CPU | 256.9 | 20.5 | 3.1 s | 43.2 s |
+
+Two shapes worth noticing: on Metal, int4 buys +20% GPU decode over int8 on top of halving the bytes; on CPU, int8's prefill is 2.5× int4's at equal decode — blockwise int4 dequant costs more than it saves when XNNPACK is doing large matmuls.
+
+On device:
+
+- **Pixel 8a** (Tensor G3, Mali-G715, 8 GB), int4, GPU (OpenCL): prefill 20.0 tok/s, decode 7.07 tok/s, TTFT 0.99 s, full delegation (1784/1784 prefill, 1614/1614 decode, zero rejections), correct answers. CPU: prefill 5.4, decode 6.98. The int8 build (3.83 GB) also completes and answers correctly on this 8 GB phone (15.5 / 3.86 tok/s, init 65 s).
+- **iPhone 17 Pro** (Metal): ship build 8/8 at the bundle's default 4096 context.
+
+## Files
+
+| File | What |
+|---|---|
+| `build_granite_4_1_3b.py` | HF checkpoint → `.litertlm`: simple-template export, int4/int8 recipes, start_token fix applied. |
+| `verify_granite_4_1_3b.py` | 8-question quality gate via the `litert-lm` CLI; `--check-metadata` asserts no `start_token`; `--bos-ab` proves the trap on the bf16 reference. |
+| `strip_start_token.py` | removes `start_token` from an already-built bundle (unpack → edit metadata → pack). |

--- a/models/granite/granite_4_1_3b/converted/build_granite_4_1_3b.py
+++ b/models/granite/granite_4_1_3b/converted/build_granite_4_1_3b.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ibm-granite/granite-4.1-3b (dense GraniteForCausalLM) -> .litertlm.
+
+Converts the Hugging Face checkpoint into a LiteRT-LM bundle through
+litert-torch's plain HF export path. Two recipes:
+
+  int4  blockwise-32 OCTAV int4 weights + int8 embedding  ~2.19 GB  (ship: phone GPU)
+  int8  dynamic int8 weights, fp32 activations            ~3.83 GB  (quality reference)
+
+The one model-specific step is the start_token fix. granite's tokenizer declares
+`add_bos_token: False`, and its BOS is the same token as its EOS
+(`<|end_of_text|>`, id 100257). The bundle builder writes `start_token` from
+`tokenizer.bos_token` unconditionally — it never consults `add_bos_token` — and
+the LiteRT-LM runtime prepends that token on the first turn. The model then reads
+every prompt as a document that has already ended, and echoes the question back
+instead of answering (quality gate 5/8 -> 8/8 with the fix; reproduced on bf16
+PyTorch, so it is a prompt bug, not quantization). This script clears
+`tokenizer.bos_token` before export so the bundle carries no start_token at all.
+See README.md for the measurements, and strip_start_token.py to repair a bundle
+that is already built.
+
+Usage:
+  python build_granite_4_1_3b.py --recipe int4 --out out_int4
+  python build_granite_4_1_3b.py --recipe int8 --out out_int8
+"""
+
+import argparse
+import copy
+
+# granite-4.1's chat template, reduced to the plain-chat form. Verified
+# byte-identical to the upstream chat_template.jinja rendering for single- and
+# multi-turn chat; the upstream file's tools/documents/strftime branches are what
+# this drops. Exporting with the simple template lets the exporter extract the
+# STRUCTURED per-role prompt templates the runtime applies directly — embedding
+# the raw upstream jinja instead would leave rendering to the runtime's minimal
+# jinja engine, which cannot run that logic.
+GRANITE_TEMPLATE = r"""{%- for message in messages -%}
+{{- '<|start_of_role|>' + message['role'] + '<|end_of_role|>' + message['content'] + '<|end_of_text|>\n' -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{- '<|start_of_role|>assistant<|end_of_role|>' -}}
+{%- endif -%}"""
+
+
+def patch_tokenizer(keep_start_token):
+  """Forces the simple chat template and (by default) clears bos_token.
+
+  Clearing `tokenizer.bos_token` is the start_token fix: the metadata builder
+  sets `start_token` from it unconditionally, so the only way to keep the field
+  out of the bundle at export time is for the tokenizer not to have one.
+  """
+  import transformers
+
+  orig_from_pretrained = transformers.AutoTokenizer.from_pretrained
+
+  def patched_from_pretrained(*args, **kwargs):
+    tok = orig_from_pretrained(*args, **kwargs)
+    tok.chat_template = GRANITE_TEMPLATE
+    if not keep_start_token:
+      tok.bos_token = None
+      print("start_token fix: bos_token cleared -> bundle will carry no start_token")
+    return tok
+
+  transformers.AutoTokenizer.from_pretrained = patched_from_pretrained
+
+
+def register_int4_recipe():
+  """Registers the int4 recipe under a name the exporter can look up.
+
+  blockwise-32 OCTAV int4 for the weights (data-free optimal clipping;
+  channelwise min-max int4 degrades LLMs measurably more), with the tied
+  100352x2560 vocab embedding kept at int8 (EMBEDDING_LOOKUP is where naive
+  int4 hurts most).
+  """
+  import ai_edge_quantizer.recipe as recipe_lib
+
+  int4_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  int4_rule["algorithm_key"] = recipe_lib.AlgorithmName.OCTAV
+  int4_rule["op_config"]["weight_tensor_config"]["granularity"] = "BLOCKWISE_32"
+
+  emb_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  emb_rule["operation"] = "EMBEDDING_LOOKUP"
+  emb_rule["op_config"]["weight_tensor_config"]["num_bits"] = 8
+
+  recipe_lib.GRANITE_INT4 = lambda: [int4_rule, emb_rule]
+  return "GRANITE_INT4"
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--recipe", choices=["int4", "int8"], default="int4")
+  ap.add_argument("--model", default="ibm-granite/granite-4.1-3b",
+                  help="HF model id or a local checkout of it")
+  ap.add_argument("--out", default=None, help="output dir (default: out_<recipe>)")
+  ap.add_argument("--cache", type=int, default=4096, help="KV cache length")
+  ap.add_argument("--prefill", default="1024,256,64,16,4,1",
+                  help="comma-separated prefill signature ladder. The 6-rung "
+                       "default is the ship ladder: each extra signature costs "
+                       "engine memory at init, and an 11-rung ladder puts the "
+                       "iPhone 17 Pro over the jetsam line at the bundle's "
+                       "default context (see README.md)")
+  ap.add_argument("--keep-start-token", action="store_true",
+                  help="skip the bos_token fix, reproducing the start_token trap "
+                       "(for study only — the resulting bundle echoes prompts)")
+  args = ap.parse_args()
+  out_dir = args.out or f"out_{args.recipe}"
+
+  patch_tokenizer(args.keep_start_token)
+
+  if args.recipe == "int4":
+    quant = register_int4_recipe()
+  else:
+    quant = "dynamic_wi8_afp32"
+
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=args.model,
+      output_dir=out_dir,
+      prefill_lengths=[int(x) for x in args.prefill.split(",") if x.strip()],
+      cache_length=args.cache,
+      quantization_recipe=quant,
+      # False -> the exporter extracts structured prompt templates from the
+      # (simple) chat template instead of embedding raw jinja in the bundle.
+      use_jinja_template=False,
+      # Splits the tied vocab embedding into its own bundle section, keeping the
+      # main weights section under the iOS ~2 GiB single-section mmap ceiling.
+      # No effect on weights or parity.
+      externalize_embedder=True,
+      trust_remote_code=True,
+  )
+  print("EXPORT_DONE")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/granite/granite_4_1_3b/converted/strip_start_token.py
+++ b/models/granite/granite_4_1_3b/converted/strip_start_token.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Removes the `start_token` from a .litertlm's LlmMetadata (weights untouched).
+
+Why this exists — measured on granite-4.1-3b:
+
+The bundle builder sets `start_token` from `tokenizer.bos_token` UNCONDITIONALLY
+and never consults `add_bos_token`. For a tokenizer that declares
+`add_bos_token: False` the runtime then prepends a token the model was never fed
+at that position — and when that token is ALSO the EOS (granite:
+bos == eos == `<|end_of_text|>`, id 100257), the model reads the prompt as a
+finished document and degenerates: it echoes the question back, or emits a run
+of backticks, instead of answering.
+
+This is not quantization damage, and the check that proves it costs one minute
+(`verify_granite_4_1_3b.py --bos-ab`): feed the SAME rendered prompt to the bf16
+PyTorch model with and without the leading BOS. granite answers "There are 7
+days in a week." without it and "Answer briefly." with it; a bundle carrying the
+start_token reproduces the with-BOS behaviour exactly.
+
+For a fresh export, build_granite_4_1_3b.py already applies the fix. This script
+repairs a bundle that is already built (unpack -> delete the `start_token`
+block -> pack; ~30 s, weights untouched):
+
+    python strip_start_token.py in.litertlm out.litertlm
+
+Needs the `litert-lm` CLI (pip install litert-lm, >= 0.15 for unpack/pack).
+Unpacking writes sections as large as the model — keep --work-dir on a disk
+with room.
+"""
+import argparse
+import os
+import re
+import subprocess
+
+
+def strip_block(pbtext, field="start_token"):
+  """Drops a top-level `field { ... }` block from a text-format proto.
+
+  Brace-counting rather than a regex: the block contains nested braces, and the
+  metadata's stop_tokens use the same shape, so a non-greedy regex would eat the
+  wrong span.
+  """
+  m = re.search(rf"^{field}\s*\{{", pbtext, re.M)
+  if not m:
+    return pbtext, False
+  i = pbtext.index("{", m.start())
+  depth = 0
+  for j in range(i, len(pbtext)):
+    if pbtext[j] == "{":
+      depth += 1
+    elif pbtext[j] == "}":
+      depth -= 1
+      if depth == 0:
+        end = j + 1
+        while end < len(pbtext) and pbtext[end] == "\n":
+          end += 1
+        return pbtext[:m.start()] + pbtext[end:], True
+  raise SystemExit(f"unbalanced braces in {field} block")
+
+
+def main():
+  ap = argparse.ArgumentParser()
+  ap.add_argument("src")
+  ap.add_argument("dst")
+  ap.add_argument("--field", default="start_token")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI — pick the build that matches "
+                       "the bundle's builder version")
+  ap.add_argument("--work-dir", default=None,
+                  help="where to unpack (default: a temp dir next to dst; the "
+                       "sections are as big as the model, so keep it on a disk "
+                       "with room)")
+  args = ap.parse_args()
+
+  work = args.work_dir or os.path.join(os.path.dirname(os.path.abspath(args.dst)),
+                                       ".strip_start_token_tmp")
+  os.makedirs(work, exist_ok=True)
+  unpack = os.path.join(work, "unpack")
+  subprocess.run([args.litert_lm, "unpack", args.src, "--output-dir", unpack],
+                 check=True)
+
+  pb = os.path.join(unpack, "LlmMetadataProto.pbtext")
+  text = open(pb).read()
+  new, found = strip_block(text, args.field)
+  if not found:
+    raise SystemExit(f"no `{args.field}` block in {pb} — nothing to strip")
+  open(pb, "w").write(new)
+
+  toml_path = os.path.join(unpack, "model.toml")
+  if os.path.exists(args.dst):  # `litert-lm pack` exits 0 without writing otherwise
+    os.remove(args.dst)
+  subprocess.run([args.litert_lm, "pack", toml_path, "--output", args.dst],
+                 check=True)
+  print(f"OK: {args.dst} ({args.field} removed)")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/granite/granite_4_1_3b/converted/verify_granite_4_1_3b.py
+++ b/models/granite/granite_4_1_3b/converted/verify_granite_4_1_3b.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate and start_token checks for a converted granite-4.1-3b bundle.
+
+Three modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm), greedy, one fresh session per
+    question, and scores correctness plus degeneracy (looping, token spam,
+    empty output). This is the publish guardrail: a conversion that collapses
+    must not ship. A bundle with the start_token bug fails it at 5/8 with
+    echoed questions; the fixed bundle scores 8/8 on CPU and GPU.
+
+      python verify_granite_4_1_3b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — unpacks the bundle and asserts its LlmMetadata carries NO
+    `start_token` block (the fix this recipe exists for). Unpacking writes
+    sections as large as the model; point --work-dir at a disk with room.
+
+      python verify_granite_4_1_3b.py model.litertlm --check-metadata
+
+  --bos-ab — the one-minute proof that the start_token trap is a prompt bug and
+    not quantization damage: feeds the SAME rendered prompt to the bf16 PyTorch
+    model with and without a leading BOS and prints both answers. Needs torch,
+    transformers, and the HF checkpoint (no bundle involved).
+
+      python verify_granite_4_1_3b.py --bos-ab [--hf ibm-granite/granite-4.1-3b]
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+# The veto on the 0.9-vs-0.11 question exists because the presence check alone
+# is one-sided: "0.11 is larger than 0.9" also contains "0.9" and would score
+# as correct — a real false pass observed on another model. Require the right
+# number AND the absence of the inverted claim.
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam.
+
+  The 5-gram trigger needs a corroborating diversity collapse: a model may
+  legitimately restate a quoted phrase a few times in a clean answer, while
+  real loops show heavy repetition AND cratered word diversity."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5:
+    return True
+  return False
+
+
+def run_one(litert_lm, model, prompt, backend, timeout):
+  """Runs one prompt through `litert-lm run`; the answer is exactly stdout."""
+  proc = subprocess.run(
+      [litert_lm, "run", str(model), "--prompt", prompt,
+       "--backend", backend, "--temperature", "0", "--top-k", "1",
+       "--cache", "no"],
+      capture_output=True, text=True, timeout=timeout,
+  )
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  return proc.stdout.strip()
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      ans = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    low = ans.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not ans.strip()) or degenerate(ans)
+    results.append({"label": label, "question": q, "ok": ok,
+                    "degenerate": degen, "answer": ans})
+    shown = " ".join(ans.split())[:90] if ans.strip() else "(empty)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results,
+    }, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def check_metadata(args):
+  work = args.work_dir or tempfile.mkdtemp(prefix="g41_unpack_")
+  unpack_dir = os.path.join(work, "unpack")
+  try:
+    subprocess.run(
+        [args.litert_lm, "unpack", str(args.model), "--output-dir", unpack_dir],
+        check=True)
+    pbtext = open(os.path.join(unpack_dir, "LlmMetadataProto.pbtext")).read()
+    has_start = bool(re.search(r"^start_token\s*\{", pbtext, re.M))
+  finally:
+    if not args.work_dir:
+      shutil.rmtree(work, ignore_errors=True)
+  if has_start:
+    print("FAIL: LlmMetadata carries a start_token block — the runtime will "
+          "prepend it and this model will echo prompts back. Repair with "
+          "strip_start_token.py, or re-export with build_granite_4_1_3b.py.")
+    return 1
+  print("PASS: no start_token in LlmMetadata.")
+  return 0
+
+
+def bos_ab(args):
+  import torch  # deferred: only this mode needs it
+  import transformers
+
+  device = args.device
+  if device == "auto":
+    device = ("mps" if torch.backends.mps.is_available()
+              else "cuda" if torch.cuda.is_available() else "cpu")
+  tok = transformers.AutoTokenizer.from_pretrained(args.hf)
+  model = transformers.AutoModelForCausalLM.from_pretrained(
+      args.hf, dtype=torch.bfloat16).to(device).eval()
+
+  def generate(ids):
+    mask = torch.ones_like(ids)
+    with torch.no_grad():
+      out = model.generate(input_ids=ids, attention_mask=mask,
+                           max_new_tokens=args.max_tokens, do_sample=False)
+    return tok.decode(out[0][ids.shape[1]:], skip_special_tokens=True)
+
+  print(f"bf16 A/B on {args.hf} ({device}): same rendered prompt, with and "
+        f"without a leading BOS (<|end_of_text|>, the token the runtime "
+        f"prepends when the bundle carries a start_token)\n")
+  for q in ["How many days are in a week?", "What is 8 times 7?",
+            "What is 17 + 25?"]:
+    text = tok.apply_chat_template(
+        [{"role": "user", "content": q + SUFFIX}],
+        tokenize=False, add_generation_prompt=True)
+    # add_special_tokens=False: the rendered template already carries every
+    # marker the model expects, and granite sets add_bos_token: False.
+    ids = tok(text, add_special_tokens=False,
+              return_tensors="pt").input_ids.to(device)
+    bos = torch.tensor([[tok.bos_token_id]], device=device)
+    no_bos = generate(ids)
+    with_bos = generate(torch.cat([bos, ids], dim=1))
+    print(f"  Q: {q}")
+    print(f"    no BOS  : {' '.join(no_bos.split())[:100]!r}")
+    print(f"    with BOS: {' '.join(with_bos.split())[:100]!r}\n")
+  print("If the two columns differ like the README table (answers vs echoes), "
+        "the trap is live in the prompt path, independent of any quantization.")
+  return 0
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / start_token checks for granite-4.1-3b")
+  ap.add_argument("model", nargs="?", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--timeout", type=int, default=900,
+                  help="seconds per question (engine init is paid every run)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--json", help="write a JSON report here (gate mode)")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--work-dir", help="unpack scratch dir for --check-metadata")
+  ap.add_argument("--bos-ab", action="store_true")
+  ap.add_argument("--hf", default="ibm-granite/granite-4.1-3b",
+                  help="HF id or local checkout (--bos-ab mode)")
+  ap.add_argument("--device", default="auto", help="--bos-ab device")
+  ap.add_argument("--max-tokens", type=int, default=64,
+                  help="--bos-ab generation budget")
+  args = ap.parse_args()
+
+  if args.bos_ab:
+    return bos_ab(args)
+  if not args.model:
+    ap.error("model.litertlm is required unless --bos-ab")
+  if not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Adds the conversion recipe for [ibm-granite/granite-4.1-3b](https://huggingface.co/ibm-granite/granite-4.1-3b) (dense `GraniteForCausalLM`, 3.4B, Apache-2.0) → `.litertlm` for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, in the `models/<family>/<model>/converted` layout. Published deployment files: [litert-community/granite-4.1-3b](https://huggingface.co/litert-community/granite-4.1-3b).

## What's inside

- `build_granite_4_1_3b.py` — HF checkpoint → `.litertlm` through the plain litert-torch export path: int4 (blockwise-32 OCTAV weights + int8 embedding, 2.19 GB — the phone-GPU build) and int8 (3.83 GB — quality reference), externalized embedder, 6-signature prefill ladder.
- `verify_granite_4_1_3b.py` — an 8-question quality gate through the `litert-lm` CLI, plus `--check-metadata` (asserts the bundle carries no `start_token`) and `--bos-ab` (a one-minute bf16 reproducer of the finding below).
- `strip_start_token.py` — removes the field from an already-built bundle (unpack → edit metadata → pack; weights untouched).

## The start_token finding

granite declares `add_bos_token: False`, and its BOS is the same token as its EOS (`<|end_of_text|>`). The metadata builder (litert-torch 0.9.3) sets `start_token` from `tokenizer.bos_token` without consulting `add_bos_token`, and the runtime prepends that token on the first turn. The model then reads every prompt as a document that has already ended, and echoes the question back instead of answering — the naive export scores 5/8 on the quality gate.

A bf16 A/B (the same rendered prompt, with and without the leading BOS) reproduces the failure on the unquantized PyTorch model, so it is a prompt-path issue, not quantization damage. With the field removed: 8/8, same weights, same file size. The distortion also reaches task metrics: measured with the field in the bundle, this checkpoint's int4 GSM8K read 61% against a bf16 88.0% and looked like an unfixable int4 collapse; with it removed, the same recipe measures 84.0%. The README documents which tokenizer shapes are eligible and why eligibility is not breakage (the published OLMo-2-1B bundle carries the same shape and answers correctly with and without it).

## Verification

- The quality gate in this PR, re-run today on the published int4 build: 8/8 on CPU, non-degenerate; `--check-metadata` confirms no `start_token`; `--bos-ab` reproduces the README's A/B table verbatim.
- From the conversion runs (documented in the README): 8Q 8/8 on GPU (Mac Metal); GSM8K n=100 greedy: bf16 88.0 / int8 87.0 / int4 84.0.
- On device: Pixel 8a (Mali, 8 GB) GPU — full delegation, zero rejected ops, correct answers, prefill 20.0 / decode 7.07 tok/s. iPhone 17 Pro (Metal) — 8/8 at the bundle's default 4096 context with the 6-signature ladder (an 11-signature ladder jetsams at engine init; measured, documented in the README). Mac M4 Max (Metal) — prefill 1241 / decode 86.3 tok/s.
