### PR TITLE
qwen3_tts: allow a local or fine-tuned snapshot via QWEN3_TTS_SNAPSHOT

### DIFF
--- a/models/qwen/qwen3_tts/converted/README.md
+++ b/models/qwen/qwen3_tts/converted/README.md
@@ -2,7 +2,7 @@
 
 Model recipes, instructions, scripts, and utilities for converting Qwen3-TTS to LiteRT.
 
-These scripts convert [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) into the three .tflite graphs plus host-side tables used by the [sample](../../../../samples/litert/text_to_speech_lm/), and numerically verify every step against the PyTorch reference. The published artifacts live at [litert-community/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/litert-community/Qwen3-TTS-12Hz-0.6B-Base).
+These scripts convert [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) (downloaded automatically; set `QWEN3_TTS_SNAPSHOT` to use a local copy or your own fine-tune of the base model) into the three .tflite graphs plus host-side tables used by the [sample](../../../../samples/litert/text_to_speech_lm/), and numerically verify every step against the PyTorch reference. The published artifacts live at [litert-community/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/litert-community/Qwen3-TTS-12Hz-0.6B-Base).
 
 ## Environments
 

--- a/models/qwen/qwen3_tts/converted/dump_codec_ref.py
+++ b/models/qwen/qwen3_tts/converted/dump_codec_ref.py
@@ -30,7 +30,8 @@ from qwen_tts.inference.qwen3_tts_tokenizer import Qwen3TTSTokenizer
 def main() -> None:
     """Dumps codec decoder output on fixed random codes to ref/."""
     torch.manual_seed(42)
-    src = snapshot_download('Qwen/Qwen3-TTS-12Hz-0.6B-Base')
+    src = os.environ.get('QWEN3_TTS_SNAPSHOT') or snapshot_download(
+        'Qwen/Qwen3-TTS-12Hz-0.6B-Base')
     tokenizer = Qwen3TTSTokenizer.from_pretrained(
         f'{src}/speech_tokenizer', dtype=torch.float32, device_map='cpu')
     decoder = tokenizer.model.decoder

--- a/models/qwen/qwen3_tts/converted/export_codec.py
+++ b/models/qwen/qwen3_tts/converted/export_codec.py
@@ -63,8 +63,9 @@ def corr(a, b) -> float:
 def main() -> None:
     """Exports the codec decoder to .tflite and checks reference parity."""
     os.makedirs(OUT, exist_ok=True)
-    src = snapshot_download('Qwen/Qwen3-TTS-12Hz-0.6B-Base',
-                            allow_patterns=['speech_tokenizer/*'])
+    src = os.environ.get('QWEN3_TTS_SNAPSHOT') or snapshot_download(
+        'Qwen/Qwen3-TTS-12Hz-0.6B-Base',
+        allow_patterns=['speech_tokenizer/*'])
     src = f'{src}/speech_tokenizer'
     config = Qwen3TTSTokenizerV2Config.from_pretrained(src)
     model = Qwen3TTSTokenizerV2Model.from_pretrained(

--- a/models/qwen/qwen3_tts/converted/export_mtp.py
+++ b/models/qwen/qwen3_tts/converted/export_mtp.py
@@ -150,7 +150,8 @@ def _load_weights() -> dict[str, torch.Tensor]:
         Dict of fp32 layer/norm weights plus 'heads' [15, 2048, 1024];
         also writes out/mtp/mtp_embeddings.npy [15, 2048, 1024].
     """
-    src = snapshot_download('Qwen/Qwen3-TTS-12Hz-0.6B-Base')
+    src = os.environ.get('QWEN3_TTS_SNAPSHOT') or snapshot_download(
+        'Qwen/Qwen3-TTS-12Hz-0.6B-Base')
     reader = safe_open(f'{src}/model.safetensors', framework='pt')
     prefix = 'talker.code_predictor.'
     weights = {}

--- a/models/qwen/qwen3_tts/converted/extract_host_tables.py
+++ b/models/qwen/qwen3_tts/converted/extract_host_tables.py
@@ -36,7 +36,8 @@ OUT = 'out/host'
 def main() -> None:
     """Saves the codec/text embedding and text projection tables."""
     os.makedirs(OUT, exist_ok=True)
-    src = snapshot_download('Qwen/Qwen3-TTS-12Hz-0.6B-Base')
+    src = os.environ.get('QWEN3_TTS_SNAPSHOT') or snapshot_download(
+        'Qwen/Qwen3-TTS-12Hz-0.6B-Base')
     reader = safe_open(f'{src}/model.safetensors', framework='pt')
 
     def get(key: str) -> np.ndarray:

--- a/models/qwen/qwen3_tts/converted/extract_talker_ckpt.py
+++ b/models/qwen/qwen3_tts/converted/extract_talker_ckpt.py
@@ -41,7 +41,9 @@ from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from safetensors.torch import save_file
 
-SRC = snapshot_download('Qwen/Qwen3-TTS-12Hz-0.6B-Base')
+# QWEN3_TTS_SNAPSHOT: local copy or your own fine-tune of the -Base model.
+SRC = os.environ.get('QWEN3_TTS_SNAPSHOT') or snapshot_download(
+    'Qwen/Qwen3-TTS-12Hz-0.6B-Base')
 DST = 'out/talker-llm'
 
 _CONFIG = {


### PR DESCRIPTION
The five scripts that download `Qwen/Qwen3-TTS-12Hz-0.6B-Base` now check the `QWEN3_TTS_SNAPSHOT` environment variable first, mirroring the bonsai recipe's `BONSAI_SNAPSHOT`. This lets the recipe convert a local copy or a fine-tune of the -Base checkpoint without editing the scripts. The default behavior is unchanged, and the README notes the variable in the same sentence the bonsai README uses.

Since the -Base release is the fine-tuning checkpoint of the family, this makes the recipe usable as a conversion tool for custom voices, not only as a reproduction script.