### PR TITLE
Add four dense LLM conversion recipes under models/ (SmolLM3-3B, VibeThinker-3B, Ministral-3-3B-Instruct-2512, Qwen2.5-Coder-1.5B-Instruct)

### DIFF
--- a/models/ministral/ministral_3_3b_instruct_2512/README.md
+++ b/models/ministral/ministral_3_3b_instruct_2512/README.md
@@ -1,0 +1,3 @@
+# Ministral 3 3B Instruct Language Model
+
+Model recipes, conversion scripts, instructions, and utilities for Mistral AI Ministral-3-3B-Instruct-2512 on-device text generation ([mistralai/Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512), text decoder only).

--- a/models/ministral/ministral_3_3b_instruct_2512/converted/.gitignore
+++ b/models/ministral/ministral_3_3b_instruct_2512/converted/.gitignore
@@ -1,0 +1,5 @@
+*.litertlm
+out_*/
+__pycache__/
+ministral3_bf16/
+ministral3_text/

--- a/models/ministral/ministral_3_3b_instruct_2512/converted/README.md
+++ b/models/ministral/ministral_3_3b_instruct_2512/converted/README.md
@@ -1,0 +1,86 @@
+# Ministral-3-3B-Instruct-2512 Conversion
+
+Model recipes, instructions, scripts, and utilities for converting Mistral AI Ministral-3-3B-Instruct-2512 (text decoder) to LiteRT-LM.
+
+These scripts convert the text decoder of [mistralai/Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512) (`Ministral3ForCausalLM`, 3.43B parameters, Apache-2.0) into a `.litertlm` bundle for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a quality gate. The published artifact is `Ministral-3-3B-Instruct-2512_q4_block32_ekv4096.litertlm` (2.34 GB) at [litert-community/Ministral-3-3B-Instruct-2512](https://huggingface.co/litert-community/Ministral-3-3B-Instruct-2512).
+
+The checkpoint is multimodal (`Mistral3ForConditionalGeneration`: a Pixtral vision tower, a projector and the Ministral3 text decoder). This recipe exports the **text decoder only** — a 26-layer dense transformer (hidden 3072, GQA 32:8, head dim 128, vocab 131072, tied embeddings, YaRN RoPE) that the plain litert-torch HF export path handles with no re-authoring once it is a standalone checkpoint. What this conversion documents is four things that each look like a model problem and are not: which source repo to load, a template that must be Mistral's own, a section-size ceiling on iOS, and a `start_token` that is correct.
+
+## Build
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int4` | blockwise-32 OCTAV int4 weights, int8 embedding (externalized) | 2.34 GB | phone GPU / iPhone / desktop |
+
+## Environment
+
+```bash
+pip install litert-torch==0.9.3 litert-converter==0.3.1 ai-edge-quantizer==0.8.0 \
+    litert-lm-builder==0.16.0 transformers==5.14.1
+pip install litert-lm   # verification CLI (>= 0.16.0)
+```
+
+## Run
+
+```bash
+python extract_text_decoder.py --out ministral3_text                     # ~7.7 GB download, once
+python build_ministral_3_3b.py --model ministral3_text --out out_int4    # ~2.34 GB bundle
+python verify_ministral_3_3b.py out_int4/*.litertlm --backend cpu        # 8-question gate
+python verify_ministral_3_3b.py out_int4/*.litertlm --check-metadata     # [INST] template, </s> stop, <s> start_token, sections < 2 GiB
+python verify_ministral_3_3b.py --bos-ab --hf ministral3_text            # is the <s> start_token legitimate? (bf16, ~1 min)
+```
+
+## Source: the plain repo is FP8
+
+`mistralai/Ministral-3-3B-Instruct-2512` ships its weights **FP8-quantized** (`config.quantization_config.quant_method = "fp8"`), which the CPU-side export path cannot load. Use the sibling **`mistralai/Ministral-3-3B-Instruct-2512-BF16`**. That repo also carries `consolidated.safetensors`, a second single-file copy of the same weights that the HF loader never reads; `extract_text_decoder.py` skips it (7.7 GB).
+
+The extractor loads the multimodal wrapper, copies `model.language_model` and `lm_head` into a plain `Ministral3ForCausalLM`, refuses to continue if any key is missing or unexpected, and saves the decoder with the tokenizer. That standalone checkpoint is what `build_ministral_3_3b.py` exports.
+
+## Template: Mistral's own, not ChatML
+
+Ministral speaks `[INST] … [/INST]` with `</s>` as its end-of-turn token, and its tekken tokenizer has **no `<|im_end|>`**. Exported under a ChatML template — the default rail for most instruct models — the int4 bundle answers correctly and then never reaches a registered stop token: it runs on with `<|im_start|>` spam. Under its native template it stops cleanly. `build_ministral_3_3b.py` forces the plain Mistral template (upstream's full jinja carries tool-calling logic the runtime's minimal jinja engine cannot run, so the structured `[INST]` / `[SYSTEM_PROMPT]` prefixes are extracted instead), and `--check-metadata` asserts the shape. Match the template to what the tokenizer can emit.
+
+## The start_token that is correct
+
+The bundle carries `start_token { token_str: "<s>" }`, and the runtime prepends it on the first turn. On granite-4.1-3b the same field breaks the model: there BOS is the same token as EOS, and the model reads the prompt as an already-ended document. Here bos `<s>` (id 1) and eos `</s>` (id 2) are different tokens, and a leading `<s>` is the Mistral convention the model was trained on — so the field stays. `verify_ministral_3_3b.py --bos-ab` feeds the same rendered `[INST]` prompt to the bf16 decoder with and without the leading `<s>` and prints both answers. Eligibility for the trap is a tokenizer shape (bos == eos, or `add_bos_token: False`); this model has neither.
+
+## Section size: the iOS ceiling
+
+Without `externalize_embedder` this 3B's weights are one **~2.55 GiB** TFLite section, above the ~2 GiB single-section `mmap` ceiling on iOS: engine creation fails with *"Failed to map section: Cannot allocate memory"*, an error that reads like a memory problem rather than a layout one. Externalizing the tied 131072×3072 embedding into its own section (0.38 GiB) drops the main section to **1.80 GiB**, dedups the tied matrix (2.74 GB → 2.34 GB on disk), and the bundle loads on iPhone. Same weights, same parity; `--check-metadata` asserts every section is under 2 GiB.
+
+## Quantization
+
+GSM8K, n=100, greedy, 0-shot CoT, 512-token budget (a direct-answer model needs no more), identical prompt and extraction for both rows:
+
+| build | GSM8K |
+|---|---|
+| bf16 (HF reference) | 89.0% |
+| int4 blockwise-32 OCTAV, int8 embedding | 85.0% |
+
+−4 pt, the ordinary healthy shape. A channelwise min-max int4 of the same model passed the 8-question sanity gate and was not at parity; blockwise-32 + OCTAV is what preserves it, and the sanity gate alone would not have shown the difference.
+
+## Verification results
+
+Quality gate on the published bundle (`verify_ministral_3_3b.py`, litert-lm 0.16.0, Mac M4 Max): **CPU 8/8, GPU 8/8, non-degenerate**, clean stop at `</s>`; `--check-metadata` 8/8.
+
+Rebuilt from scratch with these scripts on the pinned stack: extraction maps every decoder tensor (missing 0 / unexpected 0), the bundle comes out at 2,340,966,384 bytes against the published 2,340,982,768 (a 16 KB metadata difference — the published file was built on an earlier litert-torch), 8/8 on `--check-metadata`, 8/8 on the GPU gate, and `--bos-ab` prints the two answering columns above.
+
+Mac (M4 Max, `litert-lm benchmark`, `-p 256 -d 256 --runs 3`, max-num-tokens 4096, quiet machine, litert-lm 0.15.0):
+
+| backend | prefill tok/s | decode tok/s | TTFT |
+|---|---|---|---|
+| GPU (Metal) | 1234 | 95.4 | 0.23 s |
+| CPU | 123 | 22.3 | 2.39 s |
+
+On device:
+
+- **Pixel 8a** (Tensor G3, Mali-G715, 8 GB), GPU (OpenCL), `litert_lm_main` v0.16.0 driven directly: **full delegation** — 1187/1187 nodes in the 128-token prefill graph, 1087/1087 in decode, zero rejected ops — prefill 8.5 tok/s (short prompt padded to the 128-token signature), decode 6.80 tok/s, TTFT 1.68 s, engine init 20.9 s, correct answer. That is the runtime driven directly. The Google AI Edge Gallery app fixes its accelerator choice at import time from device RAM and offers only CPU for a file this size on an 8 GB phone; both are true at once — the app will not offer the GPU there, and the model runs on that phone's GPU when something else drives it.
+- **iPhone 17 Pro** (Metal, iOS 27.0, three runs through a LiteRT-LM Swift harness, 512-token budget): prefill 39.7–42.3 tok/s (short prompt), decode 14.2–17.6 tok/s, TTFT 0.40–0.42 s, load 12–62 s, footprint 1.44–1.46 GB. Decode is a range because it varied with load time across the three runs; prefill and TTFT were steady.
+
+## Files
+
+| File | What |
+|---|---|
+| `extract_text_decoder.py` | BF16 multimodal checkpoint → standalone `Ministral3ForCausalLM` (drops the Pixtral tower and projector; loud failure on any unmapped key). |
+| `build_ministral_3_3b.py` | text decoder → `.litertlm`: Mistral `[INST]` template, blockwise-32 OCTAV int4 + int8 externalized embedding, `<s>` start_token kept, single 128 prefill signature, 4096 context. |
+| `verify_ministral_3_3b.py` | 8-question quality gate via the `litert-lm` CLI; `--check-metadata` asserts the `[INST]` template, `</s>` stop, `<s>` start_token, externalized embedder and section sizes; `--bos-ab` shows the start_token is legitimate on the bf16 decoder. |

--- a/models/ministral/ministral_3_3b_instruct_2512/converted/build_ministral_3_3b.py
+++ b/models/ministral/ministral_3_3b_instruct_2512/converted/build_ministral_3_3b.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""mistralai/Ministral-3-3B-Instruct-2512 (text decoder) -> .litertlm.
+
+Converts the Ministral-3 text decoder (extracted from the multimodal
+checkpoint by extract_text_decoder.py) into a LiteRT-LM bundle through
+litert-torch's plain HF export path: blockwise-32 OCTAV int4 weights with the
+tied vocab embedding kept at int8 and split into its own section (~2.34 GB).
+`Ministral3ForCausalLM` (26 layers, hidden 3072, GQA 32:8, YaRN RoPE) needs
+no re-authoring.
+
+Three model-specific facts are baked in:
+
+  * Template. Ministral speaks Mistral's `[INST] ... [/INST]` format with
+    `</s>` as its end-of-turn token; the tekken tokenizer has NO `<|im_end|>`.
+    Exported under a ChatML template the int4 model never reaches a registered
+    stop token and runs on past the correct answer with `<|im_start|>` spam;
+    under its native template it stops cleanly. This script forces the plain
+    Mistral template (upstream's full jinja cannot run in the runtime's
+    minimal jinja engine, so the structured [INST] prefixes are extracted).
+
+  * start_token. The tokenizer declares bos `<s>` and eos `</s>` — different
+    tokens — so the `start_token { token_str: "<s>" }` the builder writes is
+    the Mistral convention, not the granite-4.1-3b trap (which needs
+    bos == eos, or add_bos_token: False). It is kept.
+    `verify_ministral_3_3b.py --bos-ab` shows the bf16 model answers with the
+    leading <s>.
+
+  * Section size. Without externalize_embedder the 3B's weights are one
+    ~2.55 GiB TFLite section, above the iOS ~2 GiB single-section mmap ceiling
+    (engine creation fails: "Failed to map section: Cannot allocate memory").
+    Externalizing the tied embedding drops the main section to ~1.8 GiB, and
+    the bundle loads on iPhone.
+
+Usage:
+  python extract_text_decoder.py --out ministral3_text     # once, ~7 GB download
+  python build_ministral_3_3b.py --model ministral3_text --out out_int4
+"""
+
+import argparse
+import copy
+import os
+
+# Mistral's plain chat format. Byte-identical to upstream's rendering of
+# system / user / assistant turns; what it drops is upstream's tool-calling
+# and default-system logic, which the structured template cannot carry.
+MISTRAL_TEMPLATE = r"""{%- for message in messages -%}
+{%- if message['role'] == 'system' -%}
+{{- '[SYSTEM_PROMPT]' + message['content'] + '[/SYSTEM_PROMPT]' -}}
+{%- elif message['role'] == 'user' -%}
+{{- '[INST]' + message['content'] + '[/INST]' -}}
+{%- elif message['role'] == 'assistant' -%}
+{{- message['content'] + '</s>' -}}
+{%- endif -%}
+{%- endfor -%}"""
+
+
+def patch_tokenizer():
+  """Forces the plain Mistral template on every tokenizer the exporter loads."""
+  import transformers
+
+  orig_from_pretrained = transformers.AutoTokenizer.from_pretrained
+
+  def patched_from_pretrained(*args, **kwargs):
+    tok = orig_from_pretrained(*args, **kwargs)
+    tok.chat_template = MISTRAL_TEMPLATE
+    # bos <s> != eos </s>: the start_token the builder writes from bos_token is
+    # legitimate for this model and is deliberately left in place.
+    assert tok.bos_token == "<s>" and tok.eos_token == "</s>", (
+        f"unexpected bos/eos {tok.bos_token!r}/{tok.eos_token!r} — re-check "
+        "the start_token story before exporting")
+    return tok
+
+  transformers.AutoTokenizer.from_pretrained = patched_from_pretrained
+
+
+def register_int4_recipe():
+  """blockwise-32 OCTAV int4 weights + int8 tied embedding (131072x3072).
+
+  Measured GSM8K 85.0% against a bf16 89.0% (n=100); a channelwise min-max
+  int4 of the same model passed the sanity gate but was not at parity — the
+  blockwise-32 + OCTAV grid is what preserves the accuracy.
+  """
+  import ai_edge_quantizer.recipe as recipe_lib
+
+  int4_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  int4_rule["algorithm_key"] = recipe_lib.AlgorithmName.OCTAV
+  int4_rule["op_config"]["weight_tensor_config"]["granularity"] = "BLOCKWISE_32"
+
+  emb_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  emb_rule["operation"] = "EMBEDDING_LOOKUP"
+  emb_rule["op_config"]["weight_tensor_config"]["num_bits"] = 8
+
+  recipe_lib.MINISTRAL3_INT4 = lambda: [int4_rule, emb_rule]
+  return "MINISTRAL3_INT4"
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--model", default="ministral3_text",
+                  help="the standalone text decoder written by "
+                       "extract_text_decoder.py (NOT the multimodal HF repo)")
+  ap.add_argument("--out", default="out_int4", help="output dir")
+  ap.add_argument("--cache", type=int, default=4096, help="KV cache length")
+  ap.add_argument("--prefill", default="128",
+                  help="comma-separated prefill signature ladder. The published "
+                       "bundle carries the single 128 signature; see README.md "
+                       "for the ladder trade-off.")
+  args = ap.parse_args()
+
+  if not os.path.exists(os.path.join(args.model, "config.json")):
+    raise SystemExit(f"{args.model}/config.json not found — run "
+                     "extract_text_decoder.py first (the multimodal repo "
+                     "cannot be exported directly).")
+
+  patch_tokenizer()
+  quant = register_int4_recipe()
+
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=args.model,
+      output_dir=args.out,
+      prefill_lengths=[int(x) for x in args.prefill.split(",") if x.strip()],
+      cache_length=args.cache,
+      quantization_recipe=quant,
+      # False -> structured [INST] prompt templates in the bundle, not raw jinja.
+      use_jinja_template=False,
+      # Required for iPhone: keeps the main weights section under the iOS
+      # ~2 GiB single-section mmap ceiling (see module doc).
+      externalize_embedder=True,
+      trust_remote_code=True,
+  )
+  print("EXPORT_DONE")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/ministral/ministral_3_3b_instruct_2512/converted/extract_text_decoder.py
+++ b/models/ministral/ministral_3_3b_instruct_2512/converted/extract_text_decoder.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extracts the text decoder of Ministral-3-3B into a standalone checkpoint.
+
+`mistralai/Ministral-3-3B-Instruct-2512` is published as
+`Mistral3ForConditionalGeneration` — a Pixtral vision tower, a projector and
+the Ministral3 text decoder under one config. litert-torch's text export path
+wants an `AutoModelForCausalLM`-loadable checkpoint, so this script loads the
+multimodal wrapper, copies the language model and lm_head into a plain
+`Ministral3ForCausalLM`, and saves it with the tokenizer:
+
+  Mistral3ForConditionalGeneration
+    .model.vision_tower           <- dropped
+    .model.multi_modal_projector  <- dropped
+    .model.language_model         -> causal.model
+    .lm_head                      -> causal.lm_head  (tied to embed_tokens)
+
+Source repo: the plain repo ships FP8 weights (config.quantization_config
+quant_method=fp8), which the CPU export path cannot load; use the BF16 repo,
+`mistralai/Ministral-3-3B-Instruct-2512-BF16`. Its `consolidated.safetensors`
+(7.7 GB) is a second, single-file copy of the same weights that the HF loader
+does not read — the download here skips it.
+
+Usage:
+  python extract_text_decoder.py --out ministral3_text
+"""
+
+import argparse
+import gc
+import os
+
+DEFAULT_SRC = "mistralai/Ministral-3-3B-Instruct-2512-BF16"
+
+
+def download(repo, local_dir):
+  """Fetches the BF16 checkpoint without the redundant consolidated file."""
+  from huggingface_hub import snapshot_download
+
+  return snapshot_download(
+      repo, local_dir=local_dir,
+      ignore_patterns=["consolidated.safetensors", "*.md", "*.png", "*.jpg"])
+
+
+def extract(src, out):
+  import torch
+  import transformers
+
+  print(f"loading multimodal wrapper from {src} (bf16, cpu) ...")
+  full = transformers.AutoModelForImageTextToText.from_pretrained(
+      src, dtype=torch.bfloat16, low_cpu_mem_usage=True)
+  full.eval()
+
+  text_cfg = full.config.text_config
+  print(f"text_config: model_type={text_cfg.model_type} "
+        f"layers={text_cfg.num_hidden_layers} hidden={text_cfg.hidden_size} "
+        f"vocab={text_cfg.vocab_size} tie={text_cfg.tie_word_embeddings}")
+
+  causal = transformers.Ministral3ForCausalLM(text_cfg)
+  causal.eval()
+
+  # language_model (Ministral3Model) -> causal.model (Ministral3Model): the
+  # key sets are identical, so this must load with nothing missing or extra.
+  missing, unexpected = causal.model.load_state_dict(
+      full.model.language_model.state_dict(), strict=False)
+  print(f"decoder load: missing={len(missing)} unexpected={len(unexpected)}")
+  if missing or unexpected:
+    raise SystemExit(f"ABORT: decoder remap incomplete — missing[:5]="
+                     f"{missing[:5]} unexpected[:5]={unexpected[:5]}")
+  causal.lm_head.load_state_dict(full.lm_head.state_dict())
+  causal.tie_weights()
+  causal = causal.to(torch.bfloat16)  # keep the saved checkpoint at 6.8 GB, not fp32
+
+  w = causal.model.embed_tokens.weight
+  if not torch.isfinite(w).all():
+    raise SystemExit("ABORT: non-finite values in embed_tokens")
+  print(f"embed_tokens {tuple(w.shape)} ok")
+
+  del full
+  gc.collect()
+
+  print(f"saving text-only checkpoint to {out} ...")
+  causal.config._name_or_path = src  # pylint: disable=protected-access
+  causal.save_pretrained(out, safe_serialization=True)
+  transformers.AutoTokenizer.from_pretrained(src).save_pretrained(out)
+  print("EXTRACT_DONE", out)
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--src", default=DEFAULT_SRC,
+                  help="HF id of the BF16 checkpoint, or a local checkout")
+  ap.add_argument("--download-dir", default="ministral3_bf16",
+                  help="where to place the HF download when --src is an id")
+  ap.add_argument("--out", default="ministral3_text",
+                  help="output dir for the standalone text decoder")
+  args = ap.parse_args()
+
+  src = args.src
+  if not os.path.isdir(src):
+    src = download(src, args.download_dir)
+  extract(src, args.out)
+
+
+if __name__ == "__main__":
+  main()

--- a/models/ministral/ministral_3_3b_instruct_2512/converted/verify_ministral_3_3b.py
+++ b/models/ministral/ministral_3_3b_instruct_2512/converted/verify_ministral_3_3b.py
@@ -1,0 +1,293 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate, metadata and start_token checks for a converted Ministral-3-3B bundle.
+
+Three modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm), greedy, one fresh session per
+    question, and scores correctness plus degeneracy (looping, token spam,
+    empty output). This is the publish guardrail: a conversion that collapses
+    must not ship — and for this model, the check that catches a ChatML
+    export (which runs away with <|im_start|> spam after the right answer).
+
+      python verify_ministral_3_3b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — reads the bundle's LlmMetadata (no unpacking) and asserts
+    the shape this recipe produces: Mistral [INST] / [/INST] per-role
+    templates, </s> (id 2) among the stop tokens, a start_token of "<s>"
+    (present on purpose — see --bos-ab), and the embedder in its own section
+    with every section under 2 GiB (the iOS single-section mmap ceiling that
+    the un-externalized 2.55 GiB build hit). Needs `pip install
+    litert-lm-builder`.
+
+      python verify_ministral_3_3b.py model.litertlm --check-metadata
+
+  --bos-ab — the one-minute check that the start_token is legitimate here:
+    feeds the SAME rendered [INST] prompt to the bf16 PyTorch text decoder
+    with and without a leading <s> and prints both answers. For granite-4.1-3b
+    (bos == eos) the with-BOS column breaks; for Ministral (bos <s> != eos
+    </s>) both columns answer, and <s>-first is what the model was trained on.
+    Needs torch, transformers and the extracted text decoder (no bundle
+    involved).
+
+      python verify_ministral_3_3b.py --bos-ab [--hf ministral3_text]
+"""
+
+import argparse
+import io
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+# The veto on the 0.9-vs-0.11 question exists because the presence check alone
+# is one-sided: "0.11 is larger than 0.9" also contains "0.9" and would score
+# as correct. Require the right number AND the absence of the inverted claim.
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam.
+
+  The 5-gram trigger needs a corroborating diversity collapse: a model may
+  legitimately restate a quoted phrase a few times in a clean answer, while
+  real loops show heavy repetition AND cratered word diversity."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5:
+    return True
+  return False
+
+
+def run_one(litert_lm, model, prompt, backend, timeout):
+  """Runs one prompt through `litert-lm run`; the answer is exactly stdout."""
+  cmd = [litert_lm, "run", str(model), "--prompt", prompt,
+         "--backend", backend, "--temperature", "0", "--top-k", "1",
+         "--cache", "no"]
+  proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  return proc.stdout.strip()
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      ans = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    low = ans.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not ans.strip()) or degenerate(ans)
+    results.append({"label": label, "question": q, "ok": ok,
+                    "degenerate": degen, "answer": ans})
+    shown = " ".join(ans.split())[:90] if ans.strip() else "(empty)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results,
+    }, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def read_metadata(model):
+  """Returns (LlmMetadata pbtext, [sections]) without unpacking the bundle."""
+  from litert_lm_builder import litertlm_peek  # pip install litert-lm-builder
+
+  buf = io.StringIO()
+  litertlm_peek.peek_litertlm_file(str(model), None, buf)
+  text = buf.getvalue()
+  m = re.search(r"start of LlmMetadata\n(.*?)>{4,} end of LlmMetadata", text, re.S)
+  pbtext = m.group(1) if m else ""
+  sections = []
+  for sm in re.finditer(
+      r"Section (\d+):\n(.*?)Begin Offset:\s*(\d+)\n\s*End Offset:\s*(\d+)\n"
+      r"\s*Data Type:\s*(\S+)", text, re.S):
+    items = sm.group(2)
+    mt = re.search(r"model_type, Value \(String\): (\S+)", items)
+    sections.append({"index": int(sm.group(1)), "type": sm.group(5),
+                     "model_type": mt.group(1) if mt else None,
+                     "bytes": int(sm.group(4)) - int(sm.group(3))})
+  return pbtext, sections
+
+
+def check_metadata(args):
+  pbtext, sections = read_metadata(args.model)
+  if not pbtext:
+    print("FAIL: no LlmMetadata section found")
+    return 1
+  checks = []
+
+  def check(name, ok, detail=""):
+    checks.append(ok)
+    print(f"  [{'v' if ok else 'X'}] {name}{(': ' + detail) if detail else ''}")
+
+  m = re.search(r"start_token\s*\{\s*token_str:\s*\"(.*?)\"", pbtext)
+  check('start_token is "<s>" (Mistral convention, bos != eos — kept on purpose)',
+        bool(m) and m.group(1) == "<s>", repr(m.group(1)) if m else "absent")
+
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", pbtext)}
+  stop_strs = set(re.findall(r"token_str:\s*\"((?:[^\"\\]|\\.)*)\"", pbtext))
+  check("</s> is a stop token", 2 in stop_ids or "</s>" in stop_strs,
+        f"ids {sorted(stop_ids)}")
+  check("no ChatML markers among the stops (tekken has no <|im_end|>)",
+        not any("<|im_end|>" in s for s in stop_strs))
+
+  def part(role, which):
+    m = re.search(role + r"\s*\{(.*?)\}", pbtext, re.S)
+    if not m:
+      return None
+    p = re.search(which + r":\s*\"((?:[^\"\\]|\\.)*)\"", m.group(1))
+    return p.group(1) if p else ""
+  check("user turn is [INST] ... [/INST]",
+        part("user", "prefix") == "[INST]" and part("user", "suffix") == "[/INST]",
+        f"{part('user', 'prefix')!r} ... {part('user', 'suffix')!r}")
+  check("model turn ends with </s>", part("model", "suffix") == "</s>",
+        repr(part("model", "suffix")))
+  check("system turn is [SYSTEM_PROMPT] ... [/SYSTEM_PROMPT]",
+        part("system", "prefix") == "[SYSTEM_PROMPT]",
+        repr(part("system", "prefix")))
+
+  types = [s["model_type"] for s in sections]
+  check("embedder in its own section", "tf_lite_embedder" in types, str(types))
+  big = [s for s in sections if s["bytes"] >= 2 * 1024 ** 3]
+  check("every section < 2 GiB (iOS mmap ceiling)", not big,
+        ", ".join(f"{s['type']}:{s['bytes'] / 1024 ** 3:.2f} GiB" for s in sections))
+
+  ok = all(checks)
+  print(f"\n  {'PASS' if ok else 'FAIL'}: {sum(checks)}/{len(checks)} metadata checks")
+  return 0 if ok else 1
+
+
+def bos_ab(args):
+  import torch  # deferred: only this mode needs it
+  import transformers
+
+  device = args.device
+  if device == "auto":
+    device = ("mps" if torch.backends.mps.is_available()
+              else "cuda" if torch.cuda.is_available() else "cpu")
+  tok = transformers.AutoTokenizer.from_pretrained(args.hf)
+  model = transformers.AutoModelForCausalLM.from_pretrained(
+      args.hf, dtype=torch.bfloat16).to(device).eval()
+  bos_id = tok.bos_token_id
+  eos_id = tok.eos_token_id
+
+  def generate(ids):
+    mask = torch.ones_like(ids)
+    with torch.no_grad():
+      out = model.generate(input_ids=ids, attention_mask=mask,
+                           max_new_tokens=args.max_tokens, do_sample=False,
+                           eos_token_id=eos_id)
+    return tok.decode(out[0][ids.shape[1]:], skip_special_tokens=True)
+
+  print(f"bf16 A/B on {args.hf} ({device}): the same rendered [INST] prompt, "
+        f"with and without a leading {tok.bos_token!r} (id {bos_id}); "
+        f"eos {tok.eos_token!r} (id {eos_id})\n")
+  for q in ["How many days are in a week?", "What is 8 times 7?",
+            "What is 17 + 25?"]:
+    text = "[INST]" + q + SUFFIX + "[/INST]"   # what the bundle's template renders
+    ids = tok(text, add_special_tokens=False,
+              return_tensors="pt").input_ids.to(device)
+    bos = torch.tensor([[bos_id]], device=device)
+    no_bos = generate(ids)
+    with_bos = generate(torch.cat([bos, ids], dim=1))
+    print(f"  Q: {q}")
+    print(f"    no BOS  : {' '.join(no_bos.split())[:100]!r}")
+    print(f"    with BOS: {' '.join(with_bos.split())[:100]!r}\n")
+  print("Expected here: both columns answer (with-BOS is the trained "
+        "convention), which is why this recipe keeps the start_token. If the "
+        "with-BOS column echoed the question, the field would have to go — "
+        "that is the granite-4.1-3b case (bos == eos), not this one.")
+  return 0
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / metadata / start_token checks for Ministral-3-3B")
+  ap.add_argument("model", nargs="?", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--timeout", type=int, default=900,
+                  help="seconds per question (engine init is paid every run)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--json", help="write a JSON report here (gate mode)")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--bos-ab", action="store_true")
+  ap.add_argument("--hf", default="ministral3_text",
+                  help="the extracted text decoder dir (--bos-ab mode)")
+  ap.add_argument("--device", default="auto", help="--bos-ab device")
+  ap.add_argument("--max-tokens", type=int, default=64,
+                  help="--bos-ab generation budget")
+  args = ap.parse_args()
+
+  if args.bos_ab:
+    return bos_ab(args)
+  if not args.model:
+    ap.error("model.litertlm is required unless --bos-ab")
+  if not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/models/qwen/qwen2_5_coder_1_5b_instruct/README.md
+++ b/models/qwen/qwen2_5_coder_1_5b_instruct/README.md
@@ -1,0 +1,3 @@
+# Qwen2.5-Coder 1.5B Instruct Language Model
+
+Model recipes, conversion scripts, instructions, and utilities for Qwen2.5-Coder-1.5B-Instruct on-device code generation ([Qwen/Qwen2.5-Coder-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct)).

--- a/models/qwen/qwen2_5_coder_1_5b_instruct/converted/.gitignore
+++ b/models/qwen/qwen2_5_coder_1_5b_instruct/converted/.gitignore
@@ -1,0 +1,3 @@
+*.litertlm
+out_*/
+__pycache__/

--- a/models/qwen/qwen2_5_coder_1_5b_instruct/converted/README.md
+++ b/models/qwen/qwen2_5_coder_1_5b_instruct/converted/README.md
@@ -1,0 +1,92 @@
+# Qwen2.5-Coder-1.5B-Instruct Conversion
+
+Model recipes, instructions, scripts, and utilities for converting Qwen2.5-Coder-1.5B-Instruct to LiteRT-LM.
+
+These scripts convert [Qwen/Qwen2.5-Coder-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct) (dense `Qwen2ForCausalLM`, 1.54B parameters, Apache-2.0) into a `.litertlm` bundle for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a quality gate and a code gate. The published artifact is `Qwen2.5-Coder-1.5B-Instruct_int4.litertlm` (1.12 GB) at [litert-community/Qwen2.5-Coder-1.5B-Instruct](https://huggingface.co/litert-community/Qwen2.5-Coder-1.5B-Instruct).
+
+The model is a 28-layer dense transformer (hidden 1536, GQA 12:2, vocab 151936, tied embeddings) — standard Qwen2, handled by the plain litert-torch HF export path with no re-authoring. What this conversion documents is a **size trap** (a tied embedding stored seven times, silently), a **template fact** (a vendor default system prompt that a plain ChatML export drops), and why the 1–2B band in int4 is where a phone is quick rather than merely capable.
+
+## Build
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int4` | blockwise-32 OCTAV int4 weights, int8 embedding (externalized) | 1.12 GB | phone GPU/CPU, desktop |
+
+## Environment
+
+```bash
+pip install litert-torch==0.9.3 litert-converter==0.3.1 ai-edge-quantizer==0.8.0 \
+    litert-lm-builder==0.16.0 transformers==5.14.1
+pip install litert-lm   # verification CLI (>= 0.16.0)
+```
+
+The published bundle was built on exactly this released stack — no patched checkout.
+
+## Run
+
+```bash
+python build_qwen2_5_coder_1_5b.py --out out_int4                                    # 1.12 GB bundle
+python verify_qwen2_5_coder_1_5b.py out_int4/*.litertlm --backend cpu                # 8-question gate
+python verify_qwen2_5_coder_1_5b.py out_int4/*.litertlm --check-metadata             # template, stops, bytes/param
+python verify_qwen2_5_coder_1_5b.py out_int4/*.litertlm --code-gate --backend gpu    # 6 functions, executed
+```
+
+## The size trap: one table, stored seven times
+
+The first export of this checkpoint came out at **2.53 GB for 1.54 B parameters** — 1.64 bytes per parameter, for a recipe whose int4 linears should land near 0.5. Nothing had failed. Inspecting the tensors:
+
+| tensor type | count | stored |
+|---|---|---|
+| INT4 | 197 | 771.8 MB — the linears, correct |
+| **INT8** | **7** | **1,633.6 MB — the 151936×1536 vocab table, once per prefill signature** |
+
+Qwen2.5-Coder ties its embedding and `lm_head`. A recipe that asks for int4 on `FULLY_CONNECTED` and int8 on `EMBEDDING_LOOKUP` describes that one tensor two ways, and the quantizer resolves the conflict by materializing the int8 copy inside every signature's graph — six prefill signatures plus decode, seven copies, 65% of the file. Decode on these runtimes is memory-bandwidth-bound; a file 2.26× too large is a bundle 2.26× slower at the thing that limits it.
+
+**Fix: `externalize_embedder=True`** (the default in `build_qwen2_5_coder_1_5b.py`). The table moves into its own bundle section, referenced by every signature: **1,117,385,648 bytes, zero duplicated tensors, 0.72 bytes/param.** Same weights, same quality. `--check-metadata` asserts the bytes-per-parameter ratio so the duplicated build cannot pass unnoticed; `--inline-embedder` reproduces it for study.
+
+The check generalizes: file size ÷ parameter count against the recipe's expected ratio (int4 ~0.5–0.75, int8 ~1.05–1.35). It costs nothing, and it is the only symptom this defect has.
+
+## The template: the vendor's default system prompt
+
+Upstream's chat template inserts `You are Qwen, created by Alibaba Cloud. You are a helpful assistant.` as a system turn whenever the caller sends no system message. The runtime applies structured per-role prefixes and has no place for a conditional default, so a plain ChatML export ships a model that never sees the system turn it was tuned with — quietly, on every default request. `build_qwen2_5_coder_1_5b.py` folds that system turn into the **user prefix**, which renders byte-identical to upstream for a single-turn request:
+
+```
+<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\n
+```
+
+The trade: a caller who does send an explicit system message gets it as its own turn *and* the default inside the user prefix. A structured template cannot say "only if absent" — pick default-path fidelity (this recipe) or explicit-system fidelity (bare ChatML), knowing which you chose.
+
+The stop set is `<|im_end|>` (151645) and `<|endoftext|>` (151643), both from `generation_config`. The tokenizer has no BOS, so no `start_token`.
+
+## Verification results
+
+Two gates on the published bundle (`verify_qwen2_5_coder_1_5b.py`, litert-lm 0.16.0, Mac M4 Max), because a general-knowledge check certifies nothing for a code model:
+
+- **8-question gate: CPU 8/8, GPU 8/8**, non-degenerate.
+- **Code gate: 6/6** on GPU — `fib`, `reverse_words`, `is_prime`, largest contiguous sublist sum, `count_vowels`, `flatten`; the generated code is executed against assertions, and a task passes only if it imports and every assertion holds. Kadane's problem (`max_sum`) is the useful signal: it needs reasoning rather than recall.
+- `--check-metadata` 7/7 (default system turn in the user prefix, both stop ids, no `start_token`, externalized embedder, 0.72 bytes/param).
+
+Rebuilt from scratch with `build_qwen2_5_coder_1_5b.py` on the pinned stack: 1,117,385,648 bytes, **byte-identical to the published bundle from the tokenizer section onward** (the 127 differing bytes are the header's uuid and creation timestamp), 7/7 metadata, 8/8 gate, 6/6 code gate.
+
+Mac (M4 Max, `litert-lm benchmark`, `-p 256 -d 256 --cache no`, quiet machine, litert-lm 0.16.0):
+
+| backend | prefill tok/s | decode tok/s | TTFT | init |
+|---|---|---|---|---|
+| GPU (Metal) | 3037 | 137.8 | 0.099 s | 2.38 s |
+| CPU | 292 | 47.1 | 1.06 s | 2.87 s |
+
+For scale, a 3B-class int4 bundle measured on the same machine and protocol on the same day (granite-4.1-3b, 2.19 GB) runs 1241 tok/s prefill / 86.3 decode / 0.233 s TTFT / 5.96 s init: 1.6× the decode, 2.4× the prefill and TTFT, 2.5× the startup, from halving the bytes.
+
+On device:
+
+- **iPhone 17 Pro** (Metal, LiteRT-LM Swift harness): loads at the bundle's default 4096 context, engine init 6.27 s, 7/8 on the composite eight-question prompt (the miss is the rhyme completion, answered "white"; granite-4.1-3b missed the same line on its CPU leg in that harness and got it right when the question was asked alone). Threshold is 6/8.
+- **Pixel 8a** (Tensor G3, Mali-G715, 8 GB), `litert_lm_main` v0.16.0 driven directly, correct answers on both backends. GPU (OpenCL): **full delegation** — 1243/1243 nodes in every prefill signature, 1132/1132 in decode, zero rejected ops — prefill 83.7 tok/s, decode 12.0 tok/s, TTFT 0.54 s, engine init 15.1 s on the runtime's default factual prompt; on a code prompt (`is_prime`, correct function) prefill 116.6, decode 11.5, TTFT 0.54 s. CPU (XNNPACK): prefill 16.1, decode 12.6, TTFT 2.44 s, init 4.9 s.
+
+Two things the phone rows say. Decode is 12.0 GPU vs 12.6 CPU: the phone's GPU and CPU share the same LPDDR, so on phone hardware the GPU buys prefill and TTFT (0.54 s vs 2.44 s), not tokens per second — the Mac's 2.9× GPU decode ratio does not carry over. And against the 3B int4 bundles measured on the same phone (7–8 tok/s decode), halving the bytes is worth about 1.6× on decode — the lever this band exists for.
+
+## Files
+
+| File | What |
+|---|---|
+| `build_qwen2_5_coder_1_5b.py` | HF checkpoint → `.litertlm`: coder template (default system turn in the user prefix), blockwise-32 OCTAV int4 + int8 externalized embedding, 6-signature prefill ladder, 4096 context. `--inline-embedder` reproduces the duplicated-table build. |
+| `verify_qwen2_5_coder_1_5b.py` | 8-question quality gate via the `litert-lm` CLI; `--check-metadata` asserts the template shape, stop ids, no `start_token`, externalized embedder and bytes/param; `--code-gate` executes six generated functions against assertions. |

--- a/models/qwen/qwen2_5_coder_1_5b_instruct/converted/build_qwen2_5_coder_1_5b.py
+++ b/models/qwen/qwen2_5_coder_1_5b_instruct/converted/build_qwen2_5_coder_1_5b.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen/Qwen2.5-Coder-1.5B-Instruct (dense Qwen2ForCausalLM) -> .litertlm.
+
+Converts the Hugging Face checkpoint into a LiteRT-LM bundle through
+litert-torch's plain HF export path: blockwise-32 OCTAV int4 weights with the
+tied vocab embedding kept at int8 and split into its own section — 1.12 GB
+for 1.54 B parameters. Standard Qwen2 architecture, nothing to re-author.
+
+Two model-specific facts are baked in:
+
+  * externalize_embedder=True is required, not cosmetic. Qwen2.5-Coder ties
+    its embedding and lm_head, so a recipe asking for int4 linears and an int8
+    embedder describes one tensor two ways; the quantizer resolves it by
+    storing the 151936x1536 table once per prefill signature. With the
+    default six signatures that is seven int8 copies, 1.63 GB, 65% of a
+    2.53 GB file — and no error anywhere. Externalizing the table removes the
+    conflict: same weights, 1.12 GB, zero duplicated tensors.
+
+  * The vendor's default system prompt is baked into the user prefix.
+    Upstream's chat template inserts "You are Qwen, created by Alibaba Cloud.
+    You are a helpful assistant." whenever the caller sends no system message.
+    The runtime applies structured per-role prefixes and has no place for a
+    conditional default, so a plain ChatML template would put the model in a
+    state it was not tuned in on every default request. Carrying the system
+    turn inside the user prefix renders byte-identical to upstream for a
+    single-turn request. (A caller who sends an explicit system message gets
+    it as its own turn AND the default in the user prefix — the structured
+    template cannot express "only if absent".)
+
+Usage:
+  python build_qwen2_5_coder_1_5b.py --out out_int4
+"""
+
+import argparse
+import copy
+
+# ChatML with Qwen's default system turn folded into the user prefix.
+CODER_TEMPLATE = r"""{%- for message in messages -%}
+{%- if message['role'] == 'system' -%}
+{{- '<|im_start|>system\n' + message['content'] + '<|im_end|>\n' -}}
+{%- elif message['role'] == 'user' -%}
+{{- '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\n' + message['content'] + '<|im_end|>\n' -}}
+{%- elif message['role'] == 'assistant' -%}
+{{- '<|im_start|>assistant\n' + message['content'] + '<|im_end|>\n' -}}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{- '<|im_start|>assistant\n' -}}
+{%- endif -%}"""
+
+
+def patch_tokenizer():
+  """Forces the coder template on every tokenizer the exporter loads."""
+  import transformers
+
+  orig_from_pretrained = transformers.AutoTokenizer.from_pretrained
+
+  def patched_from_pretrained(*args, **kwargs):
+    tok = orig_from_pretrained(*args, **kwargs)
+    tok.chat_template = CODER_TEMPLATE
+    # No bos_token -> no start_token in the bundle. (generation_config already
+    # lists both <|im_end|> and <|endoftext|> as EOS, so both become stops.)
+    assert not tok.bos_token, "unexpected bos_token — re-check the start_token story"
+    return tok
+
+  transformers.AutoTokenizer.from_pretrained = patched_from_pretrained
+
+
+def register_int4_recipe():
+  """blockwise-32 OCTAV int4 weights + int8 tied embedding (151936x1536)."""
+  import ai_edge_quantizer.recipe as recipe_lib
+
+  int4_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  int4_rule["algorithm_key"] = recipe_lib.AlgorithmName.OCTAV
+  int4_rule["op_config"]["weight_tensor_config"]["granularity"] = "BLOCKWISE_32"
+
+  emb_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  emb_rule["operation"] = "EMBEDDING_LOOKUP"
+  emb_rule["op_config"]["weight_tensor_config"]["num_bits"] = 8
+
+  recipe_lib.QWEN25_CODER_INT4 = lambda: [int4_rule, emb_rule]
+  return "QWEN25_CODER_INT4"
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--model", default="Qwen/Qwen2.5-Coder-1.5B-Instruct",
+                  help="HF model id or a local checkout of it")
+  ap.add_argument("--out", default="out_int4", help="output dir")
+  ap.add_argument("--cache", type=int, default=4096, help="KV cache length")
+  ap.add_argument("--prefill", default="1024,256,64,16,4,1",
+                  help="comma-separated prefill signature ladder (the "
+                       "published bundle carries these six)")
+  ap.add_argument("--inline-embedder", action="store_true",
+                  help="skip externalize_embedder, reproducing the 2.53 GB "
+                       "duplicated-table bundle (for study only)")
+  args = ap.parse_args()
+
+  patch_tokenizer()
+  quant = register_int4_recipe()
+
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=args.model,
+      output_dir=args.out,
+      prefill_lengths=[int(x) for x in args.prefill.split(",") if x.strip()],
+      cache_length=args.cache,
+      quantization_recipe=quant,
+      # False -> structured per-role prompt templates in the bundle, not raw
+      # jinja (upstream's tool-calling template cannot run in the runtime's
+      # minimal jinja engine).
+      use_jinja_template=False,
+      externalize_embedder=not args.inline_embedder,
+      trust_remote_code=True,
+  )
+  print("EXPORT_DONE")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/qwen/qwen2_5_coder_1_5b_instruct/converted/verify_qwen2_5_coder_1_5b.py
+++ b/models/qwen/qwen2_5_coder_1_5b_instruct/converted/verify_qwen2_5_coder_1_5b.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate, metadata and code checks for a converted Qwen2.5-Coder-1.5B bundle.
+
+Three modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm), greedy, one fresh session per
+    question, and scores correctness plus degeneracy (looping, token spam,
+    empty output). This is the publish guardrail: a conversion that collapses
+    must not ship. For a code model it certifies little else — see --code-gate.
+
+      python verify_qwen2_5_coder_1_5b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — reads the bundle's LlmMetadata (no unpacking) and asserts
+    the shape this recipe produces: the vendor's default system turn folded
+    into the user prefix, <|im_end|> (151645) and <|endoftext|> (151643) among
+    the stop-token ids, NO start_token, the embedder in its own section, and a
+    bytes-per-parameter ratio in the int4 band (< 1.0) — the check that
+    catches the 2.53 GB duplicated-embedding export, which is otherwise silent.
+    Needs `pip install litert-lm-builder`.
+
+      python verify_qwen2_5_coder_1_5b.py model.litertlm --check-metadata
+
+  --code-gate — the check that matters for this model: six small functions
+    (fib, reverse_words, is_prime, largest contiguous sublist sum,
+    count_vowels, flatten) where the generated code is EXECUTED against
+    assertions rather than read. A task passes only if the code imports and
+    every assertion holds — code that looks right and raises is a fail, which
+    is the point.
+
+      python verify_qwen2_5_coder_1_5b.py model.litertlm --code-gate [--backend gpu]
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+# The veto on the 0.9-vs-0.11 question exists because the presence check alone
+# is one-sided: "0.11 is larger than 0.9" also contains "0.9" and would score
+# as correct. Require the right number AND the absence of the inverted claim.
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+
+DEFAULT_SYSTEM = "You are Qwen, created by Alibaba Cloud. You are a helpful assistant."
+PARAMS = 1_543_714_304  # Qwen2.5-Coder-1.5B-Instruct
+
+# (id, prompt, test source). Kept short: a long prompt measures the harness's
+# patience rather than the model.
+CODE_TASKS = [
+    ("fib",
+     "Write a Python function fib(n) that returns the nth Fibonacci number, with fib(0)=0 and fib(1)=1. Code only.",
+     "assert fib(0)==0\nassert fib(1)==1\nassert fib(10)==55"),
+    ("reverse_words",
+     "Write a Python function reverse_words(s) that returns the words of s in reverse order, space separated. Code only.",
+     "assert reverse_words('a b c')=='c b a'\nassert reverse_words('hello')=='hello'"),
+    ("is_prime",
+     "Write a Python function is_prime(n) that returns True if n is a prime number and False otherwise. Code only.",
+     "assert is_prime(2)\nassert is_prime(13)\nassert not is_prime(1)\nassert not is_prime(9)"),
+    ("max_sublist",
+     "Write a Python function max_sum(nums) that returns the largest sum of any contiguous sublist of the list nums. Code only.",
+     "assert max_sum([1,-2,3,4])==7\nassert max_sum([-1,-2])==-1"),
+    ("count_vowels",
+     "Write a Python function count_vowels(s) that returns how many vowels (aeiou, case insensitive) are in s. Code only.",
+     "assert count_vowels('Hello')==2\nassert count_vowels('xyz')==0"),
+    ("flatten",
+     "Write a Python function flatten(lst) that flattens a list of lists into a single list. Code only.",
+     "assert flatten([[1,2],[3]])==[1,2,3]\nassert flatten([])==[]"),
+]
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam.
+
+  The 5-gram trigger needs a corroborating diversity collapse: a model may
+  legitimately restate a quoted phrase a few times in a clean answer, while
+  real loops show heavy repetition AND cratered word diversity."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5:
+    return True
+  return False
+
+
+def run_one(litert_lm, model, prompt, backend, timeout):
+  """Runs one prompt through `litert-lm run`; the answer is exactly stdout."""
+  cmd = [litert_lm, "run", str(model), "--prompt", prompt,
+         "--backend", backend, "--temperature", "0", "--top-k", "1",
+         "--cache", "no"]
+  proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  return proc.stdout.strip()
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      ans = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    low = ans.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not ans.strip()) or degenerate(ans)
+    results.append({"label": label, "question": q, "ok": ok,
+                    "degenerate": degen, "answer": ans})
+    shown = " ".join(ans.split())[:90] if ans.strip() else "(empty)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results,
+    }, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def read_metadata(model):
+  """Returns (LlmMetadata pbtext, [sections]) without unpacking the bundle."""
+  from litert_lm_builder import litertlm_peek  # pip install litert-lm-builder
+
+  buf = io.StringIO()
+  litertlm_peek.peek_litertlm_file(str(model), None, buf)
+  text = buf.getvalue()
+  m = re.search(r"start of LlmMetadata\n(.*?)>{4,} end of LlmMetadata", text, re.S)
+  pbtext = m.group(1) if m else ""
+  sections = []
+  for sm in re.finditer(
+      r"Section (\d+):\n(.*?)Begin Offset:\s*(\d+)\n\s*End Offset:\s*(\d+)\n"
+      r"\s*Data Type:\s*(\S+)", text, re.S):
+    items = sm.group(2)
+    mt = re.search(r"model_type, Value \(String\): (\S+)", items)
+    sections.append({"index": int(sm.group(1)), "type": sm.group(5),
+                     "model_type": mt.group(1) if mt else None,
+                     "bytes": int(sm.group(4)) - int(sm.group(3))})
+  return pbtext, sections
+
+
+def check_metadata(args):
+  pbtext, sections = read_metadata(args.model)
+  if not pbtext:
+    print("FAIL: no LlmMetadata section found")
+    return 1
+  checks = []
+
+  def check(name, ok, detail=""):
+    checks.append(ok)
+    print(f"  [{'v' if ok else 'X'}] {name}{(': ' + detail) if detail else ''}")
+
+  has_start = bool(re.search(r"^\s*start_token\s*\{", pbtext, re.M))
+  check("no start_token (no BOS on this tokenizer)", not has_start)
+
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", pbtext)}
+  check("<|im_end|> (151645) and <|endoftext|> (151643) are stop-token ids",
+        {151645, 151643} <= stop_ids, f"stop ids {sorted(stop_ids)}")
+
+  def prefix(role):
+    m = re.search(role + r"\s*\{\s*prefix:\s*\"((?:[^\"\\]|\\.)*)\"", pbtext)
+    return m.group(1) if m else None
+  up = prefix("user") or ""
+  check("user prefix carries the vendor default system turn",
+        DEFAULT_SYSTEM in up and up.endswith(r"<|im_start|>user\n"), repr(up[:60] + "..."))
+  check("model prefix", prefix("model") == r"<|im_start|>assistant\n",
+        repr(prefix("model")))
+
+  types = [s["model_type"] for s in sections]
+  check("embedder in its own section (externalize_embedder)",
+        "tf_lite_embedder" in types, str(types))
+  total = os.path.getsize(args.model)
+  bpp = total / PARAMS
+  check("bytes per parameter in the int4 band (< 1.0; duplicated-table build is 1.64)",
+        bpp < 1.0, f"{total:,} B / {PARAMS:,} params = {bpp:.2f}")
+  big = [s for s in sections if s["bytes"] >= 2 * 1024 ** 3]
+  check("every section < 2 GiB (iOS mmap ceiling)", not big,
+        ", ".join(f"{s['type']}:{s['bytes'] / 1024 ** 3:.2f} GiB" for s in sections))
+
+  ok = all(checks)
+  print(f"\n  {'PASS' if ok else 'FAIL'}: {sum(checks)}/{len(checks)} metadata checks")
+  return 0 if ok else 1
+
+
+def extract_code(text):
+  """Prefer a fenced block; fall back to the whole reply."""
+  m = re.search(r"```(?:python)?\s*\n(.*?)```", text, re.S)
+  return m.group(1) if m else text
+
+
+def run_tests(code, test_src):
+  with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+    f.write(code + "\n\n" + test_src + "\nprint('PASS')\n")
+    path = f.name
+  try:
+    r = subprocess.run([sys.executable, path], capture_output=True, text=True,
+                       timeout=20)
+    if "PASS" in r.stdout:
+      return True, ""
+    err = r.stderr.strip().split("\n")[-1] if r.stderr.strip() else "no PASS"
+    return False, err
+  except subprocess.TimeoutExpired:
+    return False, "execution timeout (infinite loop?)"
+  finally:
+    os.unlink(path)
+
+
+def code_gate(args):
+  rows = []
+  for tid, prompt, test_src in CODE_TASKS:
+    try:
+      reply = run_one(args.litert_lm, args.model, prompt, args.backend, args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{tid}': {e}", file=sys.stderr)
+      return 2
+    ok, err = run_tests(extract_code(reply), test_src)
+    rows.append({"id": tid, "ok": ok, "error": err, "reply": reply})
+    print(f"  [{'v' if ok else '.'}] {tid:14s} {'' if ok else '— ' + err[:70]}")
+  passed = sum(r["ok"] for r in rows)
+  print(f"\n  passed: {passed}/{len(CODE_TASKS)}   (threshold {args.min_pass}) — "
+        "generated code executed against assertions, not read")
+  print(f"  VERDICT: {'PASS' if passed >= args.min_pass else 'FAIL'}")
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "passed": passed, "total": len(CODE_TASKS), "rows": rows}, indent=2,
+        ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed >= args.min_pass else 1
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / metadata / code checks for Qwen2.5-Coder-1.5B")
+  ap.add_argument("model", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--min-pass", type=int, default=4, help="--code-gate threshold")
+  ap.add_argument("--timeout", type=int, default=900,
+                  help="seconds per question (engine init is paid every run)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--json", help="write a JSON report here (gate / code-gate modes)")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--code-gate", action="store_true")
+  args = ap.parse_args()
+
+  if not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  if args.code_gate:
+    return code_gate(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/models/smollm/smollm3_3b/README.md
+++ b/models/smollm/smollm3_3b/README.md
@@ -1,0 +1,3 @@
+# SmolLM3 3B Language Model
+
+Model recipes, conversion scripts, instructions, and utilities for Hugging Face SmolLM3-3B on-device text generation ([HuggingFaceTB/SmolLM3-3B](https://huggingface.co/HuggingFaceTB/SmolLM3-3B)).

--- a/models/smollm/smollm3_3b/converted/.gitignore
+++ b/models/smollm/smollm3_3b/converted/.gitignore
@@ -1,0 +1,3 @@
+*.litertlm
+out_*/
+__pycache__/

--- a/models/smollm/smollm3_3b/converted/README.md
+++ b/models/smollm/smollm3_3b/converted/README.md
@@ -1,0 +1,87 @@
+# SmolLM3-3B Conversion
+
+Model recipes, instructions, scripts, and utilities for converting Hugging Face SmolLM3-3B to LiteRT-LM.
+
+These scripts convert [HuggingFaceTB/SmolLM3-3B](https://huggingface.co/HuggingFaceTB/SmolLM3-3B) (dense `SmolLM3ForCausalLM`, 3.08B parameters, Apache-2.0) into a `.litertlm` bundle for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a quality gate. The published artifact is `SmolLM3-3B_q4_block32_ekv4096.litertlm` at [litert-community/SmolLM3-3B](https://huggingface.co/litert-community/SmolLM3-3B).
+
+The model is a 36-layer dense transformer (hidden 2048, GQA 16:4, vocab 128256, tied embeddings) with SmolLM3's **NoPE** schedule — rotary embeddings disabled on every 4th layer (`no_rope_layer_interval=4`). That lowers to generic ops through the plain litert-torch HF export path; no re-authoring. What this conversion documents instead is a **template fact**: SmolLM3's reasoning-mode system prompt cannot ride the structured template the runtime applies, so the bundle is bare ChatML and the model's dual mode becomes the caller's choice.
+
+## Build
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int4` | blockwise-32 OCTAV int4 weights, int8 embedding (externalized) | 2.00 GB | phone GPU / desktop; GSM8K at parity with bf16 |
+
+## Environment
+
+```bash
+pip install litert-torch==0.9.3 litert-converter==0.3.1 ai-edge-quantizer==0.8.0 \
+    litert-lm-builder==0.16.0 transformers==5.14.1
+pip install litert-lm   # verification CLI (>= 0.16.0)
+```
+
+## Run
+
+```bash
+python build_smollm3_3b.py --out out_int4                            # ~2.0 GB bundle
+python verify_smollm3_3b.py out_int4/*.litertlm --backend cpu        # 8-question gate
+python verify_smollm3_3b.py out_int4/*.litertlm --check-metadata     # bare ChatML, no start_token, sections < 2 GiB
+python verify_smollm3_3b.py out_int4/*.litertlm --think-ab --backend gpu   # direct vs /think mode
+```
+
+## The template: why the bundle is bare ChatML
+
+SmolLM3's official chat template inserts a long system block when the caller sends no system message — today's date, `Reasoning Mode: /think`, and the "Thought section / Solution section" instructions — inside an `{% if messages[0]['role'] != 'system' %}` branch. The runtime does not run that template. With `use_jinja_template=False` the exporter renders sample conversations through it and extracts **structured per-role prefixes and suffixes** (`<|im_start|>user\n` … `<|im_end|>\n`). Every sample conversation it renders begins with a system turn, so the conditional branch never fires and nothing conditional survives. Embedding the raw jinja instead is not an option: the runtime's minimal jinja engine cannot run `strftime_now` or the tool blocks, and the bundle dies on the first message.
+
+The bundle therefore carries bare ChatML with a system-role prefix and no default system prompt. Two consequences, both measured on the published bundle (`--think-ab`, Mac GPU, greedy):
+
+| prompt | think block | answer |
+|---|---|---|
+| plain user turn (the bundle's default) | empty — the model closes `<think></think>` at once | `42.` |
+| same turn with SmolLM3's `/think` system prompt supplied as a system message | 120 words of reasoning | `42` |
+
+By default the bundle behaves as a direct-answer instruct model; a caller who wants the reasoning mode passes SmolLM3's system prompt (the text is in `verify_smollm3_3b.py`) as a system message. What the bundle cannot do is apply a default on its own — a structured template has no place for "only when the caller sent nothing". To bake a default system turn in, fold it into the user prefix as the Qwen2.5-Coder recipe in this repository does, and accept that an explicit system message then renders alongside it.
+
+Any model whose template guards its system prompt with a role check has the same shape. Check what the exporter extracted (`--check-metadata` prints the prefixes) before assuming the bundle carries what the template says.
+
+## Quantization
+
+GSM8K, n=100, greedy, 0-shot CoT, 1024-token budget, bare ChatML for both rows so the only variable is the quantization:
+
+| build | GSM8K |
+|---|---|
+| bf16 (HF reference) | 81.0% |
+| int4 blockwise-32 OCTAV, int8 embedding | 81.0% |
+
+Parity, 0.0 pt at this n. Blockwise int4 plus OCTAV clipping is what holds it; channelwise min-max int4 is the recipe that collapses small models. The bundle's stop token is `<|im_end|>` (id 128012), from `generation_config`. SmolLM3 has no BOS token, so there is no `start_token` and no start-token trap.
+
+## Prefill signatures and memory
+
+The published bundle carries a **single 128-token prefill signature** (`--prefill 128`): the smallest engine-init memory, at the cost of prefilling long prompts in 128-token chunks and padding short ones to 128. Each extra signature is charged engine memory at init whether or not it is called. A 6-rung ladder (`--prefill 1024,256,64,16,4,1`, what the Qwen2.5-Coder recipe ships) buys TTFT on long prompts for a larger init footprint. `externalize_embedder=True` splits the tied 128256×2048 vocab table into its own bundle section (0.25 GiB), keeping the main weights section at 1.61 GiB — under the iOS ~2 GiB single-section mmap ceiling. No effect on weights or parity.
+
+## Verification results
+
+Quality gate on the published bundle (`verify_smollm3_3b.py`, litert-lm 0.16.0, Mac M4 Max): **CPU 8/8, GPU 8/8, non-degenerate**; `--check-metadata` 7/7.
+
+Rebuilt from scratch with `build_smollm3_3b.py` on the pinned stack: 2,002,241,456 bytes against the published 2,002,257,840 (a 16 KB metadata difference — the published file was built on an earlier litert-torch), 7/7 on `--check-metadata`, 8/8 on the GPU gate.
+
+Mac (M4 Max, `litert-lm benchmark`, `-p 256 -d 256 --runs 3`, max-num-tokens 4096, quiet machine, litert-lm 0.15.0):
+
+| backend | prefill tok/s | decode tok/s | TTFT |
+|---|---|---|---|
+| GPU (Metal) | 1354 | 93.2 | 0.21 s |
+| CPU | 141 | 24.1 | 2.14 s |
+
+On device:
+
+- **Pixel 8a** (Tensor G3, Mali-G715, 8 GB), GPU (OpenCL), `litert_lm_main` v0.16.0 driven directly: **full delegation** — 1476/1476 nodes in the 128-token prefill graph, 1308/1308 in decode, zero rejected ops — prefill 11.9 tok/s, decode 7.69 tok/s, TTFT 1.56 s, engine init 18.3 s, correct answer (the runtime's default factual prompt). The prefill figure is on a short prompt padded to the 128-token signature, so it reflects fixed per-turn cost rather than throughput.
+- **iPhone 17 Pro** (Metal, iOS 27.0, one cold run through a LiteRT-LM Swift harness, 512-token budget): decode 22.5 tok/s, prefill 30.8 tok/s (short prompt), TTFT 0.63 s, load 7.7 s, footprint 1.24 GB.
+
+A Mac's GPU-vs-CPU ratio does not transfer to a phone: on the M4 Max the Metal GPU decodes 3.9× the CPU, while on the Pixel 8a a 3B int4 bundle's GPU and CPU decode land within 1% of each other (7.07 vs 6.98 tok/s, measured on a granite-4.1-3b int4 bundle on the same phone), because a phone's CPU and GPU share the same LPDDR. On phone hardware the GPU buys prefill and TTFT, not tokens per second.
+
+## Files
+
+| File | What |
+|---|---|
+| `build_smollm3_3b.py` | HF checkpoint → `.litertlm`: bare-ChatML export, blockwise-32 OCTAV int4 + int8 externalized embedding, single 128 prefill signature, 4096 context. |
+| `verify_smollm3_3b.py` | 8-question quality gate via the `litert-lm` CLI; `--check-metadata` asserts the template shape, stop token, no `start_token`, section sizes; `--think-ab` shows direct vs `/think` mode on the same question. |

--- a/models/smollm/smollm3_3b/converted/build_smollm3_3b.py
+++ b/models/smollm/smollm3_3b/converted/build_smollm3_3b.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HuggingFaceTB/SmolLM3-3B (dense SmolLM3ForCausalLM) -> .litertlm.
+
+Converts the Hugging Face checkpoint into a LiteRT-LM bundle through
+litert-torch's plain HF export path: blockwise-32 OCTAV int4 weights with the
+tied vocab embedding kept at int8 and split into its own bundle section
+(~2.0 GB). SmolLM3's NoPE schedule (rotary disabled on every 4th layer,
+`no_rope_layer_interval=4`) lowers to generic ops — no re-authoring.
+
+The one thing to know before running this: SmolLM3's official chat template
+carries its reasoning-mode system prompt (`Reasoning Mode: /think` plus a long
+instruction block) inside an `if messages[0]['role'] != 'system'` branch. The
+exporter extracts STRUCTURED per-role prefixes/suffixes from the template by
+rendering sample conversations that always start with a system turn, so that
+branch never fires and nothing conditional survives into the bundle. The
+bundle is therefore bare ChatML (`<|im_start|>role\n ... <|im_end|>\n`), and
+SmolLM3 answers in direct mode by default (it closes `<think></think>` at
+once). A caller who wants the reasoning mode supplies SmolLM3's /think system
+prompt as a system message — the system-role prefix is in the bundle. See
+README.md and `verify_smollm3_3b.py --think-ab`.
+
+Usage:
+  python build_smollm3_3b.py --out out_int4
+"""
+
+import argparse
+import copy
+
+# Bare ChatML — what the exporter can carry, and what the published bundle
+# uses. Byte-identical to the upstream template's per-role markers; what it
+# drops is upstream's conditional system block (date, reasoning mode,
+# instructions), which cannot ride the structured template (see module doc).
+CHATML_TEMPLATE = r"""{%- for message in messages -%}
+{{- '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n' -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{- '<|im_start|>assistant\n' -}}
+{%- endif -%}"""
+
+
+def patch_tokenizer():
+  """Forces the bare ChatML template on every tokenizer the exporter loads."""
+  import transformers
+
+  orig_from_pretrained = transformers.AutoTokenizer.from_pretrained
+
+  def patched_from_pretrained(*args, **kwargs):
+    tok = orig_from_pretrained(*args, **kwargs)
+    tok.chat_template = CHATML_TEMPLATE
+    # SmolLM3 has no bos_token, so the bundle carries no start_token and the
+    # runtime prepends nothing. (Checkpoints that DO declare one while saying
+    # add_bos_token: False need it cleared here — see the granite-4.1-3b recipe.)
+    assert not tok.bos_token, "unexpected bos_token — re-check the start_token story"
+    return tok
+
+  transformers.AutoTokenizer.from_pretrained = patched_from_pretrained
+
+
+def register_int4_recipe():
+  """Registers the int4 recipe under a name the exporter can look up.
+
+  blockwise-32 OCTAV int4 for the weights (data-free optimal clipping;
+  channelwise min-max int4 degrades LLMs measurably more) with the tied
+  128256x2048 vocab embedding kept at int8 (EMBEDDING_LOOKUP is where naive
+  int4 hurts most). This is the recipe that measured GSM8K 81.0% against a
+  bf16 81.0% (n=100) — see README.md.
+  """
+  import ai_edge_quantizer.recipe as recipe_lib
+
+  int4_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  int4_rule["algorithm_key"] = recipe_lib.AlgorithmName.OCTAV
+  int4_rule["op_config"]["weight_tensor_config"]["granularity"] = "BLOCKWISE_32"
+
+  emb_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  emb_rule["operation"] = "EMBEDDING_LOOKUP"
+  emb_rule["op_config"]["weight_tensor_config"]["num_bits"] = 8
+
+  recipe_lib.SMOLLM3_INT4 = lambda: [int4_rule, emb_rule]
+  return "SMOLLM3_INT4"
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--model", default="HuggingFaceTB/SmolLM3-3B",
+                  help="HF model id or a local checkout of it")
+  ap.add_argument("--out", default="out_int4", help="output dir")
+  ap.add_argument("--cache", type=int, default=4096, help="KV cache length")
+  ap.add_argument("--prefill", default="128",
+                  help="comma-separated prefill signature ladder. The published "
+                       "bundle carries the single 128 signature (smallest "
+                       "engine-init memory; long prompts are prefilled in "
+                       "128-token chunks). '1024,256,64,16,4,1' trades init "
+                       "memory for TTFT on long prompts — see README.md.")
+  args = ap.parse_args()
+
+  patch_tokenizer()
+  quant = register_int4_recipe()
+
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=args.model,
+      output_dir=args.out,
+      prefill_lengths=[int(x) for x in args.prefill.split(",") if x.strip()],
+      cache_length=args.cache,
+      quantization_recipe=quant,
+      # False -> the exporter extracts structured prompt templates from the
+      # (bare ChatML) chat template instead of embedding raw jinja in the
+      # bundle. The runtime's minimal jinja engine cannot run upstream's
+      # template (strftime_now, tool blocks), so this is not optional.
+      use_jinja_template=False,
+      # Splits the tied vocab embedding into its own bundle section, keeping the
+      # main weights section (1.61 GiB) under the iOS ~2 GiB single-section
+      # mmap ceiling. No effect on weights or parity.
+      externalize_embedder=True,
+      trust_remote_code=True,
+  )
+  print("EXPORT_DONE")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/smollm/smollm3_3b/converted/verify_smollm3_3b.py
+++ b/models/smollm/smollm3_3b/converted/verify_smollm3_3b.py
@@ -1,0 +1,296 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate and template checks for a converted SmolLM3-3B bundle.
+
+Three modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm), greedy, one fresh session per
+    question, and scores correctness plus degeneracy (looping, token spam,
+    empty output). This is the publish guardrail: a conversion that collapses
+    must not ship.
+
+      python verify_smollm3_3b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — reads the bundle's LlmMetadata (no unpacking) and asserts
+    the shape this recipe produces: bare ChatML per-role templates, <|im_end|>
+    (128012) among the stop tokens, NO start_token, and the embedder in its own
+    section with every section under 2 GiB (the iOS single-section mmap
+    ceiling). Needs `pip install litert-lm-builder`.
+
+      python verify_smollm3_3b.py model.litertlm --check-metadata
+
+  --think-ab — shows what the bare-ChatML bundle does with SmolLM3's two
+    modes: the same question asked plainly (the bundle's default: the model
+    closes <think></think> immediately and answers directly) and with
+    SmolLM3's official /think system prompt supplied as a system message
+    through the CLI's --preset (the model reasons at length first). Both
+    are legitimate; the point is that the bundle carries no default system
+    prompt, so the mode is the caller's choice.
+
+      python verify_smollm3_3b.py model.litertlm --think-ab [--backend gpu]
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+# The veto on the 0.9-vs-0.11 question exists because the presence check alone
+# is one-sided: "0.11 is larger than 0.9" also contains "0.9" and would score
+# as correct. Require the right number AND the absence of the inverted claim.
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+
+# SmolLM3's official reasoning-mode system prompt (the block upstream's chat
+# template inserts when no system message is given), minus the date line.
+THINK_SYSTEM_PROMPT = (
+    "## Metadata\n\nKnowledge Cutoff Date: June 2025\nReasoning Mode: /think\n\n"
+    "## Custom Instructions\n\nYou are a helpful AI assistant named SmolLM, "
+    "trained by Hugging Face. Your role as an assistant involves thoroughly "
+    "exploring questions through a systematic thinking process before providing "
+    "the final precise and accurate solutions. This requires engaging in a "
+    "comprehensive cycle of analysis, summarizing, exploration, reassessment, "
+    "reflection, backtracking, and iteration to develop well-considered thinking "
+    "process. Please structure your response into two main sections: Thought and "
+    "Solution using the specified format: <think> Thought section </think> "
+    "Solution section. In the Thought section, detail your reasoning process in "
+    "steps. Each step should include detailed considerations such as analysing "
+    "questions, summarizing relevant findings, brainstorming new ideas, verifying "
+    "the accuracy of the current steps, refining any errors, and revisiting "
+    "previous steps. In the Solution section, based on various attempts, "
+    "explorations, and reflections from the Thought section, systematically "
+    "present the final solution that you deem correct. The Solution section "
+    "should be logical, accurate, and concise and detail necessary steps needed "
+    "to reach the conclusion.")
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam.
+
+  The 5-gram trigger needs a corroborating diversity collapse: a model may
+  legitimately restate a quoted phrase a few times in a clean answer, while
+  real loops show heavy repetition AND cratered word diversity."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5:
+    return True
+  return False
+
+
+def run_one(litert_lm, model, prompt, backend, timeout, preset=None):
+  """Runs one prompt through `litert-lm run`; the answer is exactly stdout."""
+  cmd = [litert_lm, "run", str(model), "--prompt", prompt,
+         "--backend", backend, "--temperature", "0", "--top-k", "1",
+         "--cache", "no"]
+  if preset:
+    cmd += ["--preset", preset]
+  proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  out = proc.stdout
+  if preset:
+    # --preset echoes a header (the system instruction, then "- Tools:" and one
+    # "  - name" line per tool) before the answer; drop it.
+    head, sep, tail = out.rpartition("- Tools:\n")
+    if sep:
+      out = re.sub(r"^  - .*\n", "", tail, flags=re.M)
+  return out.strip()
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      ans = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    # SmolLM3 in direct mode opens with an empty think block; score the answer body.
+    body = re.sub(r"<think>.*?</think>", "", ans, flags=re.S)
+    low = body.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not body.strip()) or degenerate(body)
+    results.append({"label": label, "question": q, "ok": ok,
+                    "degenerate": degen, "answer": ans})
+    shown = " ".join(body.split())[:90] if body.strip() else "(empty)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results,
+    }, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def read_metadata(model):
+  """Returns (LlmMetadata pbtext, [sections]) without unpacking the bundle."""
+  from litert_lm_builder import litertlm_peek  # pip install litert-lm-builder
+
+  buf = io.StringIO()
+  litertlm_peek.peek_litertlm_file(str(model), None, buf)
+  text = buf.getvalue()
+  m = re.search(r"start of LlmMetadata\n(.*?)>{4,} end of LlmMetadata", text, re.S)
+  pbtext = m.group(1) if m else ""
+  sections = []
+  for sm in re.finditer(
+      r"Section (\d+):\n(.*?)Begin Offset:\s*(\d+)\n\s*End Offset:\s*(\d+)\n"
+      r"\s*Data Type:\s*(\S+)", text, re.S):
+    items = sm.group(2)
+    mt = re.search(r"model_type, Value \(String\): (\S+)", items)
+    sections.append({"index": int(sm.group(1)), "type": sm.group(5),
+                     "model_type": mt.group(1) if mt else None,
+                     "bytes": int(sm.group(4)) - int(sm.group(3))})
+  return pbtext, sections
+
+
+def check_metadata(args):
+  pbtext, sections = read_metadata(args.model)
+  if not pbtext:
+    print("FAIL: no LlmMetadata section found")
+    return 1
+  checks = []
+
+  def check(name, ok, detail=""):
+    checks.append(ok)
+    print(f"  [{'v' if ok else 'X'}] {name}{(': ' + detail) if detail else ''}")
+
+  has_start = bool(re.search(r"^\s*start_token\s*\{", pbtext, re.M))
+  check("no start_token (SmolLM3 has no BOS)", not has_start)
+
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", pbtext)}
+  check("<|im_end|> (128012) is a stop token", 128012 in stop_ids,
+        f"stop ids {sorted(stop_ids)}")
+
+  def prefix(role):
+    m = re.search(role + r"\s*\{\s*prefix:\s*\"((?:[^\"\\]|\\.)*)\"", pbtext)
+    return m.group(1) if m else None
+  check("user prefix is bare ChatML", prefix("user") == r"<|im_start|>user\n",
+        repr(prefix("user")))
+  check("system prefix present (caller can supply /think)",
+        prefix("system") == r"<|im_start|>system\n", repr(prefix("system")))
+  check("model prefix", prefix("model") == r"<|im_start|>assistant\n",
+        repr(prefix("model")))
+
+  types = [s["model_type"] for s in sections]
+  check("embedder in its own section", "tf_lite_embedder" in types, str(types))
+  big = [s for s in sections if s["bytes"] >= 2 * 1024 ** 3]
+  check("every section < 2 GiB (iOS mmap ceiling)", not big,
+        ", ".join(f"{s['type']}:{s['bytes'] / 1024 ** 3:.2f} GiB" for s in sections))
+
+  ok = all(checks)
+  print(f"\n  {'PASS' if ok else 'FAIL'}: {sum(checks)}/{len(checks)} metadata checks")
+  return 0 if ok else 1
+
+
+def think_ab(args):
+  q = "What is 17 + 25?" + SUFFIX
+  with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+    f.write("tools = []\nsystem_instruction = " + json.dumps(THINK_SYSTEM_PROMPT) + "\n")
+    preset = f.name
+  try:
+    plain = run_one(args.litert_lm, args.model, q, args.backend, args.timeout)
+    think = run_one(args.litert_lm, args.model, q, args.backend, args.timeout,
+                    preset=preset)
+  finally:
+    os.unlink(preset)
+
+  def describe(name, text):
+    m = re.search(r"<think>(.*?)</think>", text, re.S)
+    thought = m.group(1).strip() if m else None
+    body = re.sub(r"<think>.*?</think>", "", text, flags=re.S).strip()
+    print(f"  {name}:")
+    print(f"    think block: {'none' if thought is None else ('empty' if not thought else f'{len(thought.split())} words')}")
+    print(f"    answer body: {len(body.split())} words -> {' '.join(body.split())[:120]!r}")
+    has42 = re.search(r"\b42\b", body) is not None
+    print(f"    contains 42: {'yes' if has42 else 'NO'}")
+
+  print(f"same question, {args.backend}: {q!r}\n")
+  describe("plain (bundle default, no system prompt)", plain)
+  describe("with SmolLM3's /think system prompt via --preset", think)
+  print("\nExpected: the plain run answers directly (empty or no think block); "
+        "the /think run reasons first. The bundle carries no default system "
+        "prompt, so the mode is the caller's.")
+  return 0
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / metadata / think-mode checks for SmolLM3-3B")
+  ap.add_argument("model", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--timeout", type=int, default=900,
+                  help="seconds per question (engine init is paid every run)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--json", help="write a JSON report here (gate mode)")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--think-ab", action="store_true")
+  args = ap.parse_args()
+
+  if not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  if args.think_ab:
+    return think_ab(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/models/vibethinker/vibethinker_3b/README.md
+++ b/models/vibethinker/vibethinker_3b/README.md
@@ -1,0 +1,3 @@
+# VibeThinker 3B Language Model
+
+Model recipes, conversion scripts, instructions, and utilities for WeiboAI VibeThinker-3B on-device math/reasoning text generation ([WeiboAI/VibeThinker-3B](https://huggingface.co/WeiboAI/VibeThinker-3B)).

--- a/models/vibethinker/vibethinker_3b/converted/.gitignore
+++ b/models/vibethinker/vibethinker_3b/converted/.gitignore
@@ -1,0 +1,3 @@
+*.litertlm
+out_*/
+__pycache__/

--- a/models/vibethinker/vibethinker_3b/converted/README.md
+++ b/models/vibethinker/vibethinker_3b/converted/README.md
@@ -1,0 +1,83 @@
+# VibeThinker-3B Conversion
+
+Model recipes, instructions, scripts, and utilities for converting WeiboAI VibeThinker-3B to LiteRT-LM.
+
+These scripts convert [WeiboAI/VibeThinker-3B](https://huggingface.co/WeiboAI/VibeThinker-3B) (dense `Qwen2ForCausalLM`, 3.09B parameters, MIT) into a `.litertlm` bundle for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a quality gate and a math gate. The published artifact is `model.litertlm` (2.06 GB) at [litert-community/VibeThinker-3B](https://huggingface.co/litert-community/VibeThinker-3B).
+
+VibeThinker is a **math/reasoning model**: it works a problem through an inline chain of thought, then states the answer (`\boxed{}` / `####`). Architecturally it is a 36-layer Qwen2 (hidden 2048, GQA 16:2, vocab 151936, tied embeddings), handled by the plain litert-torch HF export path with no re-authoring. What this conversion documents is a **stop-token gap** the vendor config leaves open under ChatML, and a **block-size finding**: the int4 block size that is a free speed knob on general-purpose models is not free on a model whose job is exact arithmetic.
+
+## Build
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int4` | blockwise-**32** OCTAV int4 weights, int8 embedding (externalized) | 2.06 GB | the only build — block-128 collapses this model (below) |
+
+## Environment
+
+```bash
+pip install litert-torch==0.9.3 litert-converter==0.3.1 ai-edge-quantizer==0.8.0 \
+    litert-lm-builder==0.16.0 transformers==5.14.1
+pip install litert-lm   # verification CLI (>= 0.16.0)
+```
+
+## Run
+
+```bash
+python build_vibethinker_3b.py --out out_int4                                # ~2.06 GB bundle
+python verify_vibethinker_3b.py out_int4/*.litertlm --backend cpu            # 8-question gate
+python verify_vibethinker_3b.py out_int4/*.litertlm --check-metadata         # both stop ids, no start_token, sections
+python verify_vibethinker_3b.py out_int4/*.litertlm --math --backend gpu     # 6 word problems, chain of thought
+```
+
+## Stop tokens: the vendor config declares one, ChatML needs two
+
+VibeThinker's `generation_config.json` lists a single EOS, `<|endoftext|>` (151643). Under ChatML the model ends its turn with `<|im_end|>` (151645). The bundle builder derives the id-level stop set from `generation_config`, so a naive export gives the runtime no id stop for `<|im_end|>` and the model can finish its answer and keep going. `build_vibethinker_3b.py` adds 151645 to `eos_token_id` after the model loads; the published bundle carries both ids and `--check-metadata` asserts it. The tokenizer has no BOS, so there is no `start_token`.
+
+The bundle's template is bare ChatML. Upstream's Qwen2 template also inserts `You are a helpful assistant.` as a default system turn; the bundle drops that line, and every number below was measured without it. To bake it in, fold the system turn into the user prefix as the Qwen2.5-Coder recipe in this repository does.
+
+## Block size: 32, not 128
+
+GSM8K, n=100, greedy, 0-shot CoT, **2048-token budget** (a reasoning model needs the room — at a short budget the chain of thought is cut off before the answer, and int4, whose chains run slightly longer, looks falsely degraded), identical prompt and extraction for every row:
+
+| build | GSM8K |
+|---|---|
+| bf16 (HF reference) | 97.0% |
+| int4 blockwise-**32** OCTAV, int8 embedding | **90.0%** (−7 pt) |
+| int4 blockwise-128 OCTAV, int8 embedding | 64.0% (−33 pt) |
+
+Block-128 has a quarter of the dequant scales and is the faster GPU build on general-purpose 4B reasoning models, where it measures at parity with block-32 or better. On this model it collapses. The difference is the task: exact arithmetic is precision-sensitive in a way open-ended reasoning is not, and the coarser grid loses it. Only block-32 is offered here; treat block size as a per-model measurement, not a default.
+
+## Prefill signatures and memory
+
+The published bundle carries a single 128-token prefill signature and a 4096-token KV cache. Keep the context at 4096 or above: the model spends 300–600 words per answer before it is done. `externalize_embedder=True` splits the tied 151936×2048 vocab table into its own section (0.29 GiB), keeping the main weights section at 1.62 GiB — under the iOS ~2 GiB single-section mmap ceiling.
+
+## Verification results
+
+Gates on the published bundle (`verify_vibethinker_3b.py`, litert-lm 0.16.0, Mac M4 Max), scored on the answer after the think block:
+
+- **8-question gate: CPU 8/8, GPU 7/8**, non-degenerate (the GPU miss is the rhyme completion, answered "white"; every answer took 50–100 words including its reasoning).
+- **Math gate: 6/6** on GPU — six GSM8K-shaped word problems, 294–582 words per answer, every final number correct.
+- `--check-metadata` 7/7.
+
+Rebuilt from scratch with these scripts on the pinned stack: 2,057,073,584 bytes against the published 2,057,106,352 (a 32 KB metadata difference — the published file was built on an earlier litert-torch), 7/7 on `--check-metadata` with both stop ids present, and the same 7/8 on the GPU gate with the same eight answers.
+
+Mac (M4 Max, `litert-lm benchmark`, `-p 256 -d 256 --runs 3`, max-num-tokens 4096, quiet machine, litert-lm 0.15.0):
+
+| backend | prefill tok/s | decode tok/s | TTFT |
+|---|---|---|---|
+| GPU (Metal) | 1386 | 94.1 | 0.20 s |
+| CPU | 139 | 28.4 | 2.15 s |
+
+On device:
+
+- **Pixel 8a** (Tensor G3, Mali-G715, 8 GB), GPU (OpenCL), `litert_lm_main` v0.16.0 driven directly: **full delegation** — 1603/1603 nodes in the 128-token prefill graph, 1452/1452 in decode, zero rejected ops. On an arithmetic prompt ("What is 17 + 25? Answer with just the number.") it reasons briefly and answers `42`: prefill 17.3 tok/s, decode 8.11 tok/s, TTFT 1.51 s. CPU (XNNPACK): prefill 1.62 tok/s, decode 4.10 tok/s, TTFT 10.7 s. Engine init 20–50 s on this phone.
+- **iPhone 17 Pro** (Metal): loads and generates correct answers (the 1.62 GiB main section is under the iOS limit); no on-device timing was taken.
+
+This is a math-specialised model, and it shows on a phone: on the runtime's default factual prompt (the tallest building) it reasoned at length and settled on a wrong answer — identically in shape on GPU and CPU, with different hallucinated content, which is how you tell it is the model's domain rather than the backend. Ask it arithmetic.
+
+## Files
+
+| File | What |
+|---|---|
+| `build_vibethinker_3b.py` | HF checkpoint → `.litertlm`: bare-ChatML export with the `<|im_end|>` stop added, blockwise-32 OCTAV int4 + int8 externalized embedding, single 128 prefill signature, 4096 context. |
+| `verify_vibethinker_3b.py` | 8-question quality gate via the `litert-lm` CLI (scored after the think block); `--check-metadata` asserts both stop ids, no `start_token`, template shape, section sizes; `--math` runs six word problems and checks the final number. |

--- a/models/vibethinker/vibethinker_3b/converted/build_vibethinker_3b.py
+++ b/models/vibethinker/vibethinker_3b/converted/build_vibethinker_3b.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WeiboAI/VibeThinker-3B (dense Qwen2ForCausalLM, math/reasoning) -> .litertlm.
+
+Converts the Hugging Face checkpoint into a LiteRT-LM bundle through
+litert-torch's plain HF export path: blockwise-32 OCTAV int4 weights with the
+tied vocab embedding kept at int8 and split into its own section (~2.06 GB).
+Standard Qwen2 architecture — nothing to re-author.
+
+Two model-specific facts are baked in:
+
+  * Stop tokens. VibeThinker's generation_config declares only <|endoftext|>
+    (151643) as EOS, but under ChatML the model ends its turn with <|im_end|>
+    (151645). The bundle builder derives the stop set from generation_config,
+    so without a fix the runtime has no id-level stop for <|im_end|> and can
+    keep generating past the answer. This script adds 151645 to the model's
+    eos_token_id before the metadata is built (the published bundle carries
+    both ids).
+
+  * Block size. This is a precision-sensitive math model: block-32 int4 holds
+    GSM8K at 90.0% (bf16 97.0%), while the coarser block-128 int4 collapses
+    to 64.0% (n=100, greedy, 2048-token budget). Only block-32 is offered.
+    General-purpose 4B reasoning models show the opposite (block-128 is fine
+    and faster); exact arithmetic needs the finer grid.
+
+Usage:
+  python build_vibethinker_3b.py --out out_int4
+"""
+
+import argparse
+import copy
+
+# Bare ChatML — the published bundle's template. Upstream's Qwen2 template
+# also inserts "You are a helpful assistant." as a default system turn; the
+# bundle drops that line (measured with it dropped: GSM8K 90.0%, 8Q 8/8). To
+# bake it in, put the system turn into the user prefix as the Qwen2.5-Coder
+# recipe in this repo does.
+CHATML_TEMPLATE = r"""{%- for message in messages -%}
+{{- '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n' -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{- '<|im_start|>assistant\n' -}}
+{%- endif -%}"""
+
+IM_END = 151645        # <|im_end|>
+END_OF_TEXT = 151643   # <|endoftext|>
+
+
+def patch_tokenizer():
+  """Forces the bare ChatML template on every tokenizer the exporter loads."""
+  import transformers
+
+  orig_from_pretrained = transformers.AutoTokenizer.from_pretrained
+
+  def patched_from_pretrained(*args, **kwargs):
+    tok = orig_from_pretrained(*args, **kwargs)
+    tok.chat_template = CHATML_TEMPLATE
+    # No bos_token on this tokenizer -> no start_token in the bundle.
+    assert not tok.bos_token, "unexpected bos_token — re-check the start_token story"
+    return tok
+
+  transformers.AutoTokenizer.from_pretrained = patched_from_pretrained
+
+
+def patch_stop_tokens():
+  """Adds <|im_end|> to generation_config.eos_token_id after the model loads.
+
+  The bundle builder reads `model.generation_config.eos_token_id` (int or
+  list) into the LlmMetadata stop set. VibeThinker ships eos_token_id=151643
+  only; the ChatML turn terminator is 151645.
+  """
+  import transformers
+
+  orig_from_pretrained = transformers.AutoModelForCausalLM.from_pretrained
+
+  def patched_from_pretrained(*args, **kwargs):
+    model = orig_from_pretrained(*args, **kwargs)
+    eos = model.generation_config.eos_token_id
+    eos = [eos] if isinstance(eos, int) else list(eos or [])
+    if IM_END not in eos:
+      eos.append(IM_END)
+    if END_OF_TEXT not in eos:
+      eos.append(END_OF_TEXT)
+    model.generation_config.eos_token_id = eos
+    print(f"stop-token fix: generation_config.eos_token_id = {eos}")
+    return model
+
+  transformers.AutoModelForCausalLM.from_pretrained = patched_from_pretrained
+
+
+def register_int4_recipe():
+  """blockwise-32 OCTAV int4 weights + int8 tied embedding (151936x2048).
+
+  Block-32 only, on purpose: block-128 collapsed this model's GSM8K from 90.0%
+  to 64.0% (see module doc / README.md).
+  """
+  import ai_edge_quantizer.recipe as recipe_lib
+
+  int4_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  int4_rule["algorithm_key"] = recipe_lib.AlgorithmName.OCTAV
+  int4_rule["op_config"]["weight_tensor_config"]["granularity"] = "BLOCKWISE_32"
+
+  emb_rule = copy.deepcopy(recipe_lib.dynamic_wi4_afp32()[0])
+  emb_rule["operation"] = "EMBEDDING_LOOKUP"
+  emb_rule["op_config"]["weight_tensor_config"]["num_bits"] = 8
+
+  recipe_lib.VIBETHINKER_INT4 = lambda: [int4_rule, emb_rule]
+  return "VIBETHINKER_INT4"
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--model", default="WeiboAI/VibeThinker-3B",
+                  help="HF model id or a local checkout of it")
+  ap.add_argument("--out", default="out_int4", help="output dir")
+  ap.add_argument("--cache", type=int, default=4096,
+                  help="KV cache length. Keep >= 4096: the model reasons at "
+                       "length before its \\boxed{} answer.")
+  ap.add_argument("--prefill", default="128",
+                  help="comma-separated prefill signature ladder. The published "
+                       "bundle carries the single 128 signature; see README.md "
+                       "for the ladder trade-off.")
+  args = ap.parse_args()
+
+  patch_tokenizer()
+  patch_stop_tokens()
+  quant = register_int4_recipe()
+
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=args.model,
+      output_dir=args.out,
+      prefill_lengths=[int(x) for x in args.prefill.split(",") if x.strip()],
+      cache_length=args.cache,
+      quantization_recipe=quant,
+      # False -> structured per-role prompt templates in the bundle, not raw
+      # jinja (the runtime's minimal jinja engine cannot run upstream's
+      # tool-calling template).
+      use_jinja_template=False,
+      # Tied embedding into its own section: main weights section 1.62 GiB,
+      # under the iOS ~2 GiB single-section mmap ceiling. No effect on parity.
+      externalize_embedder=True,
+      trust_remote_code=True,
+  )
+  print("EXPORT_DONE")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/vibethinker/vibethinker_3b/converted/verify_vibethinker_3b.py
+++ b/models/vibethinker/vibethinker_3b/converted/verify_vibethinker_3b.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate, metadata and math checks for a converted VibeThinker-3B bundle.
+
+Three modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm), greedy, one fresh session per
+    question, and scores correctness plus degeneracy (looping, token spam,
+    empty output). VibeThinker reasons inside <think>...</think> before it
+    answers; the gate scores the answer body after the think block. This is
+    the publish guardrail: a conversion that collapses must not ship.
+
+      python verify_vibethinker_3b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — reads the bundle's LlmMetadata (no unpacking) and asserts
+    the shape this recipe produces: bare ChatML per-role templates, BOTH
+    <|im_end|> (151645) and <|endoftext|> (151643) among the stop-token ids
+    (the fix in build_vibethinker_3b.py — upstream declares only 151643), NO
+    start_token, and the embedder in its own section with every section under
+    2 GiB (the iOS single-section mmap ceiling). Needs `pip install
+    litert-lm-builder`.
+
+      python verify_vibethinker_3b.py model.litertlm --check-metadata
+
+  --math — the check that matters for this model: six GSM8K-style word
+    problems, greedy, scored on the final number after the chain of thought
+    (\\boxed{n} / "#### n" / last number). Also reports how many words each
+    answer took, which is why the bundle needs its 4096-token context and
+    callers need max_tokens >= 2048.
+
+      python verify_vibethinker_3b.py model.litertlm --math [--backend gpu]
+"""
+
+import argparse
+import io
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+# The veto on the 0.9-vs-0.11 question exists because the presence check alone
+# is one-sided: "0.11 is larger than 0.9" also contains "0.9" and would score
+# as correct. Require the right number AND the absence of the inverted claim.
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+
+# (label, problem, answer). Small GSM8K-shaped word problems with one integer answer.
+MATH = [
+    ("pens", "A shop sells pens at 3 dollars each. Maria buys 4 pens and pays with a "
+             "20-dollar bill. How much change does she get?", "8"),
+    ("train", "A train travels 60 miles per hour for 2 hours and then 40 miles per hour "
+              "for 3 hours. How many miles does it travel in total?", "240"),
+    ("apples", "Tom has 3 times as many apples as Jane. Together they have 48 apples. "
+               "How many apples does Tom have?", "36"),
+    ("tiles", "A rectangular floor is 12 feet by 9 feet. Tiles are 1 square foot each and "
+              "come in boxes of 10. How many boxes are needed to cover the floor?", "11"),
+    ("savings", "Ana saves 15 dollars a week. After 8 weeks she spends 40 dollars. "
+                "How much does she have left?", "80"),
+    ("chairs", "A hall has 14 rows of 25 chairs. 60 chairs are removed for a stage. "
+               "How many chairs remain?", "290"),
+]
+COT = ("\n\nSolve this step by step. After your reasoning, write the final answer on "
+       "its own line in the exact form:\n#### <number>")
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam.
+
+  The 5-gram trigger needs a corroborating diversity collapse: a model may
+  legitimately restate a quoted phrase a few times in a clean answer, while
+  real loops show heavy repetition AND cratered word diversity."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5:
+    return True
+  return False
+
+
+def run_one(litert_lm, model, prompt, backend, timeout):
+  """Runs one prompt through `litert-lm run`; the answer is exactly stdout."""
+  cmd = [litert_lm, "run", str(model), "--prompt", prompt,
+         "--backend", backend, "--temperature", "0", "--top-k", "1",
+         "--cache", "no"]
+  proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  return proc.stdout.strip()
+
+
+def strip_think(text):
+  """Drops <think>...</think>; a think block left open counts as no answer."""
+  if "<think>" in text and "</think>" not in text:
+    return ""
+  return re.sub(r"<think>.*?</think>", "", text, flags=re.S)
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      ans = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    body = strip_think(ans)
+    low = body.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not body.strip()) or degenerate(body)
+    results.append({"label": label, "question": q, "ok": ok,
+                    "degenerate": degen, "answer": ans})
+    shown = " ".join(body.split())[:90] if body.strip() else "(empty)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}  ({len(ans.split())} words incl. think)")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results,
+    }, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def read_metadata(model):
+  """Returns (LlmMetadata pbtext, [sections]) without unpacking the bundle."""
+  from litert_lm_builder import litertlm_peek  # pip install litert-lm-builder
+
+  buf = io.StringIO()
+  litertlm_peek.peek_litertlm_file(str(model), None, buf)
+  text = buf.getvalue()
+  m = re.search(r"start of LlmMetadata\n(.*?)>{4,} end of LlmMetadata", text, re.S)
+  pbtext = m.group(1) if m else ""
+  sections = []
+  for sm in re.finditer(
+      r"Section (\d+):\n(.*?)Begin Offset:\s*(\d+)\n\s*End Offset:\s*(\d+)\n"
+      r"\s*Data Type:\s*(\S+)", text, re.S):
+    items = sm.group(2)
+    mt = re.search(r"model_type, Value \(String\): (\S+)", items)
+    sections.append({"index": int(sm.group(1)), "type": sm.group(5),
+                     "model_type": mt.group(1) if mt else None,
+                     "bytes": int(sm.group(4)) - int(sm.group(3))})
+  return pbtext, sections
+
+
+def check_metadata(args):
+  pbtext, sections = read_metadata(args.model)
+  if not pbtext:
+    print("FAIL: no LlmMetadata section found")
+    return 1
+  checks = []
+
+  def check(name, ok, detail=""):
+    checks.append(ok)
+    print(f"  [{'v' if ok else 'X'}] {name}{(': ' + detail) if detail else ''}")
+
+  has_start = bool(re.search(r"^\s*start_token\s*\{", pbtext, re.M))
+  check("no start_token (no BOS on this tokenizer)", not has_start)
+
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", pbtext)}
+  check("<|im_end|> (151645) is a stop-token id (the eos fix)", 151645 in stop_ids,
+        f"stop ids {sorted(stop_ids)}")
+  check("<|endoftext|> (151643) is a stop-token id", 151643 in stop_ids)
+
+  def prefix(role):
+    m = re.search(role + r"\s*\{\s*prefix:\s*\"((?:[^\"\\]|\\.)*)\"", pbtext)
+    return m.group(1) if m else None
+  check("user prefix is bare ChatML", prefix("user") == r"<|im_start|>user\n",
+        repr(prefix("user")))
+  check("model prefix", prefix("model") == r"<|im_start|>assistant\n",
+        repr(prefix("model")))
+
+  types = [s["model_type"] for s in sections]
+  check("embedder in its own section", "tf_lite_embedder" in types, str(types))
+  big = [s for s in sections if s["bytes"] >= 2 * 1024 ** 3]
+  check("every section < 2 GiB (iOS mmap ceiling)", not big,
+        ", ".join(f"{s['type']}:{s['bytes'] / 1024 ** 3:.2f} GiB" for s in sections))
+
+  ok = all(checks)
+  print(f"\n  {'PASS' if ok else 'FAIL'}: {sum(checks)}/{len(checks)} metadata checks")
+  return 0 if ok else 1
+
+
+def extract_number(text):
+  """GSM8K-style: prefer '#### n', then \\boxed{n}, then the last number."""
+  t = strip_think(text).replace(",", "")
+  for pat in (r"####\s*\$?(-?\d+(?:\.\d+)?)", r"\\boxed\{\s*\$?(-?\d+(?:\.\d+)?)",
+              r"-?\d+(?:\.\d+)?"):
+    m = re.findall(pat, t)
+    if m:
+      v = m[-1]
+      return str(int(float(v))) if float(v) == int(float(v)) else v
+  return None
+
+
+def math_gate(args):
+  rows = []
+  for label, problem, answer in MATH:
+    try:
+      out = run_one(args.litert_lm, args.model, problem + COT, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    got = extract_number(out)
+    ok = got == answer
+    words = len(out.split())
+    think = re.search(r"<think>(.*?)</think>", out, re.S)
+    rows.append({"label": label, "ok": ok, "expected": answer, "got": got,
+                 "words": words, "answer": out})
+    print(f"  [{'v' if ok else '.'}] {label:9s} expected {answer:>4s} got {str(got):>6s}"
+          f"  {words:5d} words"
+          f"{'' if think else '  (no closed think block)'}")
+  score = sum(r["ok"] for r in rows)
+  print(f"\n  correct: {score}/{len(MATH)}   words per answer: "
+        f"{min(r['words'] for r in rows)}-{max(r['words'] for r in rows)}")
+  print("  This model reasons before it answers — give it max_tokens >= 2048.")
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": len(MATH), "rows": rows}, indent=2,
+        ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if score >= args.min_math else 1
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / metadata / math checks for VibeThinker-3B")
+  ap.add_argument("model", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--min-math", type=int, default=5)
+  ap.add_argument("--timeout", type=int, default=1200,
+                  help="seconds per question (the model reasons at length "
+                       "and engine init is paid every run)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--json", help="write a JSON report here (gate / math modes)")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--math", action="store_true")
+  args = ap.parse_args()
+
+  if not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  if args.math:
+    return math_gate(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Adds four dense-LLM conversion recipes in the `models/<family>/<model>/converted` layout — the same shape as the Granite-4.1-3B recipe (#280): a build script that goes HF checkpoint → `.litertlm` through the plain litert-torch export path on the released stack (litert-torch 0.9.3 / litert-converter 0.3.1 / ai-edge-quantizer 0.8.0 / litert-lm-builder 0.16.0), a verify script with three modes (8-question quality gate through the `litert-lm` CLI, `--check-metadata`, and one model-specific check), and a README with the measurements. All four are published at `litert-community`; each recipe documents one thing that looks like a model or quantization problem and is not.

| recipe | source | build | the finding |
|---|---|---|---|
| `models/smollm/smollm3_3b` | [HuggingFaceTB/SmolLM3-3B](https://huggingface.co/HuggingFaceTB/SmolLM3-3B) (Apache-2.0) | int4 blockwise-32 OCTAV + int8 externalized embedding, 2.00 GB | SmolLM3's `/think` system prompt sits in an `if messages[0]['role'] != 'system'` branch, which the structured-template extraction never enters — the bundle is bare ChatML and the model answers in direct mode by default. `--think-ab` shows the same question answered directly (empty think block → `42.`) and, with the `/think` system prompt supplied by the caller, with 120 words of reasoning first. NoPE (rotary off every 4th layer) is not a converter blocker. |
| `models/vibethinker/vibethinker_3b` | [WeiboAI/VibeThinker-3B](https://huggingface.co/WeiboAI/VibeThinker-3B) (MIT, Qwen2 math/reasoning) | int4 blockwise-**32** OCTAV + int8 externalized embedding, 2.06 GB | Two facts baked in: the vendor `generation_config` declares only `<|endoftext|>` as EOS, so under ChatML the runtime has no id-level stop for `<|im_end|>` — the build adds it; and block size is a per-model measurement — block-128 int4 collapses this model's GSM8K from 90.0% to 64.0% (bf16 97.0%), so only block-32 is offered. `--math` runs six word problems through the chain of thought (6/6, 294–582 words each). |
| `models/ministral/ministral_3_3b_instruct_2512` | [mistralai/Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512) (Apache-2.0, text decoder only) | int4 blockwise-32 OCTAV + int8 externalized embedding, 2.34 GB | An extractor drops the Pixtral tower (the plain repo is FP8; the BF16 sibling is the source). The template must be Mistral's `[INST]` — tekken has no `<|im_end|>`, so a ChatML export answers and then runs away. The un-externalized build is one 2.55 GiB section, over the iOS ~2 GiB single-section mmap ceiling; externalized it is 1.80 GiB and loads on iPhone. And its `start_token` (`<s>`) is *correct* — bos ≠ eos — the counter-example to the granite trap; `--bos-ab` shows it on the bf16 decoder. |
| `models/qwen/qwen2_5_coder_1_5b_instruct` | [Qwen/Qwen2.5-Coder-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct) (Apache-2.0) | int4 blockwise-32 OCTAV + int8 externalized embedding, 6-signature prefill ladder, 1.12 GB | A tied embedding plus an int4-linears / int8-embedding recipe made the quantizer store the 151936×1536 table once per signature — seven copies, 1.63 GB, 65% of a 2.53 GB file, no error anywhere; `externalize_embedder=True` brings it to 1.12 GB (0.72 bytes/param) and `--check-metadata` asserts the ratio. The vendor's default system prompt is folded into the user prefix so the default path renders byte-identical to upstream. `--code-gate` executes six generated functions against assertions (6/6). |

## Verification

All numbers below are measured, on the published bundles unless stated; the READMEs carry the details and the qualifiers.

- **Quality gates re-run today** with the verify scripts in this PR (litert-lm 0.16.0, Mac M4 Max): SmolLM3-3B CPU 8/8 / GPU 8/8; VibeThinker-3B CPU 8/8 / GPU 7/8 (rhyme line) + math 6/6; Ministral-3-3B CPU 8/8 / GPU 8/8; Qwen2.5-Coder-1.5B CPU 8/8 / GPU 8/8 + code gate 6/6. `--check-metadata` passes on all four; `--think-ab` and `--bos-ab` reproduce the README tables.
- **GSM8K** (n=100, greedy, 0-shot CoT, bf16 → int4): SmolLM3 81.0 → 81.0; VibeThinker 97.0 → 90.0 (block-128: 64.0); Ministral 89.0 → 85.0.
- **Pixel 8a** (Tensor G3, Mali-G715, 8 GB), GPU/OpenCL, `litert_lm_main` v0.16.0: all four fully delegated (zero rejected ops), correct answers. Decode 7.7 / 8.1 / 6.8 tok/s for the three 3B bundles and 12.0 tok/s for the 1.5B (CPU 12.6 — a phone's GPU buys prefill and TTFT, 0.54 s vs 2.44 s, not tokens per second). The 3B bundles run on this 8 GB phone's GPU when the runtime is driven directly; the Gallery app's import-time accelerator allowlist is a separate matter and the READMEs keep the two apart.
- **iPhone 17 Pro** (Metal): SmolLM3 decode 22.5 tok/s, TTFT 0.63 s, footprint 1.24 GB; Ministral decode 14–18 tok/s, TTFT 0.40 s, 1.45 GB; Qwen2.5-Coder 7/8 at the bundle's default 4096 context, init 6.27 s; VibeThinker loads and answers (no timing taken).
- **Mac M4 Max** (Metal): decode 93.2 / 94.1 / 95.4 tok/s for the 3B bundles, 137.8 for the 1.5B.
- **The build scripts were run end to end on the pinned stack** for all four models. Qwen2.5-Coder rebuilds byte-identical to the published bundle from the tokenizer section onward (only the header uuid/timestamp differ). SmolLM3, VibeThinker and Ministral come out 16–32 KB from their published files (the published ones were built on an earlier litert-torch; the difference is metadata) and pass the same metadata checks and gates with the same answers.

## CI note

This PR only adds files under `models/` (Python scripts and Markdown). `main`'s Build-and-Test-Linux job is currently red for an unrelated reason — upstream LiteRT commit e1502e07 removed the `litert_api_with_dynamic_runtime` target the C++ samples reference — so that check will stay red here until the fix lands; the fix is open as #286.

