### PR TITLE
Add SAM 2.1 Hiera-Tiny video-tracking conversion recipe

### DIFF
--- a/models/sam2/sam2_hiera_tiny_video/README.md
+++ b/models/sam2/sam2_hiera_tiny_video/README.md
@@ -1,0 +1,3 @@
+# SAM 2.1 Hiera-Tiny (video tracking)
+
+Model recipe, conversion scripts, and verification for the SAM 2.1 Hiera-Tiny video-tracking path on LiteRT.

--- a/models/sam2/sam2_hiera_tiny_video/converted/.gitignore
+++ b/models/sam2/sam2_hiera_tiny_video/converted/.gitignore
@@ -1,0 +1,5 @@
+out/
+__pycache__/
+*.tflite
+*.bin
+*.npz

--- a/models/sam2/sam2_hiera_tiny_video/converted/README.md
+++ b/models/sam2/sam2_hiera_tiny_video/converted/README.md
@@ -1,0 +1,46 @@
+# SAM 2.1 Hiera-Tiny Video Conversion
+
+These scripts convert the video-tracking path of [facebook/sam2.1-hiera-tiny](https://huggingface.co/facebook/sam2.1-hiera-tiny) (Apache-2.0) into four fixed-shape LiteRT graphs that run on the CompiledModel GPU delegate (ML Drift on Android, Metal on iOS), and numerically verify the assembled tracking loop against the `transformers` PyTorch reference.
+
+SAM 2 tracks an object across a video with a memory bank: the image encoder runs once per frame, memory attention conditions the current frame on features remembered from past frames, the mask decoder produces the mask, and the memory encoder writes the new frame back into the bank. Only the tensor math is exported; the rolling bank and the per-frame orchestration stay on the host (`verify_video.py` carries the numpy reference of that loop, which a Kotlin or Swift app mirrors). The still-image path (encoder + prompt mask decoder) already ships as the interactive-segmentation sample; this recipe adds the parts unique to video — memory attention, the memory encoder, object pointers, and the prompt-conditioned video mask decoder.
+
+## Environments
+
+One Python environment (the "convert env") runs everything: `litert-torch`, `torch`, `transformers>=5.13` (which has `Sam2VideoModel` natively), `ai-edge-litert`, `ai-edge-quantizer`, `numpy`, and `pillow`. The verifier loads the exported graphs through the `ai_edge_litert` CompiledModel Python API and the reference through `transformers`, so no second environment is needed.
+
+## Pipeline
+
+Run from this directory. `export_video.py` writes the graphs and the host constants to `$SAM2_OUT` (default `out/`); `verify_video.py` reads them back and checks the whole tracking loop against PyTorch.
+
+| # | Script | What it does |
+|---|---|---|
+| 1 | `export_video.py` | Loads `Sam2VideoModel`, installs the GPU-clean Hiera rewrites from `hiera_gpu_clean.py`, and exports the four graphs (`encode`, `memcond7` and `memcond2`, `decode`, `memorize`) as fp16 `.tflite` plus the host constants (`sam2v_prompt.bin`, `sam2v_track_sparse.bin`, `sam2v_mtpe.bin`, `sam2v_no_obj_ptr.bin`, `sam2v_tpos_proj.bin`). Each graph is op-checked from its flatbuffer — every one reports `GPU_BAD=NONE >4D=0`. |
+| 2 | `verify_video.py` | Runs a synthetic clip (a drifting disk, one click on frame 0) through both the HF streaming reference and the exported graphs driven by the host loop, and reports the per-frame mask IoU / correlation. `--nmm` selects the bank sizes (default `7,2`) and `--frames` the clip length. |
+
+The two graph shapes worth restating (both size-independent flat float32 I/O):
+
+| Graph | Size (fp16) | In → Out |
+|---|---|---|
+| `encode` | 80 MB | image `[1,3,1024,1024]` → `pix_raw \| hi0 \| hi1` |
+| `memcond{7,2}` | 26 MB | `pix_raw \| memory bank \| temporal pos \| pointers \| key mask` → `pix_feat` |
+| `decode` | 18 MB | `pix_feat \| hi0 \| hi1 \| sparse \| nomem` → `masks \| iou \| object pointers \| object score` |
+| `memorize` | 3 MB | `pix_raw \| mask_for_mem \| occ` → spatial memory `[4096, 64]` |
+
+## GPU-clean rewrites
+
+The still-image rewrites are reused from `hiera_gpu_clean.py`: the windowed positional embedding is baked to a constant (removing the bicubic `GATHER_ND` and the tiled `BROADCAST_TO`), window partition/unpartition and the multi-scale attention are re-expressed with ≤ 4-D tensors, and `ConvTranspose2d` becomes a zero-stuffed conv. The one rewrite unique to the video path is the **memory attention**: SAM 2's `Sam2VideoRoPEAttention` runs with the batch dimension collapsed (`q/k/v` shaped `[heads, N, d]`, rank 3), and the ML Drift delegate silently mis-computes that form. Re-authoring it batch-first (`[1, heads, N, d]`, rank 4) is numerically identical on the host and correct on the GPU. The interleaved 2-D RoPE is baked into a half-split (`rotate_half`) form by permuting the q/k projection rows, and the memory-encoder sine position encoding is baked constant.
+
+## Verification results
+
+- Assembled loop vs the HF PyTorch reference (10-frame clip, both the 7-slot and 2-slot banks): min mask-IoU **0.9999**, correlation **1.0**. The short-clip check bundled here (`--frames 5`) is exact: min IoU 1.0000, min corr 1.00000, object-score match to 0.01.
+- Memory attention: the rank-4 export is exact under fp32 GPU compute (correlation **1.0**), confirming the rank-3 miscompute is avoided rather than merely masked. At fp16 the 7-slot bank sits at correlation 0.976 on device (pure accumulation over the 7 × 4096 memory keys), and that error does not reach the mask — the chained tracked-frame mask IoU is **0.9986**.
+- Every graph is fully GPU-resident with no CPU fallback. Pixel 8a (Mali, ML Drift): `encode` 828/828, `memcond` 480/480, `decode` 462/462, `memorize` 145/145 nodes, one partition each. iPhone 17 Pro (Metal): all `fullyGPU`.
+
+## Device performance (per tracked frame: encode + memcond + decode + memorize)
+
+| Host | 2-slot bank | 7-slot bank |
+|---|---|---|
+| iPhone 17 Pro (A19 Pro, Metal) | ~471 ms | ~751 ms |
+| Pixel 8a (Mali, ML Drift) | ~1.0 s | ~1.5 s |
+
+The memory attention dominates and scales with the bank size (the spatial cross-attention runs over N × 4096 memory tokens); the encoder is the second cost. The still-image path is much cheaper because it skips memory attention entirely.

--- a/models/sam2/sam2_hiera_tiny_video/converted/export_video.py
+++ b/models/sam2/sam2_hiera_tiny_video/converted/export_video.py
@@ -1,0 +1,513 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Exports the SAM 2.1 Hiera-Tiny VIDEO path to LiteRT CompiledModel GPU.
+
+The tracking loop of ``facebook/sam2.1-hiera-tiny`` becomes four stateless,
+fixed-shape per-frame graphs; the rolling memory bank and the orchestration run
+host-side (see verify_video.py for the numpy reference of that loop). Each graph
+uses a single flat float32 input and output so CompiledModel never has to
+disambiguate tensor order.
+
+  encode      image (1,3,1024,1024) -> [pix_raw | hi0 | hi1]
+              pix_raw is the Hiera top level WITHOUT the no-memory embedding
+              (the image path bakes it in; the video path needs the raw feature
+              for both memory attention and the memory encoder).
+  memcond{N}  [pix_raw | memory bank | temporal pos | pointers | key mask]
+              -> pix_feat.  Memory attention over a FIXED bank of N spatial
+              slots (N x 4096 tokens) + 16 object pointers (x4 tokens); unused
+              slots are masked, which equals HF's variable-length bank exactly.
+              Exported for N in {7, 2} (SAM2 default and a 2-slot variant).
+  decode      [pix_feat | hi0 | hi1 | sparse | nomem] -> masks | iou |
+              object pointers | object score.  nomem=1 adds the no-memory
+              embedding for the initial conditioning frame; the host picks the
+              best-IoU mask among tokens 1..3.
+  memorize    [pix_raw | mask_for_mem | occ] -> spatial memory (4096 x 64).
+
+The memory attention is re-authored batch-first (rank 4) so it avoids the
+ML Drift rank-3 batched-attention miscompute; verify_video.py confirms the
+export is exact under fp32 GPU compute.
+
+Usage (convert env: litert-torch, transformers>=5.13, ai-edge-litert,
+ai-edge-quantizer):
+    SAM2_OUT=out python export_video.py
+"""
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+import transformers.models.sam2_video.modeling_sam2_video as MV
+from transformers import Sam2VideoModel
+
+import hiera_gpu_clean as hiera
+
+hiera.stub_scipy_native_leaves()
+hiera.install_hiera_patches()
+
+CKPT = os.environ.get("SAM2_CKPT", "facebook/sam2.1-hiera-tiny")
+OUT = os.path.abspath(os.environ.get("SAM2_OUT", "out"))
+NMM_LIST = [int(x) for x in os.environ.get("SAM2_NMM", "7,2").split(",")]
+
+IE, F0, F1 = hiera.IE, hiera.F0, hiera.F1
+HW = 4096            # 64x64 top-level tokens
+MEMCH = 64           # memory channel dim
+HD = 256             # memory-attention hidden size (single head)
+NPTR_FRAMES = 16     # object-pointer frames kept
+PTR_SPLIT = 4        # tokens per pointer (256 / 64)
+NPTR = NPTR_FRAMES * PTR_SPLIT
+DEC_IN = IE + F0 + F1 + 512 + 1
+DEC_OUT = 4 * 65536 + 4 + 4 * 256 + 1
+MEM_IN = 2 * IE + 1
+MEM_OUT = HW * MEMCH
+
+# Head-dim permutation turning SAM2's pairwise-interleaved RoPE into the
+# half-split (rotate_half) form: [even dims | odd dims]. Applied to the q/k
+# projection rows so the rotated dot product is unchanged.
+PERM = torch.tensor(
+    [2 * i for i in range(HD // 2)] + [2 * i + 1 for i in range(HD // 2)])
+
+
+def rotate_half(x):
+    """Rotates the last dim by halves: [-second_half | first_half].
+
+    Args:
+        x: Tensor whose last dim is even.
+
+    Returns:
+        The half-rotated tensor.
+    """
+    d = x.shape[-1] // 2
+    return torch.cat([-x[..., d:], x[..., :d]], dim=-1)
+
+
+def deinterleave(c):
+    """Turns interleaved cos/sin (L, 256) into a 4-D [c_i | c_i] broadcast.
+
+    Args:
+        c: Rotary table (L, 256) with c[2i] == c[2i+1].
+
+    Returns:
+        A (1, 1, L, 256) tensor holding the de-interleaved half twice.
+    """
+    half = c[..., 0::2]
+    return torch.cat([half, half], -1)[None, None]
+
+
+class MemoryAttention4D(nn.Module):
+    """Batch-first (<= 4-D) re-authoring of Sam2VideoMemoryAttention.
+
+    Query = current pix_raw (4096 tokens); memory = N spatial slots x 4096
+    tokens + NPTR pointer tokens, all 64-channel. Keeping the batch dim dodges
+    the ML Drift rank-3 miscompute.
+    """
+
+    def __init__(self, ma, nmm, vision_pos, mem_pos):
+        """Caches the constant rotary, vision and memory position tables.
+
+        Args:
+            ma: The Sam2VideoMemoryAttention module (weights already permuted).
+            nmm: Number of spatial memory slots (bank size).
+            vision_pos: Top-level vision sine position embedding (1,256,64,64).
+            mem_pos: Spatial memory position encoding, token-major (1,4096,64).
+        """
+        super().__init__()
+        self.layers = ma.layers
+        self.layer_norm = ma.layer_norm
+        self.nmm = nmm
+        cos, sin = ma.rotary_emb()
+        self.register_buffer("cos", deinterleave(cos.detach().clone()))
+        self.register_buffer("sin", deinterleave(sin.detach().clone()))
+        vpos = (0.1 * vision_pos).reshape(1, HD, HW).transpose(1, 2)
+        self.register_buffer("vpos", vpos.reshape(1, 1, HW, HD).contiguous())
+        self.register_buffer(
+            "mpos", mem_pos.reshape(1, 1, HW, MEMCH).contiguous())
+
+    def rope(self, x):
+        """Applies the cached rotary embedding to a query/key tensor.
+
+        Args:
+            x: Tensor (1, 1, L, 256).
+
+        Returns:
+            The rotary-embedded tensor.
+        """
+        return x * self.cos + rotate_half(x) * self.sin
+
+    def forward(self, pix_raw, mem, tpe, ptr_tok, ptr_pos, key_mask):
+        """Runs the memory attention over the fixed bank.
+
+        Args:
+            pix_raw: Current-frame features (1, 256, 64, 64).
+            mem: Spatial memory (N*4096*64,) flat.
+            tpe: Per-slot temporal position embeddings (N*64,) flat.
+            ptr_tok: Object-pointer tokens (NPTR*64,) flat.
+            ptr_pos: Object-pointer position embeddings (NPTR*64,) flat.
+            key_mask: Additive mask over N*4096 + NPTR keys.
+
+        Returns:
+            The memory-conditioned features (1, IE) flat.
+        """
+        n = self.nmm
+        x = pix_raw.reshape(1, HD, HW).transpose(1, 2)
+        x = x.reshape(1, 1, HW, HD) + self.vpos
+        spatial = mem.reshape(1, n, HW, MEMCH)
+        spatial_pos = self.mpos + tpe.reshape(1, n, 1, MEMCH)
+        memory = torch.cat([
+            spatial.reshape(1, 1, n * HW, MEMCH),
+            ptr_tok.reshape(1, 1, NPTR, MEMCH),
+        ], 2)
+        mem_pos = torch.cat([
+            spatial_pos.reshape(1, 1, n * HW, MEMCH),
+            ptr_pos.reshape(1, 1, NPTR, MEMCH),
+        ], 2)
+        keys_in = memory + mem_pos
+        km = key_mask.reshape(1, 1, 1, n * HW + NPTR)
+        for layer in self.layers:
+            h = layer.layer_norm1(x)
+            sa = layer.self_attn
+            q = self.rope(sa.q_proj(h))
+            k = self.rope(sa.k_proj(h))
+            v = sa.v_proj(h)
+            a = torch.softmax((q @ k.transpose(-1, -2)) * sa.scaling, dim=-1)
+            x = x + sa.o_proj(a @ v)
+            h = layer.layer_norm2(x)
+            ca = layer.cross_attn_image
+            q = self.rope(ca.q_proj(h))
+            k = ca.k_proj(keys_in)
+            k_sp = k[..., :n * HW, :].reshape(1, n, HW, HD)
+            k_sp = k_sp * self.cos + rotate_half(k_sp) * self.sin
+            k_sp = k_sp.reshape(1, 1, n * HW, HD)
+            k = torch.cat([k_sp, k[..., n * HW:, :]], 2)
+            v = ca.v_proj(memory)
+            aw = (q @ k.transpose(-1, -2)) * ca.scaling + km
+            a = torch.softmax(aw, dim=-1)
+            x = x + ca.o_proj(a @ v)
+            h = layer.layer_norm3(x)
+            x = x + layer.linear2(layer.activation(layer.linear1(h)))
+        x = self.layer_norm(x)
+        return x.reshape(1, HW, HD).transpose(1, 2).reshape(1, IE)
+
+
+def _vdec4d(self, image_embeddings, image_positional_embeddings,
+            sparse_prompt_embeddings, dense_prompt_embeddings,
+            multimask_output, high_resolution_features,
+            attention_similarity=None, target_embedding=None, **kwargs):
+    """Sam2VideoMaskDecoder.forward kept <= 4-D, returning all 4 mask tokens.
+
+    Args:
+        self: The Sam2VideoMaskDecoder module.
+        image_embeddings: pix_feat (1, 256, 64, 64).
+        image_positional_embeddings: Image-wide sine embedding.
+        sparse_prompt_embeddings: Sparse prompt tokens.
+        dense_prompt_embeddings: Dense (no-mask) prompt.
+        multimask_output: Unused; all mask tokens are emitted.
+        high_resolution_features: [feat_s0, feat_s1].
+        attention_similarity: Optional PerSAM term.
+        target_embedding: Optional PerSAM term.
+        **kwargs: Forwarded to the two-way transformer.
+
+    Returns:
+        A tuple (masks, iou, mask_tokens, object_score).
+    """
+    bs, nc, h, w = image_embeddings.shape
+    pb = sparse_prompt_embeddings.shape[1]
+    output_tokens = torch.cat([
+        self.obj_score_token.weight, self.iou_token.weight,
+        self.mask_tokens.weight,
+    ], 0).repeat(bs, pb, 1, 1)
+    point = torch.cat((output_tokens, sparse_prompt_embeddings), 2)
+    point = point.to(self.iou_token.weight.dtype)
+    image_emb = (image_embeddings + dense_prompt_embeddings)
+    image_emb = image_emb.repeat_interleave(pb, 0)
+    image_pos = image_positional_embeddings.repeat_interleave(pb, 0)
+    point, image_emb = self.transformer(
+        point_embeddings=point, image_embeddings=image_emb,
+        image_positional_embeddings=image_pos,
+        attention_similarity=attention_similarity,
+        target_embedding=target_embedding, **kwargs)
+    iou_token_out = point[:, :, 1, :]
+    mask_tokens_out = point[:, :, 2:(2 + self.num_mask_tokens), :]
+    image_emb = image_emb.transpose(2, 3).view(bs * pb, nc, h, w)
+    feat_s0, feat_s1 = high_resolution_features
+    feat_s0 = feat_s0.repeat_interleave(pb, 0)
+    feat_s1 = feat_s1.repeat_interleave(pb, 0)
+    upscaled = self.activation(
+        self.upscale_layer_norm(self.upscale_conv1(image_emb) + feat_s1))
+    upscaled = self.activation(self.upscale_conv2(upscaled) + feat_s0)
+    hyper = torch.stack([
+        self.output_hypernetworks_mlps[i](mask_tokens_out[:, :, i, :])
+        for i in range(self.num_mask_tokens)
+    ], 2)
+    _, nc2, h2, w2 = upscaled.shape
+    batch = bs * pb
+    masks = (hyper.view(batch, self.num_mask_tokens, nc2)
+             @ upscaled.view(batch, nc2, h2 * w2))
+    masks = masks.view(batch, self.num_mask_tokens, h2, w2)
+    iou = self.iou_prediction_head(iou_token_out)
+    obj = self.pred_obj_score_head(point[:, :, 0, :])
+    return masks, iou, mask_tokens_out, obj
+
+
+MV.Sam2VideoMaskDecoder.forward = _vdec4d
+
+
+class ConstPos(nn.Module):
+    """Returns a constant position encoding regardless of the input shape."""
+
+    def __init__(self, const):
+        """Stores the constant tensor.
+
+        Args:
+            const: The precomputed position encoding to return.
+        """
+        super().__init__()
+        self.register_buffer("c", const)
+
+    def forward(self, *args, **kwargs):
+        """Returns the stored constant."""
+        return self.c
+
+
+def permute_rope_projections(model) -> None:
+    """Bakes PERM into every memory-attention q/k projection, once.
+
+    Args:
+        model: The Sam2VideoModel whose weights are permuted in place.
+    """
+    assert not getattr(model, "_rope_permuted", False)
+    for layer in model.memory_attention.layers:
+        for attn in (layer.self_attn, layer.cross_attn_image):
+            for proj in (attn.q_proj, attn.k_proj):
+                proj.weight.data = proj.weight.data[PERM].contiguous()
+                proj.bias.data = proj.bias.data[PERM].contiguous()
+    model._rope_permuted = True
+
+
+def memcond_in_size(nmm):
+    """Returns the flat memcond input length for a bank of ``nmm`` slots.
+
+    Args:
+        nmm: Number of spatial memory slots.
+
+    Returns:
+        The total float count of the memcond input.
+    """
+    return (IE + nmm * HW * MEMCH + nmm * MEMCH + 2 * NPTR * MEMCH
+            + nmm * HW + NPTR)
+
+
+def build(model):
+    """Builds the four flat-IO graph modules over one loaded model.
+
+    Args:
+        model: The Sam2VideoModel (patched, weights permuted).
+
+    Returns:
+        A tuple of module classes (Encode, MemCond, Decode, Memorize).
+    """
+    permute_rope_projections(model)
+    md = model.mask_decoder
+    md.upscale_conv1 = hiera.ZeroStuffConvT(md.upscale_conv1, 64)
+    md.upscale_conv2 = hiera.ZeroStuffConvT(md.upscale_conv2, 128)
+    with torch.no_grad():
+        ve = model.vision_encoder(
+            torch.randn(1, 3, 1024, 1024), return_dict=True)
+        vision_pos = ve.fpn_position_encoding[-1].detach().clone()
+        mem_pos = model.memory_encoder.position_encoding(
+            (1, MEMCH, 64, 64), torch.device("cpu"), torch.float32)
+        mem_pos = mem_pos.detach().clone()
+        mem_pos_tok = mem_pos.reshape(1, MEMCH, HW).transpose(1, 2)
+        mem_pos_tok = mem_pos_tok.contiguous()
+        img_pos = model.get_image_wide_positional_embeddings().detach().clone()
+    model.memory_encoder.position_encoding = ConstPos(mem_pos)
+
+    class Encode(nn.Module):
+        """Hiera encoder -> [pix_raw | hi0 | hi1] flat."""
+
+        def __init__(self):
+            super().__init__()
+            self.ve = model.vision_encoder
+            self.cs0, self.cs1 = md.conv_s0, md.conv_s1
+
+        def forward(self, x):
+            fpn = self.ve(x, return_dict=True).fpn_hidden_states
+            return torch.cat([
+                fpn[2].reshape(-1),
+                self.cs0(fpn[0]).reshape(-1),
+                self.cs1(fpn[1]).reshape(-1),
+            ])[None]
+
+    class MemCond(nn.Module):
+        """Memory attention over a fixed bank -> pix_feat flat."""
+
+        def __init__(self, nmm):
+            super().__init__()
+            self.nmm = nmm
+            self.attn = MemoryAttention4D(
+                model.memory_attention, nmm, vision_pos, mem_pos_tok)
+
+        def forward(self, flat):
+            n = self.nmm
+            f = flat[0]
+            o = 0
+            pix = f[o:o + IE].reshape(1, HD, 64, 64)
+            o += IE
+            mem = f[o:o + n * HW * MEMCH]
+            o += n * HW * MEMCH
+            tpe = f[o:o + n * MEMCH]
+            o += n * MEMCH
+            ptr = f[o:o + NPTR * MEMCH]
+            o += NPTR * MEMCH
+            ppos = f[o:o + NPTR * MEMCH]
+            o += NPTR * MEMCH
+            km = f[o:o + n * HW + NPTR]
+            return self.attn(pix, mem, tpe, ptr, ppos, km)
+
+    class Decode(nn.Module):
+        """Prompt-conditioned video mask decoder + object-pointer proj."""
+
+        def __init__(self):
+            super().__init__()
+            self.d = md
+            self.optr = model.object_pointer_proj
+            self.register_buffer("ipe", img_pos)
+            dense = model.prompt_encoder.no_mask_embed.weight
+            dense = dense.reshape(1, -1, 1, 1).expand(1, 256, 64, 64)
+            self.register_buffer("dense", dense.contiguous())
+            no_mem = model.no_memory_embedding.detach()
+            self.register_buffer("no_mem", no_mem.reshape(1, HD, 1, 1))
+
+        def forward(self, flat):
+            f = flat[0]
+            pix = f[:IE].reshape(1, HD, 64, 64)
+            h0 = f[IE:IE + F0].reshape(1, 32, 256, 256)
+            h1 = f[IE + F0:IE + F0 + F1].reshape(1, 64, 128, 128)
+            sparse = f[IE + F0 + F1:IE + F0 + F1 + 512]
+            sparse = sparse.reshape(1, 1, 2, 256)
+            nomem = f[IE + F0 + F1 + 512:].reshape(1, 1, 1, 1)
+            pix = pix + nomem * self.no_mem
+            masks, iou, tok, obj = self.d(
+                pix, self.ipe, sparse, self.dense, multimask_output=True,
+                high_resolution_features=[h0, h1])
+            ptr = self.optr(tok)
+            return torch.cat([
+                masks[0].reshape(-1), iou[0].reshape(-1),
+                ptr[0].reshape(-1), obj[0].reshape(-1),
+            ])[None]
+
+    class Memorize(nn.Module):
+        """Memory encoder -> spatial memory (4096 x 64) flat."""
+
+        def __init__(self):
+            super().__init__()
+            self.e = model.memory_encoder
+            occ = model.occlusion_spatial_embedding_parameter.detach()
+            self.register_buffer("occ", occ.reshape(1, MEMCH))
+
+        def forward(self, flat):
+            f = flat[0]
+            pix = f[:IE].reshape(1, HD, 64, 64)
+            mfm = f[IE:2 * IE].reshape(1, 1, 1024, 1024)
+            occ = f[2 * IE:].reshape(1, 1)
+            mem, _ = self.e(pix, mfm)
+            mem = mem.reshape(1, MEMCH, HW).transpose(1, 2)
+            mem = mem + occ * self.occ
+            return mem.reshape(1, HW * MEMCH)
+
+    return Encode, MemCond, Decode, Memorize
+
+
+def save_constants(model) -> None:
+    """Writes the host-side constants (prompt, temporal PE, projections).
+
+    Args:
+        model: The loaded Sam2VideoModel.
+    """
+    pe = model.prompt_encoder
+    gauss = pe.shared_embedding.positional_embedding
+    prompt = np.concatenate([
+        gauss.detach().numpy().flatten(),
+        pe.point_embed.weight[1].detach().numpy(),
+        pe.point_embed.weight[0].detach().numpy(),
+        pe.not_a_point_embed.weight[0].detach().numpy(),
+    ]).astype(np.float32)
+    prompt.tofile(f"{OUT}/sam2v_prompt.bin")
+    with torch.no_grad():
+        track, _ = pe(
+            input_points=torch.zeros(1, 1, 1, 2),
+            input_labels=-torch.ones(1, 1, 1, dtype=torch.int32),
+            input_boxes=None, input_masks=None)
+    track.numpy().astype(np.float32).tofile(f"{OUT}/sam2v_track_sparse.bin")
+    mtpe = model.memory_temporal_positional_encoding.detach().numpy()
+    mtpe.astype(np.float32).tofile(f"{OUT}/sam2v_mtpe.bin")
+    no_obj = model.no_object_pointer.detach().numpy()
+    no_obj.astype(np.float32).tofile(f"{OUT}/sam2v_no_obj_ptr.bin")
+    lin = model.temporal_positional_encoding_projection_layer
+    proj = np.concatenate([
+        lin.weight.detach().numpy().flatten(),
+        lin.bias.detach().numpy(),
+    ]).astype(np.float32)
+    proj.tofile(f"{OUT}/sam2v_tpos_proj.bin")
+    print("constants: prompt track_sparse mtpe no_obj_ptr tpos_proj")
+
+
+def convert(module, example, name) -> None:
+    """Traces, exports, op-checks and fp16-quantizes one graph.
+
+    Args:
+        module: The nn.Module to export.
+        example: A tuple of example inputs for tracing.
+        name: The output basename (no extension).
+    """
+    import litert_torch
+    fp32 = f"{OUT}/{name}_fp32.tflite"
+    with torch.no_grad():
+        module(*example)
+    args = tuple(t.detach().clone() for t in example)
+    litert_torch.convert(module, args).export(fp32)
+    hiera.opcheck(fp32, name)
+    size = hiera.fp16(fp32, f"{OUT}/{name}.tflite")
+    print(f"{name} fp16 {size:.1f} MB")
+    os.remove(fp32)
+
+
+def main() -> None:
+    """Exports every graph plus the host constants."""
+    os.makedirs(OUT, exist_ok=True)
+    model = Sam2VideoModel.from_pretrained(CKPT).eval()
+    print("baked pos_embed:", hiera.bake_pos_embed(model))
+    encode_cls, memcond_cls, decode_cls, memorize_cls = build(model)
+    save_constants(model)
+    which = os.environ.get(
+        "SAM2_GRAPHS", "encode,memcond,decode,memorize").split(",")
+    if "encode" in which:
+        convert(
+            encode_cls().eval(),
+            (torch.randn(1, 3, 1024, 1024),), "sam2v_encode")
+    if "memcond" in which:
+        for n in NMM_LIST:
+            convert(
+                memcond_cls(n).eval(),
+                (torch.randn(1, memcond_in_size(n)),), f"sam2v_memcond{n}")
+    if "decode" in which:
+        convert(
+            decode_cls().eval(), (torch.randn(1, DEC_IN),), "sam2v_decode")
+    if "memorize" in which:
+        convert(
+            memorize_cls().eval(), (torch.randn(1, MEM_IN),), "sam2v_memorize")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/sam2/sam2_hiera_tiny_video/converted/hiera_gpu_clean.py
+++ b/models/sam2/sam2_hiera_tiny_video/converted/hiera_gpu_clean.py
@@ -1,0 +1,362 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Shared GPU-clean rewrites for the SAM 2.1 Hiera-Tiny image path.
+
+The video-path exporter (export_video.py) reuses the same image encoder and
+the same mask-decoder upsampling, so the rewrites that make them compile on the
+LiteRT CompiledModel GPU (ML Drift) delegate live here and are installed by
+calling ``install_hiera_patches()`` before the model is traced.
+
+Every rewrite is numerically identical to the upstream forward (parity holds at
+corr 1.0 in the verifier); they exist only because ML Drift rejects tensors of
+rank > 4 and a few ops. The rewrites are: bake the windowed positional
+embedding (constant for a fixed 1024x1024 input, so the bicubic GATHER_ND and
+the tiled BROADCAST_TO disappear), re-express window partition / unpartition
+with <= 4-D tensors, replace the fused 5-D qkv reshape with a channel-wise
+q/k/v slice, and swap ConvTranspose2d for a zero-stuffed conv (TRANSPOSE_CONV
+is unsupported).
+"""
+import sys
+import types
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import transformers.models.sam2.modeling_sam2 as M
+from ai_edge_litert import schema_py_generated as schema
+
+# Flat-IO element counts, independent of the backbone size: image embedding
+# (256x64x64), high-res feature s0 (32x256x256), high-res feature s1
+# (64x128x128).
+IE = 256 * 64 * 64
+F0 = 32 * 256 * 256
+F1 = 64 * 128 * 128
+
+# Ops the ML Drift GPU delegate cannot lower; an export that emits any of these
+# has not been made GPU-clean yet.
+GPU_BAD = {
+    "GATHER_ND", "GATHER", "SELECT_V2", "SELECT", "PACK", "SPLIT", "CAST",
+    "TOPK_V2", "BROADCAST_TO", "WHILE", "TRANSPOSE_CONV",
+}
+
+# fp16 weight-only quantization recipe for ai_edge_quantizer.
+FP16_RECIPE = [{
+    "regex": ".*",
+    "operation": "*",
+    "algorithm_key": "float_casting",
+    "op_config": {
+        "weight_tensor_config": {"num_bits": 16, "dtype": "FLOAT"}
+    },
+}]
+
+
+class _Dummy:
+    """A no-op stand-in for a broken native scipy leaf module attribute."""
+
+    def __getattr__(self, name):
+        """Returns another dummy for any non-dunder attribute access.
+
+        Args:
+            name: The attribute being looked up.
+
+        Returns:
+            A nested ``_Dummy`` (or raises for dunder names).
+        """
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return _Dummy()
+
+    def __call__(self, *args, **kwargs):
+        """Returns a dummy so a stubbed callable can be invoked."""
+        return _Dummy()
+
+
+class _Leaf(types.ModuleType):
+    """A module whose attributes resolve to ``_Dummy`` placeholders."""
+
+    def __getattr__(self, name):
+        """Returns a dummy for any non-dunder attribute.
+
+        Args:
+            name: The attribute being looked up.
+
+        Returns:
+            A ``_Dummy`` placeholder (or raises for dunder names).
+        """
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return _Dummy()
+
+
+def stub_scipy_native_leaves() -> None:
+    """Stubs scipy native leaf modules that some conda builds fail to load.
+
+    Importing ``transformers``' SAM 2 stack pulls scipy; a broken native build
+    aborts the process, so replace the optional leaves with harmless stubs.
+    """
+    for name in [
+        "scipy.sparse.linalg._propack", "scipy.optimize._cobyla",
+        "scipy.optimize._slsqp", "scipy.optimize._minpack",
+        "scipy.optimize._lbfgsb", "scipy.optimize._zeros",
+        "scipy.optimize._highs", "scipy.optimize._direct",
+        "scipy.optimize._trlib", "scipy.optimize._group_columns",
+        "scipy.optimize._bglu_dense",
+    ]:
+        sys.modules[name] = _Leaf(name)
+
+
+class ZeroStuffConvT(nn.Module):
+    """ConvTranspose2d as nearest interpolate + stride mask + conv2d.
+
+    TRANSPOSE_CONV is rejected by the ML Drift delegate. The stuffing mask is a
+    constant buffer built in __init__; building it at runtime with ``.repeat()``
+    lowers to BROADCAST_TO and 8-D tensors.
+    """
+
+    def __init__(self, conv_transpose, in_hw):
+        """Bakes the flipped weight and the stride mask.
+
+        Args:
+            conv_transpose: The nn.ConvTranspose2d to replace.
+            in_hw: The (square) spatial size of this layer's input.
+        """
+        super().__init__()
+        self.stride = conv_transpose.stride[0]
+        self.kernel = conv_transpose.kernel_size[0]
+        self.out_hw = in_hw * self.stride
+        self.register_buffer(
+            "weight",
+            conv_transpose.weight.flip(2, 3).transpose(0, 1).contiguous())
+        self.bias = conv_transpose.bias
+        mask = torch.zeros(1, 1, self.out_hw, self.out_hw)
+        mask[:, :, ::self.stride, ::self.stride] = 1.0
+        self.register_buffer("mask", mask)
+
+    def forward(self, x):
+        """Runs the zero-stuffed transposed convolution.
+
+        Args:
+            x: Input feature map (N, C, H, W).
+
+        Returns:
+            The upsampled feature map (N, C, H*stride, W*stride).
+        """
+        up = F.interpolate(
+            x, size=(self.out_hw, self.out_hw), mode="nearest")
+        out = F.conv2d(
+            up * self.mask, self.weight, self.bias, padding=self.kernel - 1)
+        return out[:, :, :self.out_hw, :self.out_hw]
+
+
+def _window_partition_4d(hidden_state, window_size):
+    """Partitions [B,H,W,C] into windows using only <= 4-D reshapes.
+
+    The upstream version uses a 6-D view+permute. Splitting H into the batch,
+    transposing, then splitting W transposes row/col within each window, which
+    ``_window_unpartition_4d`` reverses exactly; window attention is
+    order-equivariant, so the result is numerically identical.
+
+    Args:
+        hidden_state: Feature map (B, H, W, C).
+        window_size: Square window edge length.
+
+    Returns:
+        A tuple of (windows, (padded_height, padded_width)).
+    """
+    batch_size, height, width, num_channels = hidden_state.shape
+    pad_h = (window_size - height % window_size) % window_size
+    pad_w = (window_size - width % window_size) % window_size
+    hidden_state = F.pad(hidden_state, (0, 0, 0, pad_w, 0, pad_h))
+    padded_h, padded_w = height + pad_h, width + pad_w
+    n_h, n_w = padded_h // window_size, padded_w // window_size
+    x = hidden_state.reshape(
+        batch_size * n_h, window_size, padded_w, num_channels)
+    x = x.transpose(1, 2)
+    windows = x.reshape(
+        batch_size * n_h * n_w, window_size, window_size, num_channels)
+    return windows, (padded_h, padded_w)
+
+
+def _window_unpartition_4d(windows, window_size, pad_hw, hw):
+    """Exact inverse of ``_window_partition_4d``, cropping any padding.
+
+    Args:
+        windows: The partitioned windows.
+        window_size: Square window edge length.
+        pad_hw: The (padded_height, padded_width) from partitioning.
+        hw: The original (height, width) to crop back to.
+
+    Returns:
+        The reassembled feature map (B, H, W, C).
+    """
+    padded_h, padded_w = pad_hw
+    height, width = hw
+    num_channels = windows.shape[-1]
+    n_h, n_w = padded_h // window_size, padded_w // window_size
+    batch_size = windows.shape[0] // (n_h * n_w)
+    x = windows.reshape(
+        batch_size * n_h, n_w * window_size, window_size, num_channels)
+    x = x.transpose(1, 2)
+    x = x.reshape(batch_size, padded_h, padded_w, num_channels)
+    if padded_h > height or padded_w > width:
+        x = x[:, :height, :width, :].contiguous()
+    return x
+
+
+def _msa_forward_4d(self, hidden_states, **kwargs):
+    """Sam2MultiScaleAttention.forward with every tensor kept <= 4-D.
+
+    Upstream reshapes qkv to a 5-D [B, H*W, 3, nHead, C] and unbinds. Slicing
+    the fused projection along the channel dim instead keeps every tensor 4-D;
+    the discarded pre-pool attention weights do not affect the pooled-query
+    result, so the computation is reproduced exactly.
+
+    Args:
+        self: The Sam2MultiScaleAttention module.
+        hidden_states: Input (B, H, W, C).
+        **kwargs: Unused, accepted for signature compatibility.
+
+    Returns:
+        The attention output projected back to (B, H, W, C).
+    """
+    batch_size, height, width, _ = hidden_states.shape
+    dim_out = self.dim_out
+    num_heads = self.num_attention_heads
+    head_dim = dim_out // num_heads
+    qkv = self.qkv(hidden_states).reshape(
+        batch_size, height * width, 3 * dim_out)
+    query = qkv[..., :dim_out].reshape(
+        batch_size, height * width, num_heads, head_dim)
+    key = qkv[..., dim_out:2 * dim_out].reshape(
+        batch_size, height * width, num_heads, head_dim)
+    value = qkv[..., 2 * dim_out:].reshape(
+        batch_size, height * width, num_heads, head_dim)
+    if self.query_stride:
+        query = M.do_pool(
+            query.reshape(batch_size, height, width, -1), self.query_stride)
+        height, width = query.shape[1:3]
+        query = query.reshape(
+            batch_size, height * width, num_heads, head_dim)
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+    attn = (query * self.scale) @ key.transpose(-2, -1)
+    attn = torch.softmax(attn, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = (attn @ value).transpose(1, 2).reshape(
+        batch_size, height, width, -1)
+    return self.proj(attn_output)
+
+
+def install_hiera_patches() -> None:
+    """Installs the module-level Hiera rewrites onto the transformers stack."""
+    M.window_partition = _window_partition_4d
+    M.window_unpartition = _window_unpartition_4d
+    M.Sam2MultiScaleAttention.forward = _msa_forward_4d
+
+
+def bake_pos_embed(model):
+    """Replaces ``_get_pos_embed`` with a precomputed constant.
+
+    For a fixed 1024x1024 input the Hiera position embedding is a pure function
+    of learned parameters (bicubic interpolate of ``pos_embed`` plus a tiled
+    ``pos_embed_window``), so it is constant. Baking it removes the GATHER_ND
+    from the bicubic sampling and the BROADCAST_TO from the tiling.
+
+    Args:
+        model: The loaded Sam2Model / Sam2VideoModel.
+
+    Returns:
+        The baked embedding shape, or None if no Hiera module was found.
+    """
+    for module in model.modules():
+        if type(module).__name__ != "Sam2HieraDetModel":
+            continue
+        with torch.no_grad():
+            embedded = module.patch_embed(torch.randn(1, 3, 1024, 1024))
+            baked = module._get_pos_embed(embedded.shape[1:3])
+            baked = baked.detach().clone()
+        module.register_buffer("baked_pos_embed", baked)
+        module._get_pos_embed = types.MethodType(
+            lambda self, hw: self.baked_pos_embed, module)
+        return baked.shape
+    return None
+
+
+def _builtin_names():
+    """Builds an int -> name map of the TFLite builtin operator codes.
+
+    Returns:
+        A dict mapping each BuiltinOperator enum value to its name.
+    """
+    return {
+        v: k for k, v in vars(schema.BuiltinOperator).items()
+        if isinstance(v, int)
+    }
+
+
+def opcheck(path, tag):
+    """Prints GPU-hostile op counts and any > 4-D tensors for one graph.
+
+    Parses the flatbuffer directly (no Interpreter) so the check does not need
+    a runtime.
+
+    Args:
+        path: Path to the .tflite file.
+        tag: A short label printed with the result.
+
+    Returns:
+        The number of GPU-hostile ops found (0 means GPU-clean).
+    """
+    with open(path, "rb") as handle:
+        buf = bytearray(handle.read())
+    model = schema.Model.GetRootAsModel(buf, 0)
+    names = _builtin_names()
+    codes = [
+        model.OperatorCodes(i) for i in range(model.OperatorCodesLength())
+    ]
+    bad = {}
+    over = 0
+    for s in range(model.SubgraphsLength()):
+        subgraph = model.Subgraphs(s)
+        for o in range(subgraph.OperatorsLength()):
+            code = codes[subgraph.Operators(o).OpcodeIndex()]
+            name = names.get(code.BuiltinCode(), "?")
+            if name in GPU_BAD:
+                bad[name] = bad.get(name, 0) + 1
+        for t in range(subgraph.TensorsLength()):
+            if subgraph.Tensors(t).ShapeLength() > 4:
+                over += 1
+    print(f"{tag}: GPU_BAD={bad or 'NONE'} >4D={over}")
+    return sum(bad.values())
+
+
+def fp16(src, dst):
+    """Quantizes a graph's weights to fp16 and returns its size in MB.
+
+    Args:
+        src: Path to the fp32 .tflite input.
+        dst: Path to write the fp16 .tflite output.
+
+    Returns:
+        The fp16 file size in megabytes.
+    """
+    import os
+    from ai_edge_quantizer import quantizer
+    if os.path.exists(dst):
+        os.remove(dst)
+    quant = quantizer.Quantizer(src)
+    quant.load_quantization_recipe(FP16_RECIPE)
+    quant.quantize().export_model(dst)
+    return os.path.getsize(dst) / 1e6

--- a/models/sam2/sam2_hiera_tiny_video/converted/verify_video.py
+++ b/models/sam2/sam2_hiera_tiny_video/converted/verify_video.py
@@ -1,0 +1,392 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Verifies the exported SAM 2.1 video graphs against the HF PyTorch model.
+
+Runs a short synthetic clip (a white disk drifting on black, one positive click
+on frame 0) through two pipelines and reports their agreement:
+
+  1. HF ``Sam2VideoModel`` streaming inference (the reference).
+  2. The four exported .tflite graphs driven by the numpy HOST LOOP in
+     ``track`` -- the same rolling-bank / best-mask / no-object / mask-for-mem
+     orchestration a Kotlin or Swift app performs on device. The graphs run
+     through the LiteRT CompiledModel Python API (``run_by_index``).
+
+The host loop is the executable specification of the on-device orchestration;
+everything heavy is a graph, everything else is plain array bookkeeping.
+
+Usage (convert env, after export_video.py has written the graphs + constants):
+    SAM2_OUT=out python verify_video.py [--nmm 7,2] [--frames 8]
+"""
+import argparse
+import math
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from ai_edge_litert.compiled_model import CompiledModel
+from PIL import Image, ImageDraw
+from transformers import Sam2VideoInferenceSession, Sam2VideoModel
+
+OUT = os.path.abspath(os.environ.get("SAM2_OUT", "out"))
+CKPT = os.environ.get("SAM2_CKPT", "facebook/sam2.1-hiera-tiny")
+IE, F0, F1 = 1048576, 2097152, 1048576
+HW, MEMCH, HD = 4096, 64, 256
+NPTR_FRAMES, PTR_SPLIT = 16, 4
+NPTR = NPTR_FRAMES * PTR_SPLIT
+NO_OBJ, MEM_SCALE, MEM_BIAS, MASK_NEG = -1024.0, 20.0, -10.0, -1e9
+MEAN = np.array([0.485, 0.456, 0.406])
+STD = np.array([0.229, 0.224, 0.225])
+CLICK = (400.0, 512.0)
+
+
+def frame(t):
+    """Renders synthetic frame ``t`` as a normalized CHW float32 array.
+
+    Args:
+        t: Frame index; the disk drifts by (14, 6) px per frame in 512-space.
+
+    Returns:
+        A (1, 3, 1024, 1024) float32 array.
+    """
+    img = Image.new("RGB", (512, 512), "black")
+    cx, cy, r = 200 + 14 * t, 256 + 6 * t, 100
+    ImageDraw.Draw(img).ellipse([cx - r, cy - r, cx + r, cy + r], fill="white")
+    arr = np.asarray(img.resize((1024, 1024), Image.BILINEAR))
+    arr = arr.astype(np.float32) / 255.0
+    chw = ((arr - MEAN) / STD).transpose(2, 0, 1)
+    return chw[None].astype(np.float32)
+
+
+def sine_pe_1d(pos, dim=256, temperature=10000.0):
+    """Computes the 1-D sine position embedding of a scalar position.
+
+    Args:
+        pos: The scalar position.
+        dim: Embedding dimension.
+        temperature: Sine temperature.
+
+    Returns:
+        A (dim,) float32 array.
+    """
+    pe_dim = dim // 2
+    dim_t = np.arange(pe_dim, dtype=np.float32)
+    dim_t = temperature ** (2 * (dim_t // 2) / pe_dim)
+    x = pos / dim_t
+    return np.concatenate([np.sin(x), np.cos(x)]).astype(np.float32)
+
+
+class Consts:
+    """Loads the host-side constant tables written by export_video.py."""
+
+    def __init__(self, directory=OUT):
+        """Reads every constant .bin from ``directory``.
+
+        Args:
+            directory: The output dir holding the sam2v_*.bin files.
+        """
+        p = np.fromfile(f"{directory}/sam2v_prompt.bin", np.float32)
+        self.gauss = p[:256]
+        self.pe1, self.pe0, self.nap = p[256:512], p[512:768], p[768:1024]
+        self.track = np.fromfile(
+            f"{directory}/sam2v_track_sparse.bin", np.float32)
+        self.mtpe = np.fromfile(
+            f"{directory}/sam2v_mtpe.bin", np.float32).reshape(7, 64)
+        self.no_obj_ptr = np.fromfile(
+            f"{directory}/sam2v_no_obj_ptr.bin", np.float32)
+        tp = np.fromfile(f"{directory}/sam2v_tpos_proj.bin", np.float32)
+        self.tpos_w = tp[:64 * 256].reshape(64, 256)
+        self.tpos_b = tp[64 * 256:]
+
+    def click_sparse(self, x, y):
+        """Builds the 2-token sparse prompt for a positive click.
+
+        Args:
+            x: Click x in model (0..1024) coordinates.
+            y: Click y in model (0..1024) coordinates.
+
+        Returns:
+            A (512,) float32 sparse prompt.
+        """
+        xn = 2 * ((x + 0.5) / 1024) - 1
+        yn = 2 * ((y + 0.5) / 1024) - 1
+        proj = 2 * math.pi * (xn * self.gauss[:128] + yn * self.gauss[128:])
+        tok = np.concatenate([np.sin(proj), np.cos(proj)]) + self.pe1
+        return np.concatenate([tok, self.nap]).astype(np.float32)
+
+    def ptr_pos(self, t_diff):
+        """Projects a temporal offset to an object-pointer position embedding.
+
+        Args:
+            t_diff: Frames between the current and the pointer's frame.
+
+        Returns:
+            A (64,) float32 position embedding.
+        """
+        pe = sine_pe_1d(t_diff / (NPTR_FRAMES - 1.0)).astype(np.float64)
+        out = self.tpos_w.astype(np.float64) @ pe + self.tpos_b
+        return out.astype(np.float32)
+
+
+def upsample_1024(low):
+    """Bilinearly upsamples a 256x256 mask to 1024x1024 (align_corners=False).
+
+    Args:
+        low: A (256, 256) float32 mask.
+
+    Returns:
+        A (1024, 1024) float32 mask.
+    """
+    t = torch.from_numpy(low)[None, None]
+    up = F.interpolate(
+        t, size=(1024, 1024), mode="bilinear", align_corners=False)
+    return up[0, 0].numpy()
+
+
+def split_dec(out):
+    """Splits the flat decoder output into its four parts.
+
+    Args:
+        out: The flat decoder output array.
+
+    Returns:
+        A tuple (masks(4,256,256), iou(4), ptr(4,256), obj_score).
+    """
+    masks = out[:4 * 65536].reshape(4, 256, 256)
+    iou = out[4 * 65536:4 * 65536 + 4]
+    ptr = out[4 * 65536 + 4:4 * 65536 + 4 + 1024].reshape(4, 256)
+    return masks, iou, ptr, float(out[-1])
+
+
+class TfliteRunner:
+    """Runs the four exported graphs through the CompiledModel Python API."""
+
+    def __init__(self, nmm_list):
+        """Loads every graph for the requested bank sizes.
+
+        Args:
+            nmm_list: The memory-bank sizes to load memcond graphs for.
+        """
+        self.enc = CompiledModel.from_file(f"{OUT}/sam2v_encode.tflite")
+        self.dec = CompiledModel.from_file(f"{OUT}/sam2v_decode.tflite")
+        self.memz = CompiledModel.from_file(f"{OUT}/sam2v_memorize.tflite")
+        self.mc = {
+            n: CompiledModel.from_file(f"{OUT}/sam2v_memcond{n}.tflite")
+            for n in nmm_list
+        }
+
+    def _run(self, model, flat, out_count):
+        """Runs a single-signature graph on one flat input.
+
+        Args:
+            model: The CompiledModel to run.
+            flat: The flat float32 input array.
+            out_count: The number of float32 outputs to read.
+
+        Returns:
+            The flat output array.
+        """
+        ins = model.create_input_buffers(0)
+        outs = model.create_output_buffers(0)
+        ins[0].write(np.ascontiguousarray(flat.astype(np.float32)))
+        model.run_by_index(0, ins, outs)
+        return outs[0].read(out_count, np.float32).copy()
+
+    def encode(self, chw):
+        """Encodes one frame into (pix_raw, hi0, hi1)."""
+        flat = self._run(self.enc, chw.ravel(), IE + F0 + F1)
+        return flat[:IE], flat[IE:IE + F0], flat[IE + F0:]
+
+    def memcond(self, n, pix_raw, mem, tpe, ptr_tok, ptr_pos, km):
+        """Runs memory attention for bank size ``n``; returns pix_feat."""
+        flat = np.concatenate([
+            pix_raw, mem.ravel(), tpe.ravel(), ptr_tok.ravel(),
+            ptr_pos.ravel(), km,
+        ])
+        return self._run(self.mc[n], flat, IE)
+
+    def decode(self, pix_feat, hi0, hi1, sparse, nomem):
+        """Runs the mask decoder; returns split outputs."""
+        flat = np.concatenate([pix_feat, hi0, hi1, sparse, [nomem]])
+        return split_dec(self._run(self.dec, flat, 4 * 65536 + 4 + 1024 + 1))
+
+    def memorize(self, pix_raw, mfm, occ):
+        """Runs the memory encoder; returns the (4096, 64) spatial memory."""
+        flat = np.concatenate([pix_raw, mfm.ravel(), [occ]])
+        return self._run(self.memz, flat, HW * MEMCH).reshape(HW, MEMCH)
+
+
+def track(run, nmm, consts, num_frames):
+    """Runs the on-device host loop over the four graphs.
+
+    Args:
+        run: A runner exposing encode/memcond/decode/memorize.
+        nmm: The spatial memory-bank size.
+        consts: The loaded ``Consts``.
+        num_frames: Number of frames to track.
+
+    Returns:
+        A list of per-frame dicts with the low-res mask and object score.
+    """
+    spatial_bank, ptr_bank, outs = {}, {}, []
+    cond = 0
+    for t in range(num_frames):
+        pix_raw, hi0, hi1 = run.encode(frame(t))
+        prompted = t == cond
+        if prompted:
+            sparse, nomem, pix_feat = consts.click_sparse(*CLICK), 1.0, pix_raw
+        else:
+            mem = np.zeros((nmm, HW, MEMCH), np.float32)
+            tpe = np.zeros((nmm, MEMCH), np.float32)
+            km = np.full(nmm * HW + NPTR, MASK_NEG, np.float32)
+            slot = 0
+            mem[slot], tpe[slot] = spatial_bank[cond], consts.mtpe[6]
+            km[slot * HW:(slot + 1) * HW] = 0
+            slot += 1
+            for off in range(nmm - 1, 0, -1):
+                pf = t - off
+                if pf in spatial_bank and pf != cond:
+                    mem[slot] = spatial_bank[pf]
+                    tpe[slot] = consts.mtpe[off - 1]
+                    km[slot * HW:(slot + 1) * HW] = 0
+                    slot += 1
+            ptr_tok = np.zeros((NPTR, MEMCH), np.float32)
+            ptr_pos = np.zeros((NPTR, MEMCH), np.float32)
+            ptrs = [(t - cond, ptr_bank[cond])]
+            for td in range(1, NPTR_FRAMES):
+                pf = t - td
+                if pf < 0:
+                    break
+                if pf in ptr_bank and pf != cond:
+                    ptrs.append((td, ptr_bank[pf]))
+            for i, (td, p) in enumerate(ptrs):
+                pos = consts.ptr_pos(td)
+                for j in range(PTR_SPLIT):
+                    tok = i * PTR_SPLIT + j
+                    ptr_tok[tok] = p[j * MEMCH:(j + 1) * MEMCH]
+                    ptr_pos[tok] = pos
+                    km[nmm * HW + tok] = 0
+            pix_feat = run.memcond(
+                nmm, pix_raw, mem, tpe, ptr_tok, ptr_pos, km)
+            sparse, nomem = consts.track, 0.0
+        masks, iou, ptr, obj = run.decode(pix_feat, hi0, hi1, sparse, nomem)
+        best = 1 + int(np.argmax(iou[1:]))
+        appearing = obj > 0
+        if appearing:
+            low = masks[best]
+            obj_ptr = ptr[best]
+        else:
+            low = np.full((256, 256), NO_OBJ, np.float32)
+            obj_ptr = consts.no_obj_ptr
+        high = upsample_1024(low)
+        if prompted:
+            mfm = (high > 0).astype(np.float32) * MEM_SCALE + MEM_BIAS
+        else:
+            mfm = 1.0 / (1.0 + np.exp(-high)) * MEM_SCALE + MEM_BIAS
+        occ = 0.0 if appearing else 1.0
+        mem_t = run.memorize(pix_raw, mfm.astype(np.float32), occ)
+        spatial_bank[t], ptr_bank[t] = mem_t, obj_ptr
+        outs.append({"mask": low, "obj": float(obj)})
+    return outs
+
+
+def reference(nmm, num_frames):
+    """Runs the clean HF streaming reference.
+
+    Args:
+        nmm: The number of memory slots to configure on the model.
+        num_frames: Number of frames to track.
+
+    Returns:
+        A list of per-frame (mask, obj_score) tuples.
+    """
+    model = Sam2VideoModel.from_pretrained(CKPT).eval()
+    model.num_maskmem = nmm
+    session = Sam2VideoInferenceSession(
+        video_height=1024, video_width=1024, dtype=torch.float32)
+    obj = session.obj_id_to_idx(1)
+    session.add_point_inputs(obj, 0, {
+        "point_coords": torch.tensor([[[[CLICK[0], CLICK[1]]]]]),
+        "point_labels": torch.tensor([[[1]]]),
+    })
+    session.obj_with_new_inputs = [1]
+    out = []
+    with torch.no_grad():
+        for t in range(num_frames):
+            result = model(
+                inference_session=session, frame=torch.from_numpy(frame(t)))
+            mask = result.pred_masks.numpy().reshape(256, 256)
+            score = float(result.object_score_logits.reshape(-1)[0])
+            out.append((mask, score))
+    return out
+
+
+def mask_iou(a, b):
+    """Computes the binary-mask IoU of two logit maps thresholded at 0.
+
+    Args:
+        a: First logit map.
+        b: Second logit map.
+
+    Returns:
+        The IoU as a float.
+    """
+    union = np.logical_or(a > 0, b > 0).sum()
+    inter = np.logical_and(a > 0, b > 0).sum()
+    return float(inter / union) if union else 1.0
+
+
+def corr(a, b):
+    """Computes the Pearson correlation of two arrays.
+
+    Args:
+        a: First array-like.
+        b: Second array-like.
+
+    Returns:
+        The correlation coefficient as a float.
+    """
+    a = np.asarray(a).ravel()
+    b = np.asarray(b).ravel()
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def main() -> None:
+    """Runs the reference and tflite pipelines and prints their agreement."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--nmm", default="7,2")
+    parser.add_argument("--frames", type=int, default=8)
+    args = parser.parse_args()
+    nmms = [int(x) for x in args.nmm.split(",")]
+    consts = Consts()
+    runner = TfliteRunner(nmms)
+    for n in nmms:
+        ref = reference(n, args.frames)
+        got = track(runner, n, consts, args.frames)
+        worst_iou, worst_corr = 1.0, 1.0
+        for t, out in enumerate(got):
+            iou = mask_iou(ref[t][0], out["mask"])
+            cc = corr(ref[t][0], out["mask"])
+            worst_iou = min(worst_iou, iou)
+            worst_corr = min(worst_corr, cc)
+            fg = int((out["mask"] > 0).sum())
+            print(f"  nmm={n} f{t:02d} IoU={iou:.4f} corr={cc:.5f} "
+                  f"fg={fg} obj={out['obj']:.2f}/{ref[t][1]:.2f}")
+        print(f"[nmm={n}] frames={args.frames} min IoU={worst_iou:.4f} "
+              f"min corr={worst_corr:.5f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a conversion recipe for the SAM 2.1 Hiera-Tiny **video-tracking** path at `models/sam2/sam2_hiera_tiny_video/converted/`, following the model-producing-first lane. The still-image path (encoder + prompt mask decoder) already ships as the interactive-segmentation sample; this recipe adds only the parts unique to video — memory attention, the memory encoder, object pointers, and the prompt-conditioned mask decoder — as four fixed-shape tflite graphs that run fully on the CompiledModel GPU delegate. The rolling memory bank and the per-frame orchestration stay on the host, so only tensor math is exported.

The one rewrite unique to the video path is the memory attention: SAM 2's RoPE attention runs with the batch dimension collapsed to rank 3, which the ML Drift GPU delegate silently mis-computes; re-authoring it batch-first at rank 4 is numerically identical on the host and correct on the GPU (exact under fp32 GPU compute). The image-path Hiera rewrites (baked position embedding, ≤4-D window partition and multi-scale attention, zero-stuffed transposed conv) are reused from `hiera_gpu_clean.py`.

Included:
- `export_video.py` — exports encode, memcond7/memcond2, decode, memorize as fp16 tflite plus host constants; each graph is op-checked from its flatbuffer and reports `GPU_BAD=NONE`, no tensor above rank 4.
- `verify_video.py` — drives a synthetic clip through both the `transformers` streaming reference and the exported graphs (via the ai_edge_litert CompiledModel Python API) with the host loop a Kotlin/Swift app mirrors, and reports per-frame mask IoU / correlation.
- `hiera_gpu_clean.py` — the shared GPU-clean Hiera rewrites.

Measured: the assembled loop matches the PyTorch reference at min mask-IoU 0.9999 over a 10-frame clip for both the 7-slot and 2-slot memory banks. Every graph is fully GPU-resident with no CPU fallback on Pixel 8a (Mali) and iPhone 17 Pro (Metal); per tracked frame is ~471 ms on the iPhone (2-slot) and ~1–1.5 s on the Pixel. The residual fp16 accumulation over the memory keys does not reach the mask (chained tracked-frame mask IoU 0.9986).

The demo app stays out of this PR; a `samples/litert/` app would be a separate, later PR. Happy to adjust placement, naming, or scope to whatever fits the repo best.
