### PR TITLE
Add Nemotron-3-Nano-4B and Hy-MT2-1.8B conversion recipes under models/

### DIFF
--- a/models/hunyuan/hy_mt2_1_8b/README.md
+++ b/models/hunyuan/hy_mt2_1_8b/README.md
@@ -1,0 +1,3 @@
+# Hy-MT2 1.8B Translation Model
+
+Model recipes, conversion scripts, instructions, and utilities for Hy-MT2-1.8B on-device multilingual translation ([tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B)).

--- a/models/hunyuan/hy_mt2_1_8b/converted/.gitignore
+++ b/models/hunyuan/hy_mt2_1_8b/converted/.gitignore
@@ -1,0 +1,3 @@
+*.litertlm
+out_*/
+__pycache__/

--- a/models/hunyuan/hy_mt2_1_8b/converted/README.md
+++ b/models/hunyuan/hy_mt2_1_8b/converted/README.md
@@ -1,0 +1,102 @@
+# Hy-MT2-1.8B Conversion
+
+Model recipes, instructions, scripts, and utilities for converting Hy-MT2-1.8B to LiteRT-LM.
+
+These scripts convert [tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B) (dense `HunYuanDenseV1ForCausalLM`, Apache-2.0, Tencent's 33-language translation model) into a `.litertlm` bundle for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a quality gate, a translation A/B against the HF reference, and two one-variable proofs. The published artifact is `Hy-MT2-1.8B_int8.litertlm` (1.82 GB) at [litert-community/Hy-MT2-1.8B](https://huggingface.co/litert-community/Hy-MT2-1.8B).
+
+The model is a 32-layer dense transformer (hidden 2048, GQA 16:4 with QK-norm, head_dim 128, intermediate 6144, vocab 120,818, tied embeddings — 2.04 B tensor parameters, 1.79 B unique). The architecture needs nothing from the exporter. What this conversion documents is a **config fact** (a `dynamic` rope that is static in practice, and how to remove the one branch that kills `torch.export` without changing a bit) and a **runtime fact** (the LiteRT-LM engine prepends the metadata `start_token` to every prompt, so a template that renders its own BOS literal must not also declare one — proved inside the runtime, not inferred from outputs).
+
+## Build
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int8` | export-time dynamic int8 on linears + embedding (`dynamic_wi8_afp32`) | 1.82 GB | desktop CPU/GPU; phone not measured |
+
+## Environment
+
+```bash
+pip install litert-torch==0.9.3 litert-converter==0.3.1 ai-edge-quantizer==0.8.0 \
+    litert-lm-builder==0.15.0 transformers==5.14.1
+pip install litert-lm   # verification CLI (>= 0.16.0 used here)
+```
+
+The published bundle was built on exactly this released stack — no patched checkout. `litert-lm-builder >= 0.15` is what the post-export metadata edit needs (pack/unpack API).
+
+## Run
+
+```bash
+python build_hy_mt2_1_8b.py --out out_int8                                          # 1.82 GB bundle, ~2 min export
+python verify_hy_mt2_1_8b.py out_int8/*.litertlm --backend cpu                      # 8-question gate
+python verify_hy_mt2_1_8b.py out_int8/*.litertlm --check-metadata                   # start_token, stop, template, bytes/param
+python verify_hy_mt2_1_8b.py out_int8/*.litertlm --translate                        # the model's task, vs HF bf16
+python verify_hy_mt2_1_8b.py out_int8/*.litertlm --rope-ab                          # the rope bake is bitwise-exact
+python build_hy_mt2_1_8b.py --out out_int8_bos --keep-start-token                   # the default (double-BOS) export, for study
+python verify_hy_mt2_1_8b.py out_int8/*.litertlm --bos-discriminator out_int8_bos/*.litertlm
+```
+
+## Why the stock export fails, and why the fix is exact
+
+`config.json` declares `rope_scaling: {type: dynamic, alpha: 1000.0, ...}` with `rope_theta: 10000` and `max_position_embeddings: 262144`. A plain `export(model, output_dir)` dies inside `torch.export`:
+
+```
+torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode:
+Could not guard on data-dependent expression Eq(u0, 1)
+  File transformers/modeling_rope_utils.py, in dynamic_frequency_update
+    if seq_len > max_seq_len_cached:  # growth
+```
+
+The branch that fails is dead for this model. transformers 5.14's hunyuan implementation resolves the alpha form **statically at init** — an init-time special case its code comments label "DynamicNTKAlphaRotary" computes `base = rope_theta · alpha^(dim/(dim−2))` once and copies the resulting `inv_freq` — and never rescales below `max_position_embeddings`. Only the generic `@dynamic_rope_update` growth guard is left in the forward, and its data-dependent comparison is what the tracer cannot guard.
+
+`build_hy_mt2_1_8b.py` therefore bakes the resolved base into `rope_theta` (**11,158,839.92507748**, `0x1.548a6fd9a3c16p+23`) and drops `rope_scaling`, in a local hub-format copy of the snapshot whose other files are symlinks. The export then goes through the stock path untouched. `--rope-ab` measures that this is not an approximation:
+
+| quantity | vendor config | baked config |
+|---|---|---|
+| `rope_type` | `dynamic` | `default` |
+| `inv_freq` | — | **bitwise-equal** (int32 view; max abs diff 0.0) |
+| `attention_scaling` | 1.0 | 1.0 |
+| teacher-forced logits, 17-token chat prompt, bf16 | — | **bitwise-equal** (max abs diff 0.0) |
+
+Faithful for every position up to 262,144; past that the HF model would enter the non-alpha dynamic recomputation, which is irrelevant to a bundle with a 4,096-token context.
+
+## The engine prepends `start_token` — proved inside the runtime
+
+Hy-MT2's template opens with the BOS written as a **literal** — `<｜hy_begin▁of▁sentence｜>` is the first thing it renders — and its tokenizer adds no BOS at encode time. The bundle builder sets `LlmMetadata.start_token` from `tokenizer.bos_token` regardless, so the question is what the engine does with it. Comparing outputs against HF could not settle that: int8 greedy divergence happened to match the "HF + extra BOS" arm on 2 of 3 probes even after the field was removed. The discriminator that decides runs entirely inside the runtime, same weights, greedy, CPU:
+
+| stream | how | result |
+|---|---|---|
+| X — `[start_token] + rest` | default bundle, `--no-template`, prompt = rendered text minus its leading BOS string | |
+| Y′ — `[template BOS] + rest` | this bundle (no `start_token`), normal templating | **X ≡ Y′ byte-for-byte on 3 of 3 probes** |
+| X′ — `rest` only | this bundle, `--no-template`, same BOS-stripped text | X ≠ X′ on 2 of 3 |
+
+So the engine does prepend the start token, it encodes to the same id as the template's literal, and the default export fed the model `[BOS][BOS]…`. This bundle drops the field; the on-device stream equals the training stream. Honest numbers: the double-BOS bundle happened to score **8/8** on the sanity gate and the stream-faithful one scores **6/8** (misses "Cool" for the opposite of hot and "pink" for the rhyme — noise-level for a translation-tuned 1.8B, no degeneration). The faithful file ships anyway; matching the training stream is the property that generalizes, a lucky gate is not.
+
+What generalizes, from auditing every published bundle afterwards: the engine renders the template with minijinja, which leaves `bos_token` **unbound** — `{{ bos_token }}` renders empty on device, and only a BOS written as a literal survives. So a template that says `{{ bos_token }}` (Falcon-H1, LFM2.5, gemma) needs the `start_token` to supply its single BOS, and dropping it would ship no BOS at all; a template with a literal BOS (Hy-MT2, Zamba2, SmolVLM2) gets one from the template and a second from the field. Render the template twice — `bos_token` bound and empty — and the two shapes separate. Do not diagnose this by comparing generations against HF; quantization noise can mimic the wrong arm.
+
+## Verification results
+
+Measured on the published bundle with `verify_hy_mt2_1_8b.py`, litert-lm 0.16.0, Mac M4 Max, re-run 2026-08-30:
+
+- **8-question gate: CPU 6/8, GPU 6/8**, non-degenerate, the same two misses on both backends ("Cool", "pink") — a property of this translation-tuned checkpoint, not of a backend. Arithmetic, factual and translation items all correct. Threshold is 6/8.
+- **`--check-metadata` 7/7**: no `start_token`; stop id 120020 (`<｜hy_place▁holder▁no▁2｜>`); the embedded Jinja is byte-equal to the repo's `chat_template.jinja` (654/654 bytes — the repo carries no `tokenizer_config.json` copy to disagree with); `max_num_tokens` 4096; 1,815,622,960 B / 1,791,080,448 unique params = 1.01 bytes/param; one 1.69 GiB model section.
+- **Translation A/B** (`--translate`, the source card's default prompt, greedy, HF bf16 on CPU vs the bundle): byte-identical on **1 of 3** probes (Japanese); the French and English probes are fluent alternates of the usual int8-vs-bf16 kind (*spectaculaire* → *significative*; "the weather is good" → "the weather is nice"). No degeneration.
+- **`--rope-ab`**: `inv_freq` and teacher-forced logits bitwise-equal (table above).
+
+Rebuilt from scratch with `build_hy_mt2_1_8b.py` on the pinned stack (2026-08-30): 1,815,622,960 bytes, **byte-identical to the published bundle in every section** — LlmMetadata (673 B), tokenizer (2,006,574 B) and the model (1,813,574,960 B); the 39 differing bytes are the file header's uuid and creation timestamp. The rebuild passes the same metadata checks and gate with the same answers.
+
+Mac (M4 Max, `litert-lm benchmark`, `-p 256 -d 256 --runs 3 --cache no`, litert-lm 0.16.0, quiet host at load ~3.3; two protocol runs per cell, the GPU cell after a ≥300 s rest):
+
+| backend | prefill tok/s | decode tok/s | TTFT |
+|---|---|---|---|
+| GPU (Metal) | 2008 / 2003 | 105.8 / 105.4 | 0.137 s |
+| CPU | 211.0 / 210.0 | 34.0 / 32.4 | 1.24 / 1.25 s |
+
+Both backends were gated on real generations before benchmarking (a broken backend still prints benchmark numbers). GPU repeats within 0.4%, CPU decode within 5%. Unlike the Nemotron-3-Nano-4B hybrid in this repository, GPU works with the runtime's default compiled-graph cache on this dense bundle.
+
+Not measured on a phone. The bundle carries the exporter's stock single 128-token prefill signature plus decode (`--prefill` changes that; the ladder was not measured).
+
+## Files
+
+| File | What |
+|---|---|
+| `build_hy_mt2_1_8b.py` | HF checkpoint → `.litertlm`: bakes the static rope (`rope_theta` 11,158,839.925, `rope_scaling` dropped), stock int8 export (embedded vendor Jinja, 4096 context), drops the metadata `start_token`. `--keep-start-token` reproduces the default double-BOS export for study. |
+| `verify_hy_mt2_1_8b.py` | 8-question quality gate via the `litert-lm` CLI; `--check-metadata`; `--translate` (three translation probes vs HF bf16 greedy); `--rope-ab` (bitwise proof of the bake); `--bos-discriminator` (the in-runtime X / Y′ / X′ comparison). |

--- a/models/hunyuan/hy_mt2_1_8b/converted/build_hy_mt2_1_8b.py
+++ b/models/hunyuan/hy_mt2_1_8b/converted/build_hy_mt2_1_8b.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tencent/Hy-MT2-1.8B (dense HunYuanDenseV1ForCausalLM) -> .litertlm.
+
+Converts the Hugging Face checkpoint into a LiteRT-LM bundle through
+litert-torch's plain HF export path with the stock int8 recipe
+(`dynamic_wi8_afp32`: dynamic int8 weights on linears + embedding): 1.82 GB for
+1.79 B unique parameters. The architecture itself needs nothing — GQA with
+QK-norm, RMSNorm, SiLU MLP, a tied embedding — and the stock exporter handles
+it. What this script adds is two things the checkpoint's *config* and
+*template* make necessary, both measured:
+
+  * A bitwise-equal rope bake. The config declares
+    `rope_scaling: {type: dynamic, alpha: 1000}`. transformers 5.14 resolves
+    that STATICALLY at init (`base = rope_theta * alpha**(dim/(dim-2))`; the
+    code comment calls it "DynamicNTKAlphaRotary"), but the forward still
+    carries the generic
+    dynamic-rope growth branch, and its data-dependent
+    `if seq_len > max_seq_len_cached` guard kills torch.export
+    (GuardOnDataDependentSymNode: Could not guard on Eq(u0, 1)). Baking the
+    resolved base into `rope_theta` (11,158,839.925…) and dropping
+    `rope_scaling` removes the dead branch and nothing else: `inv_freq` and
+    teacher-forced logits are bitwise-equal to the HF reference, valid for
+    every position up to `max_position_embeddings` (262,144) — far past this
+    bundle's 4,096 context. `verify_hy_mt2_1_8b.py --rope-ab` re-measures it.
+
+  * No metadata `start_token`. The chat template renders
+    `<｜hy_begin▁of▁sentence｜>` itself as a LITERAL, the tokenizer adds no BOS
+    at encode time, and the LiteRT-LM engine prepends the metadata
+    `start_token` to every rendered prompt unconditionally — so the default
+    export fed the model two BOS tokens. The proof runs inside the runtime:
+    `[start_token] + rest` (default bundle, `--no-template`) generates
+    byte-identical greedy output to `[template BOS] + rest` (this bundle,
+    normal templating) on 3 of 3 probes (`--bos-discriminator`). Dropping the
+    field makes the on-device stream equal the training stream.
+
+Usage:
+  python build_hy_mt2_1_8b.py --out out_int8
+  python build_hy_mt2_1_8b.py --out out_int8_bos --keep-start-token   # study
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+MODEL_ID = "tencent/Hy-MT2-1.8B"
+FINAL_NAME = "Hy-MT2-1.8B_int8.litertlm"
+EOS_ID = 120020  # <｜hy_place▁holder▁no▁2｜>, the tokenizer's eos
+
+
+def normalize_rope(snapshot, out_dir):
+  """Builds a hub-format dir whose config carries the statically resolved rope.
+
+  Everything but config.json is a symlink into the snapshot. The bake is the
+  exact expression transformers' hunyuan rotary embedding evaluates at init.
+  """
+  cfg = json.loads((snapshot / "config.json").read_text())
+  rope = cfg.get("rope_scaling") or {}
+  if rope.get("type") != "dynamic" or not rope.get("alpha"):
+    raise SystemExit(
+        f"unexpected rope_scaling {rope!r} — this recipe bakes the "
+        "dynamic-alpha form only; re-check the checkpoint's config")
+  dim = cfg["head_dim"]
+  baked = cfg["rope_theta"] * rope["alpha"] ** (dim / (dim - 2))
+
+  norm = out_dir / "rope_normalized_src"
+  norm.mkdir(parents=True, exist_ok=True)
+  for f in snapshot.iterdir():
+    if f.name == "config.json" or f.is_dir():
+      continue
+    dst = norm / f.name
+    if not dst.exists():
+      dst.symlink_to(f.resolve())
+  norm_cfg = {k: v for k, v in cfg.items() if k != "rope_scaling"}
+  norm_cfg["rope_theta"] = baked
+  (norm / "config.json").write_text(json.dumps(norm_cfg, indent=1))
+  print(f"rope: type=dynamic alpha={rope['alpha']} resolves statically -> "
+        f"rope_theta={baked!r} ({baked.hex()}), rope_scaling dropped; "
+        f"bitwise-equal below {cfg.get('max_position_embeddings')} positions")
+  return norm
+
+
+def strip_block(pbtext, field="start_token"):
+  """Drops a top-level `field { ... }` block from a text-format proto.
+
+  Brace-counting rather than a regex: the block nests braces, and the
+  metadata's stop_tokens use the same shape.
+  """
+  m = re.search(rf"^{field}\s*\{{", pbtext, re.M)
+  if not m:
+    return pbtext, False
+  i = pbtext.index("{", m.start())
+  depth = 0
+  for j in range(i, len(pbtext)):
+    if pbtext[j] == "{":
+      depth += 1
+    elif pbtext[j] == "}":
+      depth -= 1
+      if depth == 0:
+        end = j + 1
+        while end < len(pbtext) and pbtext[end] == "\n":
+          end += 1
+        return pbtext[:m.start()] + pbtext[end:], True
+  raise SystemExit(f"unbalanced braces in {field} block")
+
+
+def bos_evidence(tokenizer):
+  """Counts the leading BOS the model was trained to see vs what the bundle
+  would feed: (reference, from_template). The engine renders the template
+  with `bos_token` unbound and prepends the metadata start_token, so the
+  bundle count is from_template + 1."""
+  import jinja2
+
+  def render(bos):
+    env = jinja2.Environment(extensions=["jinja2.ext.loopcontrols"])
+    return env.from_string(tokenizer.chat_template).render(
+        messages=[{"role": "user", "content": "x"}], add_generation_prompt=True,
+        bos_token=bos, eos_token="")
+
+  def leading(text, tok):
+    n = 0
+    while tok and text.startswith(tok):
+      text, n = text[len(tok):], n + 1
+    return n
+
+  bos = tokenizer.bos_token
+  return leading(render(bos), bos), leading(render(""), bos)
+
+
+def finalize_metadata(bundle, keep_start_token):
+  """Post-export pass over LlmMetadata: assert the eos stop, drop start_token."""
+  from litert_lm_builder import pack_litertlm_file, unpack_litertlm_file
+
+  with tempfile.TemporaryDirectory(dir=bundle.parent) as td:
+    toml = unpack_litertlm_file(str(bundle), td)
+    pb = Path(td) / "LlmMetadataProto.pbtext"
+    text = pb.read_text()
+    stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", text)}
+    if EOS_ID not in stop_ids:
+      raise SystemExit(f"eos {EOS_ID} missing from stop_tokens {sorted(stop_ids)} "
+                       "— the exporter's stop derivation changed; re-check")
+    text, had = strip_block(text, "start_token")
+    if not had:
+      raise SystemExit("no start_token in the export — the bundler's behaviour "
+                       "changed; re-check the BOS story before shipping")
+    if keep_start_token:
+      print("start_token: KEPT on request (double-BOS bundle, for study only)")
+      return
+    pb.write_text(text)
+    fixed = bundle.parent / (bundle.name + ".nobos")
+    pack_litertlm_file(str(toml), str(fixed))
+    fixed.replace(bundle)
+  print("start_token: dropped (template renders the BOS literal; the engine "
+        "would have prepended a second one)")
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--model", default=MODEL_ID,
+                  help="HF model id or a local checkout of it")
+  ap.add_argument("--out", default="out_int8", help="output dir")
+  ap.add_argument("--cache", type=int, default=4096, help="KV cache length")
+  ap.add_argument("--prefill", default="128",
+                  help="comma-separated prefill signature lengths (the "
+                       "published bundle carries the exporter's stock single "
+                       "128-token signature)")
+  ap.add_argument("--keep-start-token", action="store_true",
+                  help="do not drop the metadata start_token: reproduces the "
+                       "default double-BOS export for --bos-discriminator")
+  ap.add_argument("--keep-src", action="store_true",
+                  help="keep the rope-normalized source dir under --out")
+  args = ap.parse_args()
+
+  out = Path(args.out)
+  out.mkdir(parents=True, exist_ok=True)
+
+  from huggingface_hub import snapshot_download
+  from transformers import AutoTokenizer
+
+  src = Path(args.model)
+  if not src.exists():
+    src = Path(snapshot_download(args.model,
+                                 ignore_patterns=["train/*", "imgs/*", "*.png"]))
+  tok = AutoTokenizer.from_pretrained(str(src))
+  want, from_template = bos_evidence(tok)
+  print(f"BOS: reference stream starts with {want} x {tok.bos_token!r}; the "
+        f"template renders {from_template} itself and the engine prepends the "
+        f"metadata start_token -> a default export feeds {from_template + 1}")
+  assert (want, from_template) == (1, 1), "BOS shape changed — re-derive the story"
+
+  norm = normalize_rope(src, out)
+
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=str(norm),
+      output_dir=str(out),
+      prefill_lengths=[int(x) for x in args.prefill.split(",") if x.strip()],
+      cache_length=args.cache,
+      # The exporter's stock int8: dynamic int8 weights on linears + embedding,
+      # fp32 activations. Same string the 0.9.3 defaults resolve to.
+      quantization_recipe="dynamic_wi8_afp32",
+      # The vendor Jinja is embedded verbatim and rendered on device.
+      use_jinja_template=True,
+      externalize_embedder=False,
+  )
+  bundle = out / "model.litertlm"
+  if not bundle.exists():
+    raise SystemExit("export finished without producing model.litertlm")
+
+  finalize_metadata(bundle, args.keep_start_token)
+  final = out / FINAL_NAME
+  bundle.replace(final)
+  if not args.keep_src:
+    shutil.rmtree(norm, ignore_errors=True)
+  print(f"EXPORT_DONE {final} ({os.path.getsize(final):,} B)")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/hunyuan/hy_mt2_1_8b/converted/verify_hy_mt2_1_8b.py
+++ b/models/hunyuan/hy_mt2_1_8b/converted/verify_hy_mt2_1_8b.py
@@ -1,0 +1,444 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate, metadata and model-specific checks for a converted Hy-MT2-1.8B bundle.
+
+Five modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm), greedy, one fresh session per
+    question, and scores correctness plus degeneracy (looping, token spam,
+    empty output). This is the publish guardrail: a conversion that collapses
+    must not ship. Hy-MT2 is a translation model, so this certifies little
+    about its real job — the published bundle scores 6/8 on both backends with
+    the same two misses ("Cool", "pink"); --translate is the check that
+    matters.
+
+      python verify_hy_mt2_1_8b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — reads the bundle's LlmMetadata (no unpacking) and asserts
+    the shape this recipe produces: NO start_token (the template renders the
+    BOS literal itself and the engine prepends the metadata start_token
+    unconditionally), <｜hy_place▁holder▁no▁2｜> (120020) among the stop ids,
+    the vendor Jinja template embedded byte-equal to the repo's
+    chat_template.jinja, a bytes-per-parameter ratio in the int8 band, and
+    every section under the iOS ~2 GiB single-section mmap ceiling.
+    Needs `pip install litert-lm-builder`.
+
+      python verify_hy_mt2_1_8b.py model.litertlm --check-metadata
+
+  --translate — the model's actual task: three translation probes with the
+    source card's default prompt, greedy, HF bf16 reference vs the bundle
+    through the runtime. Reports byte-identity per probe (the published
+    bundle matches on 1 of 3; the other two are fluent int8-class alternates)
+    and passes when every runtime output is a non-degenerate translation.
+    Needs torch + transformers and the source checkpoint (3.6 GB).
+
+      python verify_hy_mt2_1_8b.py model.litertlm --translate [--device cpu|mps]
+
+  --rope-ab — the one-variable proof behind the rope bake: loads the model
+    twice on CPU, once from the vendor config (rope_scaling dynamic/alpha)
+    and once from the baked config (rope_theta 11,158,839.925…, no
+    rope_scaling), and asserts inv_freq and teacher-forced logits are
+    bitwise-equal. About a minute; the bundle is not needed.
+
+      python verify_hy_mt2_1_8b.py model.litertlm --rope-ab
+
+  --bos-discriminator WITH_START_TOKEN.litertlm — decides, inside the runtime
+    and with no HF/int8 confound, whether the engine prepends the metadata
+    start_token. Three streams over the same weights (CPU, greedy):
+      X  : the default bundle, --no-template, prompt = rendered text minus
+           its leading BOS string            -> [start_token?] + rest
+      Y' : this bundle, normal templating    -> [template BOS] + rest
+      X' : this bundle, --no-template, same BOS-stripped text -> rest only
+    If the engine prepends: X == Y' on every probe and X != X' somewhere.
+    Build the default bundle with `build_hy_mt2_1_8b.py --keep-start-token`.
+
+      python verify_hy_mt2_1_8b.py model.litertlm --bos-discriminator out_int8_bos/Hy-MT2-1.8B_int8.litertlm
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+MODEL_ID = "tencent/Hy-MT2-1.8B"
+EOS_ID = 120020
+# 2,038,515,712 tensors in the checkpoint minus the tied lm_head copy
+# (120818 x 2048 = 247,435,264) that the bundle stores once.
+UNIQUE_PARAMS = 2_038_515_712 - 120_818 * 2_048
+# The repo's chat_template.jinja (the only template the repo ships).
+TEMPLATE_BYTES = 654
+TEMPLATE_MD5 = "6d883d86c23cbdc6879c208513770884"
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+
+# The source model card's default translation prompt, verbatim.
+TRANSLATE_PROMPT = ("Translate the following text into {lang}. Note that you "
+                    "should **only output the translated result without any "
+                    "additional explanation**:\n\n{text}")
+# (target language, source text, regex the translation must match)
+PROBES = [
+    ("Japanese", "The weather is nice today, so let's go for a walk in the park.",
+     r"[぀-ヿ一-鿿]"),
+    ("French", "Machine translation has improved dramatically in recent years.",
+     r"traduction"),
+    ("English", "今日は天気がいいので、公園を散歩しましょう。", r"\bpark\b"),
+]
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5:
+    return True
+  return False
+
+
+def run_one(litert_lm, model, prompt, backend, timeout, no_template=False):
+  """Runs one prompt through `litert-lm run`, greedy; the answer is stdout."""
+  cmd = [litert_lm, "run", str(model), "--backend", backend,
+         "--temperature", "0", "--top-k", "1", "--cache", "no"]
+  if no_template:
+    cmd.append("--no-template")
+  cmd += ["--prompt", prompt]
+  proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  return proc.stdout.strip()
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      ans = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend,
+                    args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    low = ans.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not ans.strip()) or degenerate(ans)
+    results.append({"label": label, "question": q, "ok": ok,
+                    "degenerate": degen, "answer": ans})
+    shown = " ".join(ans.split())[:90] if ans.strip() else "(empty)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend,
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results,
+    }, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def read_metadata(model, jinja_path=None):
+  """Returns (LlmMetadata pbtext, [sections]) without unpacking the bundle.
+
+  With jinja_path, the embedded Jinja template is written there (the peek
+  API writes only that file when no dump dir is given)."""
+  from litert_lm_builder import litertlm_peek  # pip install litert-lm-builder
+
+  buf = io.StringIO()
+  litertlm_peek.peek_litertlm_file(str(model), None, buf,
+                                   jinja_prompt_template_path=jinja_path)
+  text = buf.getvalue()
+  m = re.search(r"start of LlmMetadata\n(.*?)>{4,} end of LlmMetadata", text, re.S)
+  pbtext = m.group(1) if m else ""
+  sections = []
+  for sm in re.finditer(
+      r"Section (\d+):\n(.*?)Begin Offset:\s*(\d+)\n\s*End Offset:\s*(\d+)\n"
+      r"\s*Data Type:\s*(\S+)", text, re.S):
+    items = sm.group(2)
+    mt = re.search(r"model_type, Value \(String\): (\S+)", items)
+    sections.append({"index": int(sm.group(1)), "type": sm.group(5),
+                     "model_type": mt.group(1) if mt else None,
+                     "bytes": int(sm.group(4)) - int(sm.group(3))})
+  return pbtext, sections
+
+
+def check_metadata(args):
+  with tempfile.TemporaryDirectory() as td:
+    jinja_path = os.path.join(td, "template.jinja")
+    pbtext, sections = read_metadata(args.model, jinja_path)
+    embedded = Path(jinja_path).read_bytes() if os.path.exists(jinja_path) else b""
+  if not pbtext:
+    print("FAIL: no LlmMetadata section found")
+    return 1
+  checks = []
+
+  def check(name, ok, detail=""):
+    checks.append(ok)
+    print(f"  [{'v' if ok else 'X'}] {name}{(': ' + detail) if detail else ''}")
+
+  has_start = bool(re.search(r"^\s*start_token\s*\{", pbtext, re.M))
+  check("no start_token (template renders the BOS literal; engine prepends)",
+        not has_start)
+
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", pbtext)}
+  check(f"<｜hy_place▁holder▁no▁2｜> ({EOS_ID}) is a stop-token id",
+        EOS_ID in stop_ids, f"stop ids {sorted(stop_ids)}")
+
+  md5 = hashlib.md5(embedded).hexdigest()
+  detail = f"{len(embedded)} B, md5 {md5[:8]}…"
+  try:  # live byte comparison when the Hub is reachable; else the recorded hash
+    from huggingface_hub import hf_hub_download
+    repo_tpl = Path(hf_hub_download(MODEL_ID, "chat_template.jinja")).read_bytes()
+    check("embedded Jinja template is byte-equal to the repo's chat_template.jinja",
+          embedded == repo_tpl, detail + f" vs repo {len(repo_tpl)} B")
+  except Exception as e:  # noqa: BLE001
+    check("embedded Jinja template matches the recorded repo template hash",
+          len(embedded) == TEMPLATE_BYTES and md5 == TEMPLATE_MD5,
+          detail + f" (Hub unreachable: {type(e).__name__})")
+
+  ctx = re.search(r"max_num_tokens:\s*(\d+)", pbtext)
+  check("max_num_tokens 4096", bool(ctx) and int(ctx.group(1)) == 4096,
+        ctx.group(1) if ctx else "missing")
+
+  total = os.path.getsize(args.model)
+  bpp = total / UNIQUE_PARAMS
+  check("bytes per unique parameter in the int8 band (0.9–1.35)",
+        0.9 <= bpp <= 1.35, f"{total:,} B / {UNIQUE_PARAMS:,} params = {bpp:.2f}")
+  big = [s for s in sections if s["bytes"] >= 2 * 1024 ** 3]
+  check("every section < 2 GiB (iOS mmap ceiling)", not big,
+        ", ".join(f"{s['type']}:{s['bytes'] / 1024 ** 3:.2f} GiB" for s in sections))
+  types = [s["type"] for s in sections]
+  check("dense bundle: LlmMetadata + tokenizer + one prefill/decode model, "
+        "no ExecutorMetadata needed", "ExecutorMetadataProto" not in types
+        and "TFLiteModel" in types, str(types))
+
+  sp = re.search(r"sampler_params \{.*?\n\}", pbtext, re.S)
+  if sp:
+    print("  (i) sampler_params from the vendor generation_config: "
+          + " ".join(sp.group(0).split()) + " — the gate overrides with "
+          "--temperature 0 --top-k 1")
+
+  ok = all(checks)
+  print(f"\n  {'PASS' if ok else 'FAIL'}: {sum(checks)}/{len(checks)} metadata checks")
+  return 0 if ok else 1
+
+
+def load_reference(device):
+  import torch
+  from transformers import AutoModelForCausalLM, AutoTokenizer
+
+  tok = AutoTokenizer.from_pretrained(MODEL_ID)
+  model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16)
+  return tok, model.to(device).eval()
+
+
+def translate(args):
+  import torch
+
+  device = args.device
+  if device == "auto":
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+  tok, model = load_reference(device)
+  rows, matches, passed = [], 0, 0
+  for lang, text, must in PROBES:
+    q = TRANSLATE_PROMPT.format(lang=lang, text=text)
+    rendered = tok.apply_chat_template([{"role": "user", "content": q}],
+                                       tokenize=False, add_generation_prompt=True)
+    ids = tok(rendered, add_special_tokens=False, return_tensors="pt").input_ids
+    with torch.no_grad():
+      out = model.generate(ids.to(device), max_new_tokens=128, do_sample=False,
+                           pad_token_id=tok.pad_token_id)
+    ref = tok.decode(out[0, ids.shape[1]:], skip_special_tokens=True).strip()
+    try:
+      rt = run_one(args.litert_lm, args.model, q, args.backend, args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on {lang}: {e}", file=sys.stderr)
+      return 2
+    same = rt == ref
+    ok = bool(rt) and not degenerate(rt) and bool(re.search(must, rt, re.I))
+    matches += same
+    passed += ok
+    rows.append({"lang": lang, "source": text, "hf_bf16": ref, "runtime": rt,
+                 "byte_identical": same, "ok": ok})
+    print(f"  [{'v' if ok else '.'}] {lang:9s} byte-identical={'yes' if same else 'no '}")
+    print(f"        HF bf16 : {ref!r}")
+    print(f"        runtime : {rt!r}")
+  print(f"\n  byte-identical to HF bf16 greedy: {matches}/{len(PROBES)}; "
+        f"valid non-degenerate translations: {passed}/{len(PROBES)}")
+  print(f"  VERDICT: {'PASS' if passed == len(PROBES) else 'FAIL'} "
+        f"(identity is reported, not required — int8 greedy may take a fluent "
+        "alternate)")
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend, "device": device,
+        "byte_identical": matches, "passed": passed, "rows": rows},
+        indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed == len(PROBES) else 1
+
+
+def rope_ab(args):
+  import torch
+  from huggingface_hub import snapshot_download
+  from transformers import AutoModelForCausalLM, AutoTokenizer
+
+  sys.path.insert(0, str(Path(__file__).resolve().parent))
+  from build_hy_mt2_1_8b import normalize_rope  # noqa: E402
+
+  snap = Path(snapshot_download(MODEL_ID, ignore_patterns=["train/*", "imgs/*", "*.png"]))
+  with tempfile.TemporaryDirectory() as td:
+    norm = normalize_rope(snap, Path(td))
+    a = AutoModelForCausalLM.from_pretrained(str(snap), dtype=torch.bfloat16).eval()
+    b = AutoModelForCausalLM.from_pretrained(str(norm), dtype=torch.bfloat16).eval()
+  ra, rb = a.model.rotary_emb, b.model.rotary_emb
+  inv_equal = torch.equal(ra.inv_freq.view(torch.int32), rb.inv_freq.view(torch.int32))
+  tok = AutoTokenizer.from_pretrained(str(snap))
+  msgs = [{"role": "user", "content":
+           "Translate to French: The quick brown fox jumps over the lazy dog."}]
+  ids = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=True,
+                                return_dict=True, return_tensors="pt")["input_ids"]
+  with torch.no_grad():
+    la = a(ids, use_cache=False).logits
+    lb = b(ids, use_cache=False).logits
+  logits_equal = torch.equal(la, lb)
+  print(f"  rope_type: {ra.rope_type} -> {rb.rope_type}; "
+        f"attention_scaling {float(ra.attention_scaling)} / {float(rb.attention_scaling)}")
+  print(f"  [{'v' if inv_equal else 'X'}] inv_freq bitwise-equal "
+        f"(max |diff| {float((ra.inv_freq - rb.inv_freq).abs().max()):g})")
+  print(f"  [{'v' if logits_equal else 'X'}] teacher-forced logits bitwise-equal "
+        f"over {int(ids.shape[1])} tokens (max |diff| {float((la - lb).abs().max()):g})")
+  ok = inv_equal and logits_equal
+  print(f"\n  VERDICT: {'PASS' if ok else 'FAIL'} — the bake is "
+        f"{'exact' if ok else 'NOT exact; do not ship'}")
+  return 0 if ok else 1
+
+
+def bos_discriminator(args):
+  from transformers import AutoTokenizer
+
+  tok = AutoTokenizer.from_pretrained(MODEL_ID)
+  with_bos, nobos = Path(args.bos_discriminator), args.model
+  if not with_bos.exists():
+    print(f"ERROR: {with_bos} not found (build it with --keep-start-token)",
+          file=sys.stderr)
+    return 2
+  rows = []
+  for lang, text, _ in PROBES:
+    q = TRANSLATE_PROMPT.format(lang=lang, text=text)
+    rendered = tok.apply_chat_template([{"role": "user", "content": q}],
+                                       tokenize=False, add_generation_prompt=True)
+    assert rendered.startswith(tok.bos_token), "template no longer renders a BOS literal"
+    stripped = rendered[len(tok.bos_token):]
+    try:
+      x = run_one(args.litert_lm, with_bos, stripped, "cpu", args.timeout, no_template=True)
+      yp = run_one(args.litert_lm, nobos, q, "cpu", args.timeout)
+      xp = run_one(args.litert_lm, nobos, stripped, "cpu", args.timeout, no_template=True)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on {lang}: {e}", file=sys.stderr)
+      return 2
+    rows.append({"lang": lang, "X": x, "Yp": yp, "Xp": xp,
+                 "X_eq_Yp": x == yp, "X_eq_Xp": x == xp})
+    print(f"  {lang:9s} X==Y' {'yes' if x == yp else 'NO '}   X==X' {'yes' if x == xp else 'no '}")
+    print(f"        X  [start_token]+rest : {x!r}")
+    print(f"        Y' [template BOS]+rest: {yp!r}")
+    print(f"        X' rest only          : {xp!r}")
+  all_xy = all(r["X_eq_Yp"] for r in rows)
+  all_xx = all(r["X_eq_Xp"] for r in rows)
+  verdict = ("engine prepends start_token (X == Y' everywhere, X != X' somewhere) "
+             "-> the default export fed BOS twice; dropping it is correct"
+             if all_xy and not all_xx else
+             "engine does NOT prepend (X == X' everywhere, X != Y' somewhere)"
+             if all_xx and not all_xy else "inconclusive on these probes")
+  print(f"\n  VERDICT: {verdict}")
+  if args.json:
+    Path(args.json).write_text(json.dumps({"with_start_token": str(with_bos),
+                                           "model": str(nobos), "verdict": verdict,
+                                           "rows": rows}, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if (all_xy and not all_xx) else 1
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / metadata / task checks for Hy-MT2-1.8B")
+  ap.add_argument("model", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--timeout", type=int, default=900,
+                  help="seconds per prompt (engine init is paid every run)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--device", default="auto",
+                  help="--translate: HF reference device (cpu|mps|auto; the "
+                       "recorded numbers are CPU)")
+  ap.add_argument("--json", help="write a JSON report here")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--translate", action="store_true")
+  ap.add_argument("--rope-ab", action="store_true")
+  ap.add_argument("--bos-discriminator", metavar="WITH_START_TOKEN_BUNDLE")
+  args = ap.parse_args()
+
+  if not args.rope_ab and not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  if args.translate:
+    return translate(args)
+  if args.rope_ab:
+    return rope_ab(args)
+  if args.bos_discriminator:
+    return bos_discriminator(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/models/nemotron/nemotron_3_nano_4b/README.md
+++ b/models/nemotron/nemotron_3_nano_4b/README.md
@@ -1,0 +1,3 @@
+# Nemotron 3 Nano 4B Language Model
+
+Model recipes, conversion scripts, instructions, and utilities for Nemotron-3-Nano-4B on-device reasoning ([nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16)).

--- a/models/nemotron/nemotron_3_nano_4b/converted/.gitignore
+++ b/models/nemotron/nemotron_3_nano_4b/converted/.gitignore
@@ -1,0 +1,5 @@
+*.litertlm
+out_*/
+__pycache__/
+litert-torch-nemotron/
+work_unpack/

--- a/models/nemotron/nemotron_3_nano_4b/converted/README.md
+++ b/models/nemotron/nemotron_3_nano_4b/converted/README.md
@@ -1,0 +1,93 @@
+# Nemotron-3-Nano-4B Conversion
+
+Model recipes, instructions, scripts, and utilities for converting Nemotron-3-Nano-4B to LiteRT-LM.
+
+These scripts convert [nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16) (`NemotronHForCausalLM`, 3.97 B parameters, [NVIDIA Nemotron Open Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-nemotron-open-model-license/)) into a `.litertlm` bundle for the [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) runtime, and verify the result with a think-aware quality gate, a metadata check, and two one-variable reproducers. The published artifact is `Nemotron-3-Nano-4B_int8.litertlm` (4.13 GB) at [litert-community/Nemotron-3-Nano-4B](https://huggingface.co/litert-community/Nemotron-3-Nano-4B). **Requires litert-lm ≥ 0.15**, which is where the runtime started binding hybrid state through the `ExecutorMetadata` section.
+
+The model is a three-kind hybrid: **21 Mamba2 selective-scan layers + 17 plain MLP layers + 4 grouped-query attention layers** (42 in all, `hybrid_override_pattern` `M-M-M-MM-M-M*-M-M*-M-M-M*-M-M-MM*-MMM-M-M-`), hidden 3136, 40 query / 8 KV heads, mamba 96 heads × 80 dim (state 128, conv kernel 4, 8 groups), vocab 131,072, untied embeddings. It is a reasoning model: ChatML turns, and every reply opens with a `<think>` block. Only the 4 attention layers keep KV; the mamba layers carry constant-size conv + SSM state and the MLP layers none — **50 state buffers** in total, so memory stays nearly flat with context.
+
+No released litert-torch (0.9.3, 0.9.4) carries a Mamba2 cache layer — 0.9.4's generic path maps the mamba layers to a linear-attention cache and dies before tracing (measured on a granite-4.0-h checkpoint, the same Mamba2 cache gap; no released wheel was run on this checkpoint). This recipe therefore pins a litert-torch checkout and applies **`nemotron_h_litert_torch.patch`** (1,878 added lines: the NemotronH export extension, the granite-4-h extension it ports its scan from, and a hybrid cache with a cache-less layer type). What this conversion documents is the **family recipe** (six steps, each with its measured reason), the **`--cache no` GPU trap** (isolated as a one-variable comparison), and three facts from evaluating the checkpoint — `auto_map` is not proof of remote code, the ≥3B prefill ladder, and a spurious `start_token` the model happens to tolerate.
+
+## Build
+
+| recipe | quantization | file | use |
+|---|---|---|---|
+| `int8` | post-hoc dynamic int8 on linears + embedding (convolutions and the selective scan stay float); fp32 activations declared | 4.13 GB | desktop CPU, desktop GPU with `--cache no`; phone not measured |
+
+## Environment
+
+```bash
+pip install litert-converter==0.3.1 ai-edge-quantizer==0.8.0 ai-edge-litert==2.1.6 \
+    litert-lm-builder==0.15.0 transformers==5.14.1 torch==2.12.1
+pip install litert-lm   # verification CLI (>= 0.15; 0.16.0 used here)
+python build_nemotron_3_nano_4b.py --setup   # clones litert-torch @ 115a1360 (2026-06-19) into ./litert-torch-nemotron and applies the patch
+```
+
+The build script puts the patched checkout first on `sys.path` and refuses to run if `litert_torch` imports from anywhere else. A released `litert-torch` wheel may be installed alongside; it is not used. The published bundle was built with this checkout + patch on the pinned dependencies above, packaged with litert-lm-builder 0.15/0.16 and gated with litert-lm 0.16.0.
+
+## Run
+
+```bash
+python build_nemotron_3_nano_4b.py --out out_int8                                   # ~9 min on an M4 Max; a 15.97 GB float intermediate plus converter temporaries
+python verify_nemotron_3_nano_4b.py out_int8/*.litertlm --backend cpu               # 8-question gate, think-aware
+python verify_nemotron_3_nano_4b.py out_int8/*.litertlm --backend gpu               # same, GPU (the script always passes --cache no)
+python verify_nemotron_3_nano_4b.py out_int8/*.litertlm --check-metadata            # start_token, stops, template, 50 state buffers, fp32
+python verify_nemotron_3_nano_4b.py out_int8/*.litertlm --cache-ab                  # GPU with the default cache vs --cache no
+python verify_nemotron_3_nano_4b.py out_int8/*.litertlm --bos-ab                    # HF bf16 greedy with / without the leading <s>
+```
+
+## The family recipe, step by step
+
+`build_nemotron_3_nano_4b.py` exports once in float and then edits the bundle through the litert-lm-builder pack/unpack API — one unpack, one pack; the weights are quantized once and never touched again.
+
+1. **Float export through the patched exporter** — bundle, vendor Jinja embedded verbatim, 4096-token KV budget for the 4 attention layers, reduced 7-signature prefill ladder (1024/256/64/16/4/1 + decode). The patch's scan is a *port*, not reuse: NemotronH's `torch_forward` is an older spelling of the same SSD idiom as granite-4-h, with a min-only `dt` clamp (pads must be forced to `dt = 0` *after* the clamp or a partially filled prefill chunk decays the state) and two width-0 `d_mlp` slices in the in_proj split. The lesson that cost the most time: `NemotronHBlock` picks its mixer class from a module-level `MIXER_TYPES` dict bound at import, so swapping the class attribute alone exports the **unrewritten reference scan** — with every parity gate green, because reference math is correct math. A parity gate can never prove which scan form got traced; only a padded-prefill sweep can. The patch swaps the dict entry and asserts loudly that its mixers were instantiated.
+2. **Post-hoc int8 on the linears and the embedding only.** `FULLY_CONNECTED` and `EMBEDDING_LOOKUP` (channelwise) go to dynamic int8; the causal convolutions and the selective scan stay float. Export-time int8 quantizes the convolutions too; the one export-time-int8 comparison on a hybrid of another family scored lower on the gate (cause not isolated between the recipe and the template shape), and keeping the state path float is the rule every published bundle of the granite-4-h, Qwen3.5 and Nemotron-H families ships with. 3.97 B parameters → 4,126,697,184 B, 1.04 bytes/param.
+3. **An `ExecutorMetadata` section.** litert-lm ≥ 0.15 binds per-layer state buffers through it; without one a state-carrying bundle fails at inference with `NOT_FOUND: The given map is missing some output TensorBuffers`. The pinned exporter writes none, so the script reads the decode signature's `kv_cache_*` inputs and declares them: `kv_cache_mc_N` / `kv_cache_mr_N` (mamba conv and recurrent state, 21 + 21) as `TYPE_LINEAR_ATTENTION`, opaque to the executor; `kv_cache_k_N` / `kv_cache_v_N` (attention, 4 + 4) with their sequence axis and the 4096 maximum. 50 buffers, cross-checked against the layer pattern.
+4. **`<|im_end|>` (id 11) added to the stop set.** The vendor `generation_config` declares only `eos_token_id: 2`, so the export carries id 2 plus the template-derived string `"<|im_end|>\n"`. The tokenizer's own `eos_token` is `<|im_end|>` = 11; the recipe adds it as an id-level stop. (The case that made this guard exist was measured on another family whose bundle never stopped; here the string form was already present, and the id is belt-and-braces.)
+5. **The metadata `start_token` dropped.** The bundler sets `start_token` from `tokenizer.bos_token` (`<s>`) without consulting `add_bos_token: False`, and the template opens with `<|im_start|>` — the model was never trained on a leading `<s>`. `--bos-ab` measures the consequence on the bf16 model: greedy decoding of the same rendered prompt with and without the `<s>` is **byte-identical on 2 of 3 probes**; the third diverges at token 28, inside the thought, and reaches the same final answer. The gate scores 7/8 with the field and 7/8 without it (same single miss). So at 4B this is a stream-fidelity fix, not a rescue — the 350M granite sibling is where the same mismatch bites. The published sibling Nemotron-H-4B bundle carries the field; no defect claim is made for it.
+6. **`prefer_activation_type = fp32` declared on the model section.** The GPU executor runs activations in fp16 by default; on these hybrids the scan's intermediates leave that range and the engine's sampler reports invalid results and emits token 0 (measured on sibling hybrids, which is why this is the family rule — the fp16 arm was not measured on this checkpoint; `--fp16-activations` builds it for study). The GPU gate below is the fp32 bundle.
+
+## GPU needs `--cache no`
+
+Same runner, same file, one flag flipped (litert-lm 0.16.0, M4 Max):
+
+- `litert-lm run --backend gpu` (default compiled-graph cache): fails with WebGPU `Invalid BindGroup` validation errors; an 8-question sweep through the Mac verifier, which has no cache flag, returned token soup — `<unk>[INST]<SPECIAL_22>…` on every question, 0/8.
+- `litert-lm run --backend gpu --cache no`: answers, **8/8**.
+
+The cache path is where it goes wrong; the root cause is not isolated further here, and the two symptoms (a validation error vs. token soup) are not asserted to be the same bug. The sibling Nemotron-H-4B card documents the same invocation, so treat it as a family-level caveat, not a property of this checkpoint. Two operational consequences: `verify_nemotron_3_nano_4b.py` passes `--cache no` on every run (on CPU the cache is a weight-sized file written next to the model), and a green CPU gate says nothing about GPU for this family — gate the backend you ship. `--cache-ab` reproduces the comparison in two runs.
+
+## Three facts from evaluating the checkpoint
+
+- **`auto_map` is not proof of remote code.** The repo declares `auto_map` (a back-compat shim for older transformers), and a converter that refuses on `auto_map` alone refuses this model for no reason. transformers 5.14.1 registers `nemotron_h` natively, so without `trust_remote_code` the library implementation loads and the repo's Python is never imported (`AutoConfig.from_pretrained` returns transformers' own `NemotronHConfig`; the export ran with `trust_remote_code: False`). Refuse only when `auto_map` is present *and* the model_type is absent from `CONFIG_MAPPING`.
+- **≥3B exports use the reduced 7-signature ladder.** Every exported signature costs engine RAM whether or not it is called: a 12 GB iPhone jetsam-kills a 248k-vocab hybrid 4B during engine creation with the full 11-signature ladder, and the export's converter passes scale with the merged module (a full-ladder 4B export was killed three times on a 128 GB host). Both measured on a Qwen3.5-4B-class hybrid — a different model family, not this checkpoint or its Nemotron-H sibling; no correctness cost — the runtime plans coarser prefill chunks.
+- **The template to compare against is the one `AutoTokenizer` resolves.** The embedded Jinja is byte-equal to the repo's `chat_template.jinja` (10,504 / 10,504 bytes). The same repo's `tokenizer_config.json` carries a *different* 10,497-byte copy; compare against that one and you report a false mismatch.
+
+## Verification results
+
+Measured on the published bundle with `verify_nemotron_3_nano_4b.py`, litert-lm 0.16.0, Mac M4 Max, re-run 2026-08-30 (thought budget: none imposed — the CLI runs to the stop token; thoughts on the gate are 17–48 words):
+
+- **8-question gate: CPU 7/8, GPU (`--cache no`) 8/8**, non-degenerate. The single CPU miss is the rhyme completion — it answers "purple" where the gate wants "blue"; the GPU run answers "blue". Every arithmetic, factual and translation item is correct on both backends. Threshold is 6/8.
+- **`--check-metadata` 9/9**: no `start_token`; stop ids {2, 11}; embedded Jinja byte-equal to the repo's `chat_template.jinja`; `max_num_tokens` 4096; `ExecutorMetadata` present with 42 linear-attention + 8 K/V buffers, attention caches sized to 4096; `prefer_activation_type` fp32; 1.04 bytes/param. The weights are one 3.84 GiB section (this recipe path does not externalize the embedder).
+- **`--cache-ab`**: the default-cache arm exits 0 with an **empty** reply and `Validation error: Buffer size (54896640) wrapping…` followed by `[Invalid BindGroup] is invalid due to a previous error` on stderr, and leaves a 93 MB program cache and a 3,972 MB weight cache next to the model (the script removes them); the `--cache no` arm answers "42.".
+- **`--bos-ab`** (HF bf16, MPS, `use_cache=False`, 96 new tokens): identical on 2 of 3, third diverges at token 28 with the same final answer (こんにちは).
+
+Rebuilt from scratch with `build_nemotron_3_nano_4b.py` on the pinned checkout (2026-08-30, 9 min end to end on an M4 Max, float intermediate 15.97 GB): 4,126,697,184 bytes, **byte-identical to the published bundle in every section** — LlmMetadata (10,543 B, including the stop-token edit and the dropped start_token), ExecutorMetadata (3,365 B, all 50 buffers), tokenizer (2,806,488 B) and the model (4,123,829,984 B); the 193 differing bytes are the file header's uuid, creation timestamp and an `Authors` key. The rebuild passes the same 9/9 metadata checks and gates CPU 7/8 / GPU (`--cache no`) 8/8 with the same answers.
+
+Mac (M4 Max, `litert-lm benchmark`, `-p 256 -d 256 --runs 3 --cache no`, litert-lm 0.16.0; two independent runs per cell):
+
+| backend | prefill tok/s | decode tok/s | TTFT | init |
+|---|---|---|---|---|
+| GPU (Metal, `--cache no`) | 803 / 792 | 83.3 / 82.4 | 0.33 / 0.34 s | 7.2 / 7.4 s |
+| CPU | 99.6 / 113.3 | 22.7 / 22.5 | 2.64 / 2.30 s | 25.7 / 24.9 s |
+
+GPU repeats within 1.4%; CPU prefill spreads 13%, partly because the host was **not idle** during these runs (a concurrent export) — read the CPU column as an order of magnitude. `--cache no` is part of the protocol, not tidiness: with the cache the benchmark reports a much faster CPU prefill (395 tok/s was measured that way) because it is not doing the same work.
+
+**Not measured on a phone.** A 4B of this family did not fit an 8 GB Android phone when the sibling Nemotron-H-4B was measured (engine creation aborts on both backends), so expect to need a higher-RAM device; that is an expectation carried over from a different bundle, not a measurement of this one.
+
+## Files
+
+| File | What |
+|---|---|
+| `build_nemotron_3_nano_4b.py` | `--setup` pins and patches litert-torch; then HF checkpoint → float export → post-hoc int8 (linears + embedding) → `ExecutorMetadata` (50 buffers) → stop id 11 → `start_token` dropped → fp32 activations → `.litertlm`. `--keep-start-token`, `--fp16-activations`, `--keep-float` for study. |
+| `nemotron_h_litert_torch.patch` | Against litert-torch `115a13607c730c81018bb9789138a3e5e5119e3d`: `model_ext/nemotron_h` (folded rank≤4 SSD scan port with the pad guard and the `MIXER_TYPES` swap), `model_ext/granitemoehybrid` (the scan it derives from), `core/cache.py` (hybrid cache; cache-less layer type for the MLP blocks). Apache-2.0 headers. |
+| `verify_nemotron_3_nano_4b.py` | Think-aware 8-question gate via the `litert-lm` CLI (always `--cache no`); `--check-metadata`; `--cache-ab` (the GPU trap, one variable); `--bos-ab` (HF bf16 greedy with / without the leading `<s>`). |

--- a/models/nemotron/nemotron_3_nano_4b/converted/build_nemotron_3_nano_4b.py
+++ b/models/nemotron/nemotron_3_nano_4b/converted/build_nemotron_3_nano_4b.py
@@ -1,0 +1,327 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16 (NemotronHForCausalLM hybrid) -> .litertlm.
+
+A three-kind hybrid: 21 Mamba2 selective-scan layers + 17 plain MLP layers +
+4 grouped-query attention layers (42 in all, pattern
+`M-M-M-MM-M-M*-M-M*-M-M-M*-M-M-MM*-MMM-M-M-`). No released litert-torch
+carries a Mamba2 cache layer, so this recipe pins a litert-torch checkout
+(115a1360, 2026-06-19) and applies `nemotron_h_litert_torch.patch` — the
+folded rank<=4 SSD scan port, a cache-less layer type for the MLP blocks, and
+the generic hybrid cache — then runs the family recipe:
+
+  1. float export through the patched exporter (bundle, embedded Jinja,
+     4096-token KV budget for the 4 attention layers, reduced 7-signature
+     prefill ladder 1024/256/64/16/4/1 + decode);
+  2. post-hoc dynamic int8 on the linears and the embedding ONLY — the
+     causal convolutions and the selective scan stay float — the rule every
+     published bundle of this and the sibling hybrid families ships with
+     (an export-time-int8 comparison on another family's hybrid scored
+     lower; cause not isolated);
+  3. an ExecutorMetadata section: litert-lm >= 0.15 binds per-layer state
+     buffers through it, and the pinned exporter does not write one. The
+     50 buffers (42 mamba conv+SSM, 8 attention K/V) are named from the
+     decode signature;
+  4. `<|im_end|>` (id 11) added to the stop set — generation_config declares
+     only id 2, and the vendor template's ChatML turns end with <|im_end|>;
+  5. the metadata `start_token` (`<s>`) dropped: the tokenizer says
+     `add_bos_token: False` and the template opens with `<|im_start|>`, so a
+     start token would be a stream the model never trained on. At 4B the
+     model is robust either way (gate 7/8 with and without; HF greedy
+     byte-identical on 2 of 3 probes) — this aligns the runtime stream with
+     the training stream, it does not rescue anything;
+  6. `prefer_activation_type = fp32` declared on the model section: the GPU
+     executor runs activations in fp16 by default and the SSM scan's
+     intermediates do not fit that range.
+
+Every step edits the bundle through the litert-lm-builder pack/unpack API;
+the weights are quantized once and never touched again.
+
+Usage:
+  python build_nemotron_3_nano_4b.py --setup             # one-time: clone + pin + patch
+  python build_nemotron_3_nano_4b.py --out out_int8      # ~9 min on an M4 Max; 16 GB float intermediate
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+FINAL_NAME = "Nemotron-3-Nano-4B_int8.litertlm"
+HERE = Path(__file__).resolve().parent
+PATCH = HERE / "nemotron_h_litert_torch.patch"
+PIN = "115a13607c730c81018bb9789138a3e5e5119e3d"
+LITERT_TORCH_GIT = "https://github.com/google-ai-edge/litert-torch"
+IM_END_ID = 11  # <|im_end|>, the tokenizer's eos
+
+
+def setup_checkout(checkout):
+  """Clones litert-torch at the pinned commit and applies the hybrid patch."""
+  if (checkout / "litert_torch/generative/export_hf/model_ext/nemotron_h/patch.py").exists():
+    print(f"checkout already set up: {checkout}")
+    return
+  if not checkout.exists():
+    subprocess.run(["git", "clone", LITERT_TORCH_GIT, str(checkout)], check=True)
+  subprocess.run(["git", "-C", str(checkout), "fetch", "origin", PIN], check=True)
+  subprocess.run(["git", "-C", str(checkout), "checkout", PIN], check=True)
+  subprocess.run(["git", "-C", str(checkout), "apply", str(PATCH)], check=True)
+  print(f"checkout ready: {checkout} @ {PIN[:8]} + {PATCH.name}")
+
+
+def use_checkout(checkout):
+  """Puts the patched tree first on sys.path and proves it is what imports."""
+  ext = checkout / "litert_torch/generative/export_hf/model_ext/nemotron_h/patch.py"
+  if not ext.exists():
+    raise SystemExit(f"{checkout} is not the patched checkout — run --setup first")
+  sys.path.insert(0, str(checkout))
+  import litert_torch  # noqa: E402
+  got = Path(litert_torch.__file__).resolve()
+  if checkout.resolve() not in got.parents:
+    raise SystemExit(f"litert_torch imported from {got}, not the pinned checkout")
+  print(f"litert_torch: {got.parent} (pinned {PIN[:8]} + patch)")
+
+
+def expected_state_buffers(model_dir):
+  cfg = json.loads((Path(model_dir) / "config.json").read_text())
+  pat = cfg["hybrid_override_pattern"]
+  return 2 * pat.count("M"), 2 * pat.count("*"), pat
+
+
+def float_export(model, out, prefill, cache):
+  from litert_torch.generative.export_hf.export import export
+
+  export(
+      model=model,
+      output_dir=str(out),
+      prefill_lengths=prefill,
+      cache_length=cache,
+      # "" (not None) — None would fall through to the exporter's default
+      # dynamic int8, which quantizes the convolutions too. The int8 recipe
+      # this family ships is applied post hoc in quantize_int8().
+      quantization_recipe="",
+      use_jinja_template=True,
+      bundle_litert_lm=True,
+  )
+  bundle = out / "model.litertlm"
+  if not bundle.exists():
+    raise SystemExit("export finished without producing model.litertlm")
+  print(f"float export: {bundle} ({os.path.getsize(bundle):,} B)")
+  return bundle
+
+
+def quantize_int8(tflite):
+  """Dynamic int8 on FULLY_CONNECTED + EMBEDDING_LOOKUP (channelwise); convs
+  and the scan stay float. Rewrites the tflite in place."""
+  from ai_edge_quantizer import qtyping, quantizer, recipe_manager
+
+  rm = recipe_manager.RecipeManager()
+  rm.add_dynamic_config(regex=".*", operation_name=qtyping.TFLOperationName.FULLY_CONNECTED,
+                        num_bits=8)
+  rm.add_dynamic_config(regex=".*", operation_name=qtyping.TFLOperationName.EMBEDDING_LOOKUP,
+                        num_bits=8, granularity=qtyping.QuantGranularity.CHANNELWISE)
+  qt = quantizer.Quantizer(str(tflite), rm.get_quantization_recipe())
+  if qt.need_calibration:
+    raise SystemExit("recipe unexpectedly needs calibration")
+  before = os.path.getsize(tflite)
+  qpath = tflite.with_suffix(".int8.tflite")
+  qt.quantize().export_model(str(qpath))
+  qpath.replace(tflite)
+  print(f"int8 (linears + embedding): {before / 1e9:.2f} GB -> "
+        f"{os.path.getsize(tflite) / 1e9:.2f} GB")
+
+
+def read_state_buffers(tflite):
+  """[(name, shape)] for every kv_cache_* input of the decode signature."""
+  from ai_edge_litert.interpreter import Interpreter
+
+  it = Interpreter(model_path=str(tflite))
+  sigs = it.get_signature_list()
+  key = "decode" if "decode" in sigs else sorted(sigs)[0]
+  details = it.get_signature_runner(key).get_input_details()
+  names = sorted(n for n in sigs[key]["inputs"] if n.startswith("kv_cache_"))
+  return [(n, [int(x) for x in details[n]["shape"]]) for n in names]
+
+
+def executor_pbtext(buffers):
+  """The ExecutorMetadata the runtime binds hybrid state through.
+
+  Exporter naming: kv_cache_mc_N the mamba conv state, kv_cache_mr_N the
+  mamba recurrent (SSM) state — both TYPE_LINEAR_ATTENTION, opaque to the
+  executor (c/s and lc/lr are the ShortConv and linear-attention spellings of
+  other hybrids); kv_cache_k_N / _v_N the attention caches with their
+  sequence axis.
+  """
+  blocks = []
+  for name, shape in buffers:
+    kind = name.split("_")[2]
+    if kind in ("mc", "mr", "c", "s", "lc", "lr"):
+      typ, extra = "TYPE_LINEAR_ATTENTION", ""
+    elif kind in ("k", "v"):
+      typ = "TYPE_GLOBAL_KEY_CACHE" if kind == "k" else "TYPE_GLOBAL_VALUE_CACHE"
+      axis = shape.index(max(shape))
+      extra = f"\n    sequence_axis: {axis}\n    maximum_sequence_length: {max(shape)}"
+    else:
+      raise SystemExit(f"unknown state tensor kind for {name}")
+    blocks.append(
+        "  state_buffers {\n"
+        f'    prefill_input_name: "{name}"\n'
+        f'    prefill_output_name: "{name}"\n'
+        f'    decode_input_name: "{name}"\n'
+        f'    decode_output_name: "{name}"\n'
+        f"    type: {typ}{extra}\n"
+        "  }")
+  return "llm_executor_metadata {\n  max_history_size: 0\n" + "\n".join(blocks) + "\n}\n"
+
+
+def strip_block(pbtext, field="start_token"):
+  """Drops a top-level `field { ... }` block from a text-format proto
+  (brace-counting: the block nests, and stop_tokens share the shape)."""
+  m = re.search(rf"^{field}\s*\{{", pbtext, re.M)
+  if not m:
+    return pbtext, False
+  i = pbtext.index("{", m.start())
+  depth = 0
+  for j in range(i, len(pbtext)):
+    if pbtext[j] == "{":
+      depth += 1
+    elif pbtext[j] == "}":
+      depth -= 1
+      if depth == 0:
+        end = j + 1
+        while end < len(pbtext) and pbtext[end] == "\n":
+          end += 1
+        return pbtext[:m.start()] + pbtext[end:], True
+  raise SystemExit(f"unbalanced braces in {field} block")
+
+
+def finalize(float_bundle, out, model_dir, keep_start_token, fp16_activations):
+  """One unpack -> quantize + executor metadata + metadata edits -> one pack."""
+  from litert_lm_builder import pack_litertlm_file, unpack_litertlm_file
+
+  work = out / "work_unpack"
+  shutil.rmtree(work, ignore_errors=True)
+  toml_path = Path(unpack_litertlm_file(str(float_bundle), str(work)))
+  toml = toml_path.read_text()
+  m = re.search(r'section_type = "TFLiteModel"\n(?:.*\n)*?data_path = "([^"]+)"', toml)
+  if not m:
+    raise SystemExit("model.toml has no TFLiteModel section")
+  tflite = work / m.group(1)
+
+  quantize_int8(tflite)
+
+  buffers = read_state_buffers(tflite)
+  n_la = sum(1 for n, _ in buffers if n.split("_")[2] in ("mc", "mr", "c", "s", "lc", "lr"))
+  n_kv = sum(1 for n, _ in buffers if n.split("_")[2] in ("k", "v"))
+  want_la, want_kv, pat = expected_state_buffers(model_dir)
+  print(f"state buffers: {len(buffers)} = {n_la} mamba conv+SSM + {n_kv} attention K/V "
+        f"(layer pattern {pat})")
+  if (n_la, n_kv) != (want_la, want_kv):
+    raise SystemExit(f"expected {want_la} + {want_kv} state buffers from the config "
+                     "— the patched cache layer did not export the layout it should")
+  (work / "ExecutorMetadataProto.pbtext").write_text(executor_pbtext(buffers))
+  marker = 'data_path = "LlmMetadataProto.pbtext"\n'
+  if marker not in toml or "ExecutorMetadata" in toml:
+    raise SystemExit("unexpected model.toml layout")
+  toml = toml.replace(marker, marker + '\n[[section]]\nsection_type = "ExecutorMetadata"\n'
+                      'data_path = "ExecutorMetadataProto.pbtext"\n')
+  if not fp16_activations:
+    toml = toml.replace('section_type = "TFLiteModel"',
+                        'section_type = "TFLiteModel"\nprefer_activation_type = "fp32"')
+  toml_path.write_text(toml)
+
+  pb = work / "LlmMetadataProto.pbtext"
+  text = pb.read_text()
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", text)}
+  if IM_END_ID not in stop_ids:
+    block = re.search(r"stop_tokens \{.*?\n\}", text, re.S)
+    if not block:
+      raise SystemExit("no stop_tokens block to extend")
+    text = text.replace(block.group(0), block.group(0) +
+                        "\nstop_tokens {\n  token_ids {\n    ids: %d\n  }\n}" % IM_END_ID, 1)
+    print(f"stop tokens: added <|im_end|> ({IM_END_ID}) to {sorted(stop_ids)}")
+  if not re.search(r"^start_token\s*\{", text, re.M):
+    raise SystemExit("no start_token in the export — the bundler's behaviour changed; "
+                     "re-check the BOS story before shipping")
+  if keep_start_token:
+    print("start_token: KEPT on request (<s>, a stream the model never trained on; "
+          "for study only)")
+  else:
+    text, _ = strip_block(text, "start_token")
+    print("start_token: dropped (add_bos_token False, template opens with <|im_start|>)")
+  pb.write_text(text)
+
+  final = out / FINAL_NAME
+  if final.exists():
+    final.unlink()
+  pack_litertlm_file(str(toml_path), str(final))
+  shutil.rmtree(work, ignore_errors=True)
+  return final
+
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+  ap.add_argument("--model", default=MODEL_ID,
+                  help="HF model id or a local checkout of it")
+  ap.add_argument("--out", default="out_int8", help="output dir")
+  ap.add_argument("--checkout", default=str(HERE / "litert-torch-nemotron"),
+                  help="the pinned, patched litert-torch tree (see --setup)")
+  ap.add_argument("--setup", action="store_true",
+                  help="clone litert-torch at the pinned commit into --checkout "
+                       "and apply the patch, then exit")
+  ap.add_argument("--cache", type=int, default=4096,
+                  help="KV budget for the 4 attention layers (mamba state is "
+                       "constant-size, MLP layers hold none)")
+  ap.add_argument("--prefill", default="1024,256,64,16,4,1",
+                  help="comma-separated prefill signature ladder (the published "
+                       "bundle carries these six: every exported signature costs "
+                       "engine RAM whether or not it is called)")
+  ap.add_argument("--keep-float", action="store_true",
+                  help="keep the float model.litertlm next to the int8 bundle")
+  ap.add_argument("--keep-start-token", action="store_true",
+                  help="do not drop the metadata start_token (study only)")
+  ap.add_argument("--fp16-activations", action="store_true",
+                  help="do not declare fp32 activations (study only: the GPU "
+                       "executor then runs the scan in fp16)")
+  args = ap.parse_args()
+
+  checkout = Path(args.checkout)
+  if args.setup:
+    setup_checkout(checkout)
+    return
+  use_checkout(checkout)
+
+  out = Path(args.out)
+  out.mkdir(parents=True, exist_ok=True)
+  model_dir = Path(args.model)
+  if not model_dir.exists():
+    from huggingface_hub import snapshot_download
+    model_dir = Path(snapshot_download(args.model))
+
+  prefill = [int(x) for x in args.prefill.split(",") if x.strip()]
+  float_bundle = float_export(args.model, out, prefill, args.cache)
+  final = finalize(float_bundle, out, model_dir, args.keep_start_token,
+                   args.fp16_activations)
+  if not args.keep_float:
+    float_bundle.unlink()
+  print(f"EXPORT_DONE {final} ({os.path.getsize(final):,} B)")
+
+
+if __name__ == "__main__":
+  main()

--- a/models/nemotron/nemotron_3_nano_4b/converted/nemotron_h_litert_torch.patch
+++ b/models/nemotron/nemotron_3_nano_4b/converted/nemotron_h_litert_torch.patch
@@ -1,0 +1,1971 @@
+diff --git a/litert_torch/generative/export_hf/core/cache.py b/litert_torch/generative/export_hf/core/cache.py
+index 5c13dea..5914fe2 100644
+--- a/litert_torch/generative/export_hf/core/cache.py
++++ b/litert_torch/generative/export_hf/core/cache.py
+@@ -116,6 +116,10 @@ class LiteRTLMCacheLayer(cache_base_lib.LiteRTLMCacheLayerMixin):
+   is_compileable = True
+   is_sliding = False
+ 
++  def get_max_length(self) -> int:
++    # transformers >= 5.14 Cache ABC requirement (upstream returns max_cache_len).
++    return self.max_cache_len
++
+   def __init__(
+       self,
+       key_cache: KeyCache,
+@@ -437,10 +441,675 @@ class LiteRTLMConvCacheLayer(
+     )
+ 
+ 
++class LiteRTLMLinearAttentionCacheLayer(
++    cache_base_lib.LiteRTLMCacheLayerMixin,
++    cache_utils.LinearAttentionCacheLayerMixin,
++):
++  """Conv + recurrent state cache layer for gated-delta-net / linear-attention layers.
++
++  Used for HF arches whose `layer_types[i] == "linear_attention"` (e.g. Qwen3.5's
++  GatedDeltaNet). Unlike LiteRTLMConvCacheLayer (conv state only — LFM2 ShortConv), a
++  gated-delta-net layer also carries a per-head recurrent state, so this layer holds BOTH
++  `conv_states` and `recurrent_states`. Registering it for "linear_attention" is what makes
++  the export cache actually contain a LinearAttention layer, so the model's own
++  `cache.has_previous_state(...)` no longer raises mid-trace.
++  """
++
++  is_compileable = True
++  is_sliding = False
++
++  def get_max_length(self) -> int:
++    # transformers >= 5.14 Cache ABC: -1 = no sequence-length dimension
++    # (linear-attention recurrent state), per the base-class docstring.
++    return -1
++
++  def __init__(
++      self,
++      conv_states: torch.Tensor,
++      recurrent_states: torch.Tensor,
++      batch_size: int = 1,
++      decode_mode: bool = False,
++      **kwargs,
++  ):
++    cache_utils.LinearAttentionCacheLayerMixin.__init__(self)
++    # HF modeling reads these as one-element containers (`conv_states[0]`,
++    # `recurrent_states[0][:, None]` in the chunk-continuation path), so keep
++    # the raw buffers private and expose list views via properties below.
++    self._conv_state = conv_states
++    self._recurrent_state = recurrent_states
++    # decode_mode: the DECODE exportable module traces the single-step branch
++    # (seq_len==1, conv window rolled by one); prefill traces the chunked
++    # branch WITH state continuation (previous conv/ssm state consumed), so
++    # multi-chunk prefill composes correctly. Both need has_previous_state
++    # truthy — decode_mode only selects the conv-update semantics.
++    self._decode_mode = decode_mode
++    # transformers >= 5.14 keys these by state index (dict.values() is called on
++    # has_previous_state); a single (conv, recurrent) state pair -> index 0.
++    # On <= 5.13 the flags are read as plain bools (and a non-empty dict would be
++    # truthy -> wrong branch), so pick the shape by version.
++    import transformers as _tf
++    _tf514 = tuple(int(x) for x in _tf.__version__.split(".")[:2]) >= (5, 14)
++    self.is_conv_states_initialized = {0: True} if _tf514 else True
++    self.is_recurrent_states_initialized = {0: True} if _tf514 else True
++    # Static export carries both state buffers as graph I/O, but — like the LFM2 conv
++    # path — prefill recomputes from zeroed state, so keep has_previous_state False to take
++    # Always truthy: prefill traces the chunked branch WITH continuation
++    # (chunk 1 starts from engine-zeroed state, so the math is unchanged for a
++    # single chunk, and chunks 2+ continue correctly), decode traces the
++    # single-step branch. (dict keyed by state index since transformers 5.14;
++    # plain bool on <= 5.13 where the flag is read directly.)
++    self.has_previous_state = {0: True} if _tf514 else True
++    self.batch_size = batch_size
++    self.is_initialized = True
++    self.conv_kernel_size = conv_states.shape[-1]
++    self.keys = torch.zeros((1, 1, 1, 1))
++    self.values = torch.zeros((1, 1, 1, 1))
++
++  def get_batch_size(self) -> int:
++    return self.batch_size
++
++  def get_k_ts_idx(self) -> int:
++    return 2  # Not used.
++
++  def get_v_ts_idx(self) -> int:
++    return 3  # Not used.
++
++  def lazy_initialization(self, *args, **kwargs):
++    raise NotImplementedError("Lazy initialization is not supported.")
++
++  def update(self, key_states, value_states, *args, **kwargs):
++    raise ValueError("Cannot call update on LinearAttentionCacheLayer.")
++
++  def update_conv_state(
++      self, conv_states: torch.Tensor, state_idx: int = 0, **kwargs
++  ) -> torch.Tensor:
++    # Unlike the LFM2 ShortConv path (which hands the FULL-sequence conv input and asks the
++    # cache to roll it), gated-delta-net produces the final kernel-width conv state itself
++    # (`F.pad(mixed_qkv, (K - L, 0))` → [B, conv_dim, K]) and just asks the cache to store
++    # it. So this is a plain store into the static buffer. (state_idx: single-state
++    # layers only — transformers >= 5.14 passes it positionally.)
++    self._conv_state.copy_(conv_states)
++    return self._conv_state
++
++  def update_recurrent_state(
++      self, recurrent_states: torch.Tensor, state_idx: int = 0, **kwargs
++  ) -> torch.Tensor:
++    self._recurrent_state.copy_(recurrent_states)
++    return self._recurrent_state
++
++  @property
++  def conv_states(self):
++    # One-element container view: HF modeling indexes `conv_states[0]`.
++    return [self._conv_state]
++
++  @conv_states.setter
++  def conv_states(self, value):
++    # The transformers LinearAttention mixin __init__ assigns bookkeeping
++    # containers here; the static export buffer replaces them, so only accept
++    # tensor assignment and drop the rest.
++    if isinstance(value, torch.Tensor):
++      self._conv_state = value
++
++  @property
++  def recurrent_states(self):
++    return [self._recurrent_state]
++
++  @recurrent_states.setter
++  def recurrent_states(self, value):
++    if isinstance(value, torch.Tensor):
++      self._recurrent_state = value
++
++  def get_mask_sizes(self, cache_position: torch.Tensor):
++    return self.conv_kernel_size, 0
++
++  def get_seq_length(self) -> int:
++    return 0
++
++  def get_max_cache_shape(self) -> int:
++    return self.conv_kernel_size
++
++  @classmethod
++  def create_from_config(
++      cls,
++      model_config,
++      layer_index,
++      export_config: ExportableModuleConfig,
++      **kwargs,
++  ) -> "LiteRTLMLinearAttentionCacheLayer":
++    assert model_config.layer_types[layer_index] == "linear_attention"
++    cfg = getattr(model_config, "text_config", model_config)
++    key_dim = cfg.linear_key_head_dim * cfg.linear_num_key_heads
++    value_dim = cfg.linear_value_head_dim * cfg.linear_num_value_heads
++    conv_dim = key_dim * 2 + value_dim
++    batch_size = kwargs.pop("batch_size", export_config.batch_size)
++    # gated-delta-net stores a full kernel-width conv state (F.pad to K), not K-1.
++    conv_states = torch.zeros(
++        (batch_size, conv_dim, cfg.linear_conv_kernel_dim),
++        dtype=torch.float32,
++    )
++    recurrent_states = torch.zeros(
++        (
++            batch_size,
++            cfg.linear_num_value_heads,
++            cfg.linear_key_head_dim,
++            cfg.linear_value_head_dim,
++        ),
++        dtype=torch.float32,
++    )
++    return cls(
++        conv_states,
++        recurrent_states,
++        batch_size=batch_size,
++        **kwargs,
++    )
++
++
++class LiteRTLMMambaCacheLayer(LiteRTLMLinearAttentionCacheLayer):
++  """Conv + SSM-state cache layer for Mamba2 selective-scan layers.
++
++  Used for HF arches that interleave Mamba2 and attention layers and tag the SSM layers
++  `layer_types[i] == "mamba"` (e.g. IBM Granite-4-h's `granitemoehybrid`; Bamba/Nemotron-H
++  share the layout). Structurally identical to
++  LiteRTLMLinearAttentionCacheLayer — both hold a `conv_states` plus a per-head
++  recurrent state, and both store the final kernel-width conv state with a plain copy
++  (Mamba2's `torch_forward` pads to the full kernel width via `F.pad(.., (d_conv-L, 0))`
++  and asks the cache to store it, exactly like gated-delta-net) — so only the SHAPE
++  derivation differs: Mamba2 sizes its state from the `mamba_*` config fields rather
++  than gated-delta-net's `linear_*` fields. Registering it for "mamba" is what makes the
++  export cache contain a LinearAttention-style layer, so the model's own
++  `_update_mamba_mask` → `cache.has_previous_state()` no longer raises mid-trace.
++  """
++
++  def update_conv_state(self, conv_states, state_idx=0, **kwargs):
++    # Unified window update covering every granite call site:
++    # - chunked prefill (seq>1) passes the full K-wide window (pad-and-store)
++    #   -> cat(old, full)[..., -K:] == full, a plain store;
++    # - single-step (seq==1: decode, and length-1 prefill chunks) passes one
++    #   raw column -> cat rolls the window left by one.
++    # A plain copy_ here would silently BROADCAST a [B,dim,1] update over the
++    # [B,dim,K] buffer on the single-step path — that corrupted every prompt
++    # whose chunk plan contained a length-1 chunk.
++    merged = torch.cat([self._conv_state, conv_states], dim=-1)[
++        ..., -self.conv_kernel_size:
++    ]
++    self._conv_state.copy_(merged)
++    return merged
++
++  @classmethod
++  def create_from_config(
++      cls,
++      model_config,
++      layer_index,
++      export_config: ExportableModuleConfig,
++      **kwargs,
++  ) -> "LiteRTLMMambaCacheLayer":
++    # transformers >= 5.14 renamed the layer type "mamba" -> "linear_attention"
++    assert model_config.layer_types[layer_index] in ("mamba", "linear_attention")
++    cfg = getattr(model_config, "text_config", model_config)
++    # Two config vocabularies for the same Mamba2 mixer geometry:
++    # granite/bamba spell it mamba_* (n_heads, d_head, d_state, d_conv,
++    # n_groups), NemotronH spells it mamba_num_heads / mamba_head_dim /
++    # ssm_state_size / conv_kernel / n_groups. The mixer-faithful intermediate
++    # is heads * head_dim (== mamba_expand * hidden_size on granite/bamba by
++    # construction; NemotronH's differs from expand * hidden, so heads *
++    # head_dim is the one formula that matches every mixer's own
++    # `self.intermediate_size`).
++    num_heads = getattr(cfg, "mamba_n_heads", None) or cfg.mamba_num_heads
++    head_dim = getattr(cfg, "mamba_d_head", None) or cfg.mamba_head_dim
++    d_state = getattr(cfg, "mamba_d_state", None) or cfg.ssm_state_size
++    d_conv = getattr(cfg, "mamba_d_conv", None) or cfg.conv_kernel
++    n_groups = getattr(cfg, "mamba_n_groups", None) or cfg.n_groups
++    intermediate_size = num_heads * head_dim
++    conv_dim = intermediate_size + 2 * n_groups * d_state
++    batch_size = kwargs.pop("batch_size", export_config.batch_size)
++    # conv buffer is the full kernel width d_conv (not d_conv - 1) — see the plain-store
++    # contract in update_conv_state inherited from LiteRTLMLinearAttentionCacheLayer.
++    conv_states = torch.zeros(
++        (batch_size, conv_dim, d_conv),
++        dtype=torch.float32,
++    )
++    # ssm recurrent state: [B, num_heads, head_dim, state_size].
++    recurrent_states = torch.zeros(
++        (
++            batch_size,
++            num_heads,
++            head_dim,
++            d_state,
++        ),
++        dtype=torch.float32,
++    )
++    return cls(
++        conv_states,
++        recurrent_states,
++        batch_size=batch_size,
++        **kwargs,
++    )
++
++
++def _is_mla_config(model_config) -> bool:
++  """True for Multi-head Latent Attention configs (DeepSeek-V2/V3/V3.2, MiniMax-M2).
++
++  MLA configs carry a low-rank KV latent (`kv_lora_rank`) and split the query/key
++  head into a no-RoPE part and a decoupled RoPE part, with a separate value head
++  dim — i.e. the K head dim (`qk_nope_head_dim + qk_rope_head_dim`) and the V head
++  dim (`v_head_dim`) are ASYMMETRIC. These configs have no per-layer `layer_types`,
++  so they fall through to the default full-attention cache, which assumes one shared
++  head dim and mis-sizes the cache.
++  """
++  cfg = getattr(model_config, "text_config", model_config)
++  return all(
++      getattr(cfg, k, None) is not None
++      for k in ("kv_lora_rank", "qk_rope_head_dim", "qk_nope_head_dim", "v_head_dim")
++  )
++
++
++class LiteRTLMMLACacheLayer(LiteRTLMCacheLayer):
++  """KV cache layer for Multi-head Latent Attention (DeepSeek-V2/V3, MiniMax-M2).
++
++  MLA compresses KV into a low-rank latent at runtime, but the transformers
++  modeling DECOMPRESSES it back to full per-head K/V *before* it calls
++  `past_key_values.update` (`kv_b_proj` in DeepseekV2/V3Attention.forward) — and
++  the decompress is a plain Linear + split/cat, so it lowers to generic ops. Hence
++  the export cache stores materialized K/V exactly like full attention, with ONE
++  difference: the K and V head dims are ASYMMETRIC. K head dim is
++  `qk_nope_head_dim + qk_rope_head_dim` (the no-RoPE part concatenated with the
++  decoupled RoPE part) while V head dim is `v_head_dim`. The base LiteRTLMCacheLayer
++  assumes a single shared `head_dim` for both, so its `update` reshape mangles MLA's
++  K/V and the score einsum then mismatches (`size 64 ... does not broadcast with
++  192`). This subclass sizes and reshapes K and V with their own head dims.
++  """
++
++  def __init__(
++      self,
++      key_cache: KeyCache,
++      value_cache: ValueCache,
++      batch_size: int = 1,
++      k_ts_idx: int = 2,
++      v_ts_idx: int = 3,
++      **kwargs,
++  ):
++    super().__init__(
++        key_cache, value_cache, batch_size, k_ts_idx, v_ts_idx, **kwargs
++    )
++    # Base sets self.head_dim from the V cache; record K's (possibly different) dim.
++    k_head_dim_idx = 3 if self.k_ts_idx == 2 else 2
++    self.k_head_dim = self.k_cache_shape[k_head_dim_idx]
++    self.v_head_dim = self.head_dim
++
++  def update(
++      self,
++      key_states: torch.Tensor,
++      value_states: torch.Tensor,
++      *args,
++      **kwargs,
++  ) -> tuple[torch.Tensor, torch.Tensor]:
++    cache_kwargs = self.get_cache_runtime_args()
++    seq_len = key_states.shape[2]
++    self.cumulative_length += seq_len
++
++    key_states = key_states.to(self.keys.dtype)
++    value_states = value_states.to(self.values.dtype)
++
++    # Identical to the base update except K and V use their own head dims.
++    if not cache_kwargs.get("kv_slice_preprocessed", False):
++      if self.k_ts_idx == 3:
++        key_states = key_states.permute(0, 1, 3, 2).reshape(
++            1, -1, self.k_head_dim, seq_len
++        )
++      elif self.k_ts_idx == 2:
++        key_states = key_states.reshape(1, -1, seq_len, self.k_head_dim)
++      else:
++        raise ValueError(f"Unsupported k_ts_idx: {self.k_ts_idx}")
++      if self.v_ts_idx == 3:
++        value_states = value_states.permute(0, 1, 3, 2).reshape(
++            1, -1, self.v_head_dim, seq_len
++        )
++      elif self.v_ts_idx == 2:
++        value_states = value_states.reshape(1, -1, seq_len, self.v_head_dim)
++      else:
++        raise ValueError(f"Unsupported v_ts_idx: {self.v_ts_idx}")
++
++    cache_position: jt.Int32[torch.Tensor, "T"] = cache_kwargs.get(
++        "cache_position"
++    )
++    assert (
++        cache_position is not None
++    ), "For export, cache position should always be set."
++    merged_kwargs = {**kwargs, **cache_kwargs}
++    merged_kwargs.pop("cache_position", None)
++    self.keys, self.values = _update_kv_impl(
++        self.keys,
++        self.values,
++        key_states,
++        value_states,
++        cache_position,
++        self.k_ts_idx,
++        self.v_ts_idx,
++        **merged_kwargs,
++    )
++    return self.keys, self.values
++
++  @classmethod
++  def _infer_cache_shape_from_config(
++      cls,
++      model_config,
++      layer_index,
++      export_config: ExportableModuleConfig,
++  ):
++    """Sizes K and V caches with the asymmetric MLA head dims."""
++    cfg = getattr(model_config, "text_config", model_config)
++    cache_length = export_config.cache_length
++    batch_size = export_config.batch_size
++    k_ts_idx = export_config.k_ts_idx
++    v_ts_idx = export_config.v_ts_idx
++    # MLA materializes one K/V per query head (num_key_value_groups == 1).
++    num_kv_heads = cfg.num_attention_heads
++    k_head_dim = cfg.qk_nope_head_dim + cfg.qk_rope_head_dim
++    v_head_dim = cfg.v_head_dim
++
++    def _shape(ts_idx, head_dim):
++      if ts_idx == 2:
++        return (1, batch_size * num_kv_heads, cache_length, head_dim)
++      elif ts_idx == 3:
++        return (1, batch_size * num_kv_heads, head_dim, cache_length)
++      raise ValueError(f"Unsupported ts_idx: {ts_idx}")
++
++    return _shape(k_ts_idx, k_head_dim), _shape(v_ts_idx, v_head_dim)
++
++
++class LiteRTLMMLAIndexerCacheLayer(LiteRTLMMLACacheLayer):
++  """MLA cache plus a DeepSeek Sparse Attention (DSA) indexer key cache.
++
++  DeepSeek-V3.2 (`layer_types[i] == "deepseek_sparse_attention"`) keeps the
++  asymmetric MLA K/V cache (inherited from LiteRTLMMLACacheLayer) AND a second,
++  lightweight per-layer cache for its sparse-attention indexer
++  (`DeepseekV32Indexer`): a single-head key cache of shape
++  `[batch_size, seq_len, index_head_dim]` updated via
++  `past_key_values.update_indexer()` — independent of the main K/V `update`.
++  transformers stores it on `DynamicIndexedLayer` / `StaticIndexedLayer`; for
++  export we add a static indexer-key buffer here and write it with the same
++  `dynamic_update_slice` primitive as K/V. (Without `update_indexer`, the modeling
++  raises `ValueError: Cannot call update_indexer ... it has no indexer key cache`
++  mid FX-trace.) The indexer buffer is laid out `[1, batch_size, cache_length,
++  index_head_dim]` (single head, seq at index 2), folding batch into dim 1 so the
++  4D `dynamic_update_slice` path is reused unchanged.
++  """
++
++  # Buffer seq dimension for the (always 4D) indexer-key cache.
++  indexer_ts_idx = 2
++
++  def __init__(
++      self,
++      key_cache: KeyCache,
++      value_cache: ValueCache,
++      indexer_cache: torch.Tensor,
++      batch_size: int = 1,
++      k_ts_idx: int = 2,
++      v_ts_idx: int = 3,
++      **kwargs,
++  ):
++    super().__init__(
++        key_cache, value_cache, batch_size, k_ts_idx, v_ts_idx, **kwargs
++    )
++    self.indexer_keys = indexer_cache
++    self.index_head_dim = self.indexer_keys.shape[3]
++
++  def update_indexer(self, indexer_key_states: torch.Tensor) -> torch.Tensor:
++    """Writes the new indexer keys into the static buffer and returns it.
++
++    Mirrors `update` but for the single-head indexer cache: the modeling passes
++    `[batch_size, seq_len, index_head_dim]`; we fold batch into dim 1 to reuse the
++    4D `dynamic_update_slice`, then return the full `[batch_size, cache_length,
++    index_head_dim]` buffer (unfilled positions are masked downstream, exactly as
++    the static K/V path returns its full preallocated cache).
++    """
++    cache_kwargs = self.get_cache_runtime_args()
++    cache_position: jt.Int32[torch.Tensor, "T"] = cache_kwargs.get(
++        "cache_position"
++    )
++    assert (
++        cache_position is not None
++    ), "For export, cache position should always be set."
++    seq_len = indexer_key_states.shape[1]
++    idx_slice = indexer_key_states.to(self.indexer_keys.dtype).reshape(
++        1, -1, seq_len, self.index_head_dim
++    )
++    positions = cache_position[0]
++    slice_indices = _get_slice_indices(
++        positions.clone(), 4, self.indexer_ts_idx
++    )
++    self.indexer_keys = tfl_dus.dynamic_update_slice(
++        self.indexer_keys, idx_slice, [x for x in slice_indices]
++    )
++    return self.indexer_keys.reshape(
++        -1, self.max_cache_len, self.index_head_dim
++    )
++
++  @classmethod
++  def create_from_config(
++      cls,
++      model_config,
++      layer_index,
++      export_config: ExportableModuleConfig,
++      **kwargs,
++  ) -> "LiteRTLMMLAIndexerCacheLayer":
++    """Creates the asymmetric MLA K/V caches plus the indexer key cache."""
++    k_cache_shape, v_cache_shape = cls._infer_cache_shape_from_config(
++        model_config, layer_index, export_config
++    )
++    cfg = getattr(model_config, "text_config", model_config)
++    keys = torch.zeros(k_cache_shape, dtype=torch.float32)
++    values = torch.zeros(v_cache_shape, dtype=torch.float32)
++    indexer_cache = torch.zeros(
++        (1, export_config.batch_size, export_config.cache_length, cfg.index_head_dim),
++        dtype=torch.float32,
++    )
++    return cls(
++        keys,
++        values,
++        indexer_cache,
++        k_ts_idx=export_config.k_ts_idx,
++        v_ts_idx=export_config.v_ts_idx,
++        **kwargs,
++    )
++
++
++class LiteRTLMHybridCacheLayer(
++    LiteRTLMCacheLayer, cache_utils.LinearAttentionCacheLayerMixin
++):
++  """KV + Mamba2 conv/recurrent state at ONE layer index.
++
++  For arches whose `layer_types[i] == "hybrid"` — the layer runs full
++  attention AND a Mamba2/SSM mixer in parallel on the same input (FalconH1:
++  every layer; Zamba2: its 'hybrid' subset). The attention side is exactly
++  LiteRTLMCacheLayer (keys/values/update; first in the MRO so the attention
++  mask machinery sees KV semantics); inheriting
++  cache_utils.LinearAttentionCacheLayerMixin is what lets transformers'
++  `Cache.has_previous_state(layer_idx)` accept the layer as state-carrying.
++  The mamba surface replicates LiteRTLMMambaCacheLayer: one-element container
++  views and the unified cat-window conv store. Both states flatten under the
++  SAME layer index (k_i/v_i + mc_i/mr_i) — the runtime binds states by tensor
++  name, so co-residency at one index is packaging, not a new contract.
++  """
++
++  def __init__(
++      self,
++      key_cache: torch.Tensor,
++      value_cache: torch.Tensor,
++      conv_states: torch.Tensor,
++      recurrent_states: torch.Tensor,
++      batch_size: int = 1,
++      decode_mode: bool = False,
++      **kwargs,
++  ):
++    super().__init__(key_cache, value_cache, batch_size=batch_size, **kwargs)
++    # Mixin init first (it assigns through the conv_states/recurrent_states
++    # property setters), then overwrite with the real buffers — same order
++    # dance as LiteRTLMLinearAttentionCacheLayer.
++    cache_utils.LinearAttentionCacheLayerMixin.__init__(self)
++    self._conv_state = conv_states
++    self._recurrent_state = recurrent_states
++    self._decode_mode = decode_mode
++    import transformers as _tf
++    _tf514 = tuple(int(x) for x in _tf.__version__.split(".")[:2]) >= (5, 14)
++    self.is_conv_states_initialized = {0: True} if _tf514 else True
++    self.is_recurrent_states_initialized = {0: True} if _tf514 else True
++    # Always truthy — same tracing contract as the LinearAttention layer.
++    self.has_previous_state = {0: True} if _tf514 else True
++    self.conv_kernel_size = conv_states.shape[-1]
++
++  def update_conv_state(self, conv_states, state_idx=0, **kwargs):
++    # Same unified window update as LiteRTLMMambaCacheLayer: chunked prefill
++    # passes the full K-wide window (plain store), single-step passes one raw
++    # column (rolls the window left by one). See that class for the
++    # broadcast-store trap this form avoids.
++    del state_idx, kwargs
++    merged = torch.cat([self._conv_state, conv_states], dim=-1)[
++        ..., -self.conv_kernel_size:
++    ]
++    self._conv_state.copy_(merged)
++    return merged
++
++  def update_recurrent_state(self, recurrent_states, state_idx=0, **kwargs):
++    del state_idx, kwargs
++    self._recurrent_state.copy_(recurrent_states)
++    return self._recurrent_state
++
++  @property
++  def conv_states(self):
++    # One-element container view: HF modeling indexes `conv_states[0]`.
++    return [self._conv_state]
++
++  @conv_states.setter
++  def conv_states(self, value):
++    self._conv_state = value
++
++  @property
++  def recurrent_states(self):
++    return [self._recurrent_state]
++
++  @recurrent_states.setter
++  def recurrent_states(self, value):
++    self._recurrent_state = value
++
++  @classmethod
++  def create_from_config(
++      cls,
++      model_config,
++      layer_index,
++      export_config: ExportableModuleConfig,
++      **kwargs,
++  ) -> "LiteRTLMHybridCacheLayer":
++    assert model_config.layer_types[layer_index] == "hybrid"
++    cfg = getattr(model_config, "text_config", model_config)
++    k_cache_shape, v_cache_shape = cls._infer_cache_shape_from_config(
++        model_config, layer_index, export_config
++    )
++    # Mamba geometry, FalconH1 vocabulary (mamba_d_ssm overrides
++    # expand*hidden when set; mamba_d_head resolves from 'auto' in the
++    # config's __post_init__). Zamba2's 'hybrid' layers spell these
++    # differently (n_mamba_heads/mamba_headdim/mamba_ngroups) — add that
++    # vocabulary when its extension lands.
++    intermediate_size = (
++        cfg.mamba_d_ssm
++        if getattr(cfg, "mamba_d_ssm", None)
++        else int(cfg.mamba_expand * cfg.hidden_size)
++    )
++    conv_dim = intermediate_size + 2 * cfg.mamba_n_groups * cfg.mamba_d_state
++    batch_size = kwargs.pop("batch_size", export_config.batch_size)
++    keys = torch.zeros(k_cache_shape, dtype=torch.float32)
++    values = torch.zeros(v_cache_shape, dtype=torch.float32)
++    conv_states = torch.zeros(
++        (batch_size, conv_dim, cfg.mamba_d_conv), dtype=torch.float32
++    )
++    recurrent_states = torch.zeros(
++        (batch_size, cfg.mamba_n_heads, cfg.mamba_d_head, cfg.mamba_d_state),
++        dtype=torch.float32,
++    )
++    return cls(
++        keys,
++        values,
++        conv_states,
++        recurrent_states,
++        batch_size=batch_size,
++        **kwargs,
++    )
++
++
++class LiteRTLMNoCacheLayer(cache_base_lib.LiteRTLMCacheLayerMixin):
++  """Placeholder for cache-less layer types (e.g. NemotronH's `mlp` layers).
++
++  Keeps `LiteRTLMCache.layers` indexed by ABSOLUTE layer index (mamba and
++  attention layers address `cache_params.layers[self.layer_idx]`) while
++  contributing ZERO tensors to the flattened state — no signature I/O, no
++  runtime state buffers. Without it, the dict fallback hands every `mlp`
++  layer a full attention KV cache: NemotronH-4B would carry 24 phantom KV
++  buffers that cost signature RAM and confuse the runtime's state binding.
++  The owning layer has no cache semantics, so `update` must never be called.
++  """
++
++  is_compileable = True
++  is_sliding = False
++
++  def __init__(self, batch_size: int = 1, **kwargs):
++    self.batch_size = batch_size
++
++  def lazy_initialization(self, key_states):
++    del key_states
++
++  def update(self, key_states=None, value_states=None, cache_kwargs=None):
++    raise RuntimeError(
++        "LiteRTLMNoCacheLayer.update called - a cache-less layer type was"
++        " asked to store state; the layer_types routing is wrong."
++    )
++
++  def get_seq_length(self, cache_position=None) -> int:
++    del cache_position
++    return 0
++
++  def get_max_length(self) -> int:
++    return -1
++
++  def get_max_cache_shape(self) -> int:
++    return 0
++
++  def get_mask_sizes(self, cache_position):
++    del cache_position
++    return 0, 0
++
++  def get_batch_size(self) -> int:
++    return self.batch_size
++
++  def get_k_ts_idx(self) -> int:
++    return -1
++
++  def get_v_ts_idx(self) -> int:
++    return -1
++
++  @classmethod
++  def create_from_config(
++      cls,
++      model_config,
++      layer_index,
++      export_config: ExportableModuleConfig,
++      **kwargs,
++  ) -> "LiteRTLMNoCacheLayer":
++    del model_config, layer_index
++    kwargs.pop("batch_size", None)
++    return cls(batch_size=export_config.batch_size)
++
++
+ LAYER_TYPE_TO_CLASS = {
+     "full_attention": LiteRTLMCacheLayer,
+     "sliding_attention": LiteRTLMCacheLayer,
+     "conv": LiteRTLMConvCacheLayer,
++    "linear_attention": LiteRTLMLinearAttentionCacheLayer,
++    "mamba": LiteRTLMMambaCacheLayer,
++    "deepseek_sparse_attention": LiteRTLMMLAIndexerCacheLayer,
++    # cache-less layer types (NemotronH interleaves plain MLP blocks)
++    "mlp": LiteRTLMNoCacheLayer,
++    # attention + SSM in the same layer (FalconH1 everywhere; Zamba2 subset)
++    "hybrid": LiteRTLMHybridCacheLayer,
+ }
+ 
+ 
+@@ -464,6 +1133,17 @@ class LiteRTLMCache(cache_base_lib.LiteRTLMCacheMixin):
+       if hasattr(model_config, "layer_types"):
+         layer_type = model_config.layer_types[layer_index]
+       layer_class = LAYER_TYPE_TO_CLASS.get(layer_type, LiteRTLMCacheLayer)
++      # transformers >= 5.14 renamed mamba layer_types to the standardized
++      # "linear_attention"; distinguish mamba2 by its config keys —
++      # granite/bamba spell it `mamba_n_heads`, NemotronH `mamba_num_heads`.
++      if (layer_class is LiteRTLMLinearAttentionCacheLayer
++          and (hasattr(model_config, "mamba_n_heads")
++               or hasattr(model_config, "mamba_num_heads"))):
++        layer_class = LiteRTLMMambaCacheLayer
++      # MLA (DeepSeek-V2/V3, MiniMax-M2) has no per-layer types and needs an
++      # asymmetric K/V cache; route its (otherwise full-attention) layers to it.
++      if layer_class is LiteRTLMCacheLayer and _is_mla_config(model_config):
++        layer_class = LiteRTLMMLACacheLayer
+       layers.append(
+           layer_class.create_from_config(
+               model_config,
+@@ -519,10 +1199,61 @@ def _flatten_kvc_t(
+     v_ts_idx = layer_0.get_v_ts_idx()
+   layer_types = []
+   for i, layer in enumerate(kvc.layers):
+-    if isinstance(layer, LiteRTLMConvCacheLayer):
++    if isinstance(layer, LiteRTLMNoCacheLayer):
++      # cache-less layer (e.g. NemotronH mlp): holds the index, owns no tensors
++      layer_types.append("none")
++    elif isinstance(layer, LiteRTLMHybridCacheLayer):
++      # Must precede the LiteRTLMCacheLayer branch (it is a subclass).
++      # KV + mamba state at one index; mamba names match the mamba layer's so
++      # the runtime's state binding sees nothing new.
++      layer_types.append("hybrid")
++      flattened.append(layer.keys)
++      flat_names.append(f"k_{i}")
++      flattened.append(layer.values)
++      flat_names.append(f"v_{i}")
++      flattened.append(layer._conv_state)
++      flat_names.append(f"mc_{i}")
++      flattened.append(layer._recurrent_state)
++      flat_names.append(f"mr_{i}")
++    elif isinstance(layer, LiteRTLMMambaCacheLayer):
++      # Must precede the LiteRTLMLinearAttentionCacheLayer branch (it is a subclass).
++      layer_types.append("mamba")
++      flattened.append(layer._conv_state)
++      flat_names.append(f"mc_{i}")
++      flattened.append(layer._recurrent_state)
++      flat_names.append(f"mr_{i}")
++    elif isinstance(layer, LiteRTLMLinearAttentionCacheLayer):
++      layer_types.append("linear_attention")
++      flattened.append(layer._conv_state)
++      flat_names.append(f"lc_{i}")
++      flattened.append(layer._recurrent_state)
++      flat_names.append(f"lr_{i}")
++    elif isinstance(layer, LiteRTLMConvCacheLayer):
+       layer_types.append("conv")
+       flattened.append(layer.conv_states)
+       flat_names.append(f"c_{i}")
++    elif isinstance(layer, LiteRTLMMLAIndexerCacheLayer):
++      # Must precede the LiteRTLMMLACacheLayer branch (it is a subclass). MLA
++      # K/V reuse the `k_`/`v_` names (like plain MLA); the DSA indexer adds a
++      # third single-head key cache `idx_{i}`. The "mla_indexer" layer_type in
++      # the context drives the indexer-buffer rebuild on unflatten.
++      layer_types.append("mla_indexer")
++      flattened.append(layer.keys)
++      flat_names.append(f"k_{i}")
++      flattened.append(layer.values)
++      flat_names.append(f"v_{i}")
++      flattened.append(layer.indexer_keys)
++      flat_names.append(f"idx_{i}")
++    elif isinstance(layer, LiteRTLMMLACacheLayer):
++      # Must precede the LiteRTLMCacheLayer branch (it is a subclass). MLA stores
++      # materialized K/V exactly like full attention, so it reuses the same
++      # `k_`/`v_` tensor names (the runtime keys its KV cache off `kv_cache_k_0`);
++      # the "mla" layer_type in the context drives the asymmetric-dim rebuild.
++      layer_types.append("mla")
++      flattened.append(layer.keys)
++      flat_names.append(f"k_{i}")
++      flattened.append(layer.values)
++      flat_names.append(f"v_{i}")
+     elif isinstance(layer, LiteRTLMCacheLayer):
+       layer_types.append("full_attention")
+       flattened.append(layer.keys)
+@@ -531,9 +1262,18 @@ def _flatten_kvc_t(
+       flat_names.append(f"v_{i}")
+     else:
+       raise ValueError(f"Unsupported layer type: {type(layer)}")
++  # decode_mode must survive the flatten/unflatten round-trip torch.export
++  # performs, or the traced modeling silently falls back to prefill semantics.
++  decode_mode = any(
++      getattr(layer, "_decode_mode", False) for layer in kvc.layers
++  )
+   return (
+       flattened,
+-      (flat_names, (batch_size, num_layers, k_ts_idx, v_ts_idx, layer_types)),
++      (
++          flat_names,
++          (batch_size, num_layers, k_ts_idx, v_ts_idx, layer_types,
++           decode_mode),
++      ),
+   )
+ 
+ 
+@@ -543,11 +1283,55 @@ def _unflatten_kvc_t(
+ ) -> LiteRTLMCache:
+   """Unflattens the cache from a list of tensors."""
+   flat_names = context[0]
+-  batch_size, num_layers, k_ts_idx, v_ts_idx, layer_types = context[1]
++  # decode_mode was appended to the context (older 5-tuple contexts default False)
++  if len(context[1]) == 6:
++    batch_size, num_layers, k_ts_idx, v_ts_idx, layer_types, decode_mode = (
++        context[1]
++    )
++  else:
++    batch_size, num_layers, k_ts_idx, v_ts_idx, layer_types = context[1]
++    decode_mode = False
+   layers = []
+   for i in range(num_layers):
+     layer_type = layer_types[i]
+-    if layer_type == "conv":
++    if layer_type == "none":
++      layers.append(LiteRTLMNoCacheLayer(batch_size=batch_size))
++    elif layer_type == "hybrid":
++      layers.append(
++          LiteRTLMHybridCacheLayer(
++              key_cache=values[flat_names.index(f"k_{i}")],
++              value_cache=values[flat_names.index(f"v_{i}")],
++              conv_states=values[flat_names.index(f"mc_{i}")],
++              recurrent_states=values[flat_names.index(f"mr_{i}")],
++              batch_size=batch_size,
++              decode_mode=decode_mode,
++              k_ts_idx=k_ts_idx,
++              v_ts_idx=v_ts_idx,
++          )
++      )
++    elif layer_type == "mamba":
++      mc_idx = flat_names.index(f"mc_{i}")
++      mr_idx = flat_names.index(f"mr_{i}")
++      layers.append(
++          LiteRTLMMambaCacheLayer(
++              conv_states=values[mc_idx],
++              recurrent_states=values[mr_idx],
++              batch_size=batch_size,
++              decode_mode=decode_mode,
++          )
++      )
++    elif layer_type == "linear_attention":
++      lc_idx = flat_names.index(f"lc_{i}")
++      lr_idx = flat_names.index(f"lr_{i}")
++      layers.append(
++          LiteRTLMLinearAttentionCacheLayer(
++              conv_states=values[lc_idx],
++              recurrent_states=values[lr_idx],
++              batch_size=batch_size,
++              decode_mode=decode_mode,
++          )
++      )
++    elif layer_type == "conv":
+       c_cache_idx = flat_names.index(f"c_{i}")
+       layers.append(
+           LiteRTLMConvCacheLayer(
+@@ -555,6 +1339,32 @@ def _unflatten_kvc_t(
+               batch_size=batch_size,
+           )
+       )
++    elif layer_type == "mla_indexer":
++      k_cache_idx = flat_names.index(f"k_{i}")
++      v_cache_idx = flat_names.index(f"v_{i}")
++      idx_cache_idx = flat_names.index(f"idx_{i}")
++      layers.append(
++          LiteRTLMMLAIndexerCacheLayer(
++              key_cache=values[k_cache_idx],
++              value_cache=values[v_cache_idx],
++              indexer_cache=values[idx_cache_idx],
++              batch_size=batch_size,
++              k_ts_idx=k_ts_idx,
++              v_ts_idx=v_ts_idx,
++          )
++      )
++    elif layer_type == "mla":
++      k_cache_idx = flat_names.index(f"k_{i}")
++      v_cache_idx = flat_names.index(f"v_{i}")
++      layers.append(
++          LiteRTLMMLACacheLayer(
++              key_cache=values[k_cache_idx],
++              value_cache=values[v_cache_idx],
++              batch_size=batch_size,
++              k_ts_idx=k_ts_idx,
++              v_ts_idx=v_ts_idx,
++          )
++      )
+     elif layer_type == "full_attention":
+       k_cache_idx = flat_names.index(f"k_{i}")
+       v_cache_idx = flat_names.index(f"v_{i}")
+diff --git a/litert_torch/generative/export_hf/model_ext/granitemoehybrid/__init__.py b/litert_torch/generative/export_hf/model_ext/granitemoehybrid/__init__.py
+new file mode 100644
+index 0000000..c0f98a7
+--- /dev/null
++++ b/litert_torch/generative/export_hf/model_ext/granitemoehybrid/__init__.py
+@@ -0,0 +1,14 @@
++# Copyright 2026 The LiteRT Torch Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++# ==============================================================================
+diff --git a/litert_torch/generative/export_hf/model_ext/granitemoehybrid/patch.py b/litert_torch/generative/export_hf/model_ext/granitemoehybrid/patch.py
+new file mode 100644
+index 0000000..11f5d3f
+--- /dev/null
++++ b/litert_torch/generative/export_hf/model_ext/granitemoehybrid/patch.py
+@@ -0,0 +1,639 @@
++# Copyright 2026 The LiteRT Torch Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++# ==============================================================================
++"""Patch for Granite-4-h (granitemoehybrid: Mamba2 selective-scan + attention hybrid).
++
++Two things live here.
++
++1. The mamba prefill-pad guard. The LiteRT-LM engine runs prefill chunks
++   PARTIALLY FILLED (its chunk planner pads the remainder chunk), and granite's
++   own `apply_mask_to_padding_states` is a no-op at batch size 1 — so without a
++   guard, padding tokens poison the conv/SSM state and corrupt generation at
++   chunk-plan-dependent prompt lengths (the mamba analog of the LFM2 ShortConv
++   prefill-pad bug). The guard:
++
++     1. valid mask = `input_ids != 0` (the engine zero-fills pad tokens),
++        stashed on each mixer by the patched model `forward`;
++     2. pad positions' hidden states zeroed before/after the conv (so x/B/C
++        contribute nothing to the scan);
++     3. pad positions' dt forced to -30 pre-softplus -> dt ~ 0 -> exp(dt*A) ~ 1
++        and dt*B*x ~ 0: the SSM update is an IDENTITY step on pads (a plain
++        zeroed-input step would still decay the state by exp(dt_bias*A));
++     4. the stored conv window is gathered ending at the last VALID column via
++        an in-graph one-hot matmul (the upstream LFM2 0.9.2 technique), instead
++        of the chunk's last K columns (which are pads).
++
++2. A rank<=4 rewrite of the SSD scan, which is what makes the layer GPU-eligible.
++   Upstream writes the five SSD contractions as broadcast-multiply-reduce ("begin
++   ssd naive implementation without einsums"), producing rank-5 and rank-6
++   intermediates. Every mobile GPU delegate we gate on refuses tensors above rank
++   4 ("Tensor dimensions must be less than 5"), which is why the published
++   granite int8 delegates 109/3673 ops and aborts. Writing the same contractions
++   as batched matmuls with the chunk and head axes folded into the batch axis
++   keeps every tensor at rank <= 4 — and it never materializes the naive form's
++   chunks*chunk_len^2*heads*d_state intermediates. Two more ops have to go, and
++   neither is about rank:
++
++     - BROADCAST_TO is refused outright. It arrives from `expand` (inside
++       `segment_sum`) and `repeat_interleave` (group->head replication of B/C).
++       Both are outer products with a ones vector, so a matmul against a ones row
++       is the same tensor through a supported op.
++     - PAD is refused on a rank-2 tensor ("expected 4x2 or 3x2, got 2x2"). Every
++       pad here is written as a `cat` with an explicit zero block instead.
++
++   The decode step (seq_len == 1) is written out for the same reason: upstream
++   `expand`s dt/A/B/C/D to [bsz, heads, head_dim, state] and each `expand` is a
++   BROADCAST_TO. Implicit (None-indexed) broadcasting produces the same rank-4
++   arithmetic with no BROADCAST_TO.
++
++   Set `LITERT_GRANITE_SSD=naive` to export the upstream scan instead (guard
++   still applied, via anchored source replacement). That is the pre-rewrite path,
++   kept so a quality regression can be bisected against a known-good graph.
++
++The rewrite is checked against the installed transformers implementation at
++patch time (`_selfcheck_folded_ssd`), so a modeling change that moves the math
++fails loudly instead of silently exporting something else.
++"""
++
++import contextlib
++import inspect
++import os
++import textwrap
++
++import torch
++from litert_torch.generative.export_hf.model_ext import patches as patches_lib
++from transformers.models.granitemoehybrid import modeling_granitemoehybrid
++
++nn = torch.nn
++F = torch.nn.functional
++
++_PAD_DT = -30.0  # pre-softplus dt on pad positions -> identity SSM step
++
++
++class PatchedGraniteMoeHybridModel(modeling_granitemoehybrid.GraniteMoeHybridModel):
++  """Export-friendly Granite-4-h text model (class swap; persists on the instance)."""
++
++  # transformers >= 5.14 gates experts_implementation on a module-source heuristic
++  # that the swapped class fails; the underlying model supports it, so short-circuit.
++  _can_set_experts_implementation_cached_value = True
++
++  def forward(self, input_ids=None, **kwargs):
++    # Engine pads prefill chunks with token id 0; derive the per-position valid
++    # mask here and stash it directly on every mamba mixer instance — in
++    # transformers 5.14 the mixers receive attention_mask=None (there is no
++    # `_update_mamba_mask` route anymore), so torch_forward reads
++    # `self._litert_valid` instead.
++    valid = (input_ids != 0).to(torch.float32) if input_ids is not None else None
++    for module in self.modules():
++      if isinstance(module, PatchedGraniteMoeHybridMambaLayer):
++        module._litert_valid = valid
++    return super().forward(input_ids=input_ids, **kwargs)
++
++
++# ---------------------------------------------------------------------------
++# rank<=4 helpers
++# ---------------------------------------------------------------------------
++
++
++def _ones_row(like, n):
++  return torch.ones(1, n, device=like.device, dtype=like.dtype)
++
++
++def _cumsum_last(x):
++  """Inclusive cumulative sum along the last axis of a (batch, l) tensor.
++
++  CUMSUM by default. `LITERT_GRANITE_CUMSUM=matmul` swaps in a GEMM against a
++  constant upper-triangular ones matrix, which is the same values through a
++  different primitive — kept because "is the delegate's scan kernel wrong?" is a
++  question worth being able to ask in one env var. Measured 2026-08-13 on Mac
++  WebGPU: the GEMM form made the model's GPU output *worse* (token-0 spam rather
++  than wrong-but-formed text), so CUMSUM is not the broken op and the GEMM form
++  costs an l x l matmul for nothing.
++  """
++  if os.environ.get("LITERT_GRANITE_CUMSUM") != "matmul":
++    return torch.cumsum(x, dim=-1)
++  l = x.size(-1)
++  tri = torch.triu(torch.ones(l, l, device=x.device, dtype=x.dtype))
++  return torch.matmul(x[..., None, :], tri)[..., 0, :]
++
++
++def _exp_segment_sum_from_cumsum(cs):
++  """`exp(segment_sum(x))` given `cs = cumsum(x, -1)`: (batch, l) -> (batch, l, l).
++
++  `segment_sum(x)[i, j] = sum_{k=j+1..i} x[k] = cs[i] - cs[j]` for `i >= j`, so
++  the whole matrix comes from the cumulative sum we already compute along the
++  last axis. Three things upstream does are avoided, and none of them is about
++  rank:
++
++  - upstream's `expand` lowers to BROADCAST_TO, refused outright. A matmul
++    against a ones row builds the same tensor through a supported op, and its
++    transpose gives the other operand.
++  - upstream builds the matrix with a `cumsum` along a NON-INNERMOST axis of a
++    rank-3 tensor. Deriving it from the last-axis cumsum removes that op — it
++    was also the single largest tensor in the scan (chunks*heads x l x l with an
++    l-step scan).
++  - upstream fills the strict upper triangle with `-inf` before exponentiating.
++    Here the difference is masked to 0 BEFORE the exp (so nothing infinite ever
++    reaches it) and the triangle is zeroed after, which is the same matrix: on
++    and below the diagonal `cs` is non-increasing (A = -exp(A_log) < 0, dt > 0)
++    so the exponent is <= 0 and cannot overflow either.
++  """
++  l = cs.size(-1)
++  # Arithmetic broadcast, not `expand` (which is BROADCAST_TO) and not a matmul
++  # against a ones row (a K=1 batched matmul against a rank-2 operand — an edge
++  # case worth not depending on). SUB broadcasts natively.
++  diff = cs[..., :, None] - cs[..., None, :]  # diff[i, j] = cs[i] - cs[j]
++  keep = torch.tril(torch.ones(l, l, device=cs.device, dtype=cs.dtype), diagonal=0)
++  return torch.exp(diff * keep) * keep
++
++
++def _repeat_groups(t, rep):
++  """(b, s, g, n) -> (b, s, g*rep, n), each group repeated `rep` times.
++
++  Same tensor as `repeat_interleave(rep, dim=2)`, which lowers to BROADCAST_TO.
++  A concatenation of per-group slices is the same tensor through an op every
++  backend implements plainly.
++  """
++  g = t.shape[2]
++  return torch.cat(
++      [t[:, :, i : i + 1] for i in range(g) for _ in range(rep)], dim=2
++  )
++
++
++def _repeat_groups_step(t, n_groups, rep, n):
++  """(b, n_groups*n) -> (b, n_groups*rep, n) for the single-token path."""
++  b = t.shape[0]
++  t = torch.matmul(t.reshape(b * n_groups, n, 1), _ones_row(t, rep))  # (b*g, n, rep)
++  return t.transpose(1, 2).reshape(b, n_groups * rep, n)
++
++
++def _zeros_cat(t, pad_size, dim):
++  """`F.pad`-equivalent trailing zero pad, written as a cat (PAD is rejected on
++  rank-2 tensors and the cat form is what the delegate takes everywhere)."""
++  if pad_size == 0:
++    return t
++  shape = list(t.shape)
++  shape[dim] = pad_size
++  return torch.cat([t, torch.zeros(shape, device=t.device, dtype=t.dtype)], dim=dim)
++
++
++# ---------------------------------------------------------------------------
++# the rewritten mixer forward
++# ---------------------------------------------------------------------------
++
++
++def _folded_torch_forward(self, input_states, cache_params=None, attention_mask=None):
++  """rank<=4, BROADCAST_TO-free `GraniteMoeHybridMambaLayer.torch_forward`.
++
++  Numerically the upstream scan (checked at patch time); structurally a shape
++  every mobile GPU delegate accepts.
++  """
++  del attention_mask  # the pad mask arrives via `_litert_valid` (see model.forward)
++  batch_size, seq_len, _ = input_states.shape
++  dtype = input_states.dtype
++  H, P, N = self.num_heads, self.head_dim, self.ssm_state_size
++  n_groups = self.n_groups
++  rep = H // n_groups
++
++  # --- guard (1): zero pad positions, and only arm the guard on prefill. A
++  # legitimately generated token id 0 must not be masked during decode. ---
++  valid = getattr(self, "_litert_valid", None)
++  if valid is not None and seq_len > 1:
++    valid = valid.to(dtype)
++    input_states = input_states * valid[..., None]
++  else:
++    valid = None
++
++  projected_states = self.in_proj(input_states)
++  gate, hidden_states_B_C, dt = projected_states.split(
++      [self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
++  )
++  hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
++
++  # --- guard (3): identity SSM step on pads. ---
++  if valid is not None:
++    dt = dt * valid[..., None] + (1.0 - valid[..., None]) * _PAD_DT
++
++  use_precomputed_states = cache_params is not None and cache_params.has_previous_state(
++      self.layer_idx
++  )
++  # Diagnostic only (LITERT_GRANITE_IGNORE_STATE=1): trace the chunked path as
++  # if there were no incoming conv/SSM state. For a prompt that fits ONE chunk
++  # the result is unchanged (the state is zero there anyway), so a backend whose
++  # answer changes under this flag is handing the graph non-zero state buffers.
++  # It breaks multi-chunk continuation — never export a ship file with it.
++  ignore_state = os.environ.get("LITERT_GRANITE_IGNORE_STATE") == "1"
++  if ignore_state and seq_len > 1:
++    use_precomputed_states = False
++  if use_precomputed_states:
++    conv_state = cache_params.layers[self.layer_idx].conv_states[0]
++
++  single_step = use_precomputed_states and seq_len == 1
++
++  # 2. Convolution sequence transformation
++  if single_step:
++    conv_states = cache_params.update_conv_state(hidden_states_B_C, self.layer_idx)[
++        ..., -self.conv_kernel_size :
++    ]
++    hidden_states_B_C = torch.sum(
++        conv_states * self.conv1d.weight.squeeze(1), dim=-1
++    )
++    if self.use_conv_bias:
++      hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
++    hidden_states_B_C = self.act(hidden_states_B_C)
++  else:
++    if use_precomputed_states:
++      hidden_states_B_C = torch.cat([conv_state, hidden_states_B_C], dim=-1)
++    if cache_params is not None:
++      # --- guard (4): store the conv window ending at the last VALID column,
++      # selected in-graph with a one-hot matmul. ---
++      # LITERT_GRANITE_CONV_GUARD=off stores the chunk's last K columns
++      # instead of the last VALID ones. That is the pre-guard behaviour
++      # (pad tokens poison the stored window at chunk-plan-dependent
++      # prompt lengths), kept ONLY to isolate this store on GPU.
++      if valid is not None and os.environ.get(
++          "LITERT_GRANITE_CONV_GUARD") != "off":
++        _w = hidden_states_B_C.shape[-1]
++        _K = self.conv_kernel_size
++        _seq = valid.shape[-1]
++        _lead = torch.zeros(
++            hidden_states_B_C.shape[:-1] + (_K,),
++            device=hidden_states_B_C.device,
++            dtype=hidden_states_B_C.dtype,
++        )
++        _padded = torch.cat([_lead, hidden_states_B_C], dim=-1)
++        # ⚠ KEEP THE BATCH DIMENSION. Reducing the mask to a RANK-0 scalar and
++        # broadcasting that against `arange` is what breaks this store on the
++        # GPU delegates: measured 2026-08-13 with tools/backend_diff, a bare
++        # `arange` matches CPU exactly, `100.0 + arange` matches exactly, and
++        # the mask and its sum match exactly — but `rank0_scalar + arange` does
++        # not (CPU [12,13,14,15], GPU max 12), the selector built from it comes
++        # back ALL ZERO, and every mamba layer's stored conv state is then
++        # exactly 0.0 on GPU while CPU has real values. Generation collapses
++        # because decode convolves against no history. With `keepdim=True` the
++        # whole chain — index, selector and gather — matches CPU exactly.
++        #
++        # int64 is separately fatal here: the CAST/ADD it produces is refused
++        # outright, and these nodes sit upstream of every mamba layer, so three
++        # of them cost 97% of the delegated graph. Every value is a small exact
++        # integer, so float32 index arithmetic is exact.
++        _valid_len = valid.sum(-1, keepdim=True).to(_padded.dtype)  # (B, 1)
++        _base = float(_w - _seq) + _valid_len  # (B, 1)
++        _idx = _base + torch.arange(
++            _K, device=_padded.device, dtype=_padded.dtype
++        )  # (B, K)
++        _cols = torch.arange(
++            _w + _K, device=_padded.device, dtype=_padded.dtype
++        )  # (P,)
++        # Selector by arithmetic distance rather than `==`: same tensor, and it
++        # keeps a bool/CAST pair out of the graph. Distances are exact integers.
++        _sel = torch.relu(
++            1.0 - torch.abs(_cols[None, :, None] - _idx[:, None, :])
++        )  # (B, P, K)
++        conv_states = torch.matmul(_padded, _sel)
++      else:
++        conv_states = F.pad(
++            hidden_states_B_C,
++            (self.conv_kernel_size - hidden_states_B_C.shape[-1], 0),
++        )
++      cache_params.update_conv_state(conv_states, self.layer_idx)
++
++    hidden_states_B_C = self.act(
++        self.conv1d(hidden_states_B_C)[..., : hidden_states_B_C.shape[-1]]
++    )
++    if use_precomputed_states:
++      hidden_states_B_C = hidden_states_B_C[..., -seq_len:]
++    hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
++
++  # --- guard (2): zero x/B/C at pad positions for the scan. ---
++  if valid is not None:
++    hidden_states_B_C = hidden_states_B_C * valid[..., None]
++
++  hidden_states, B, C = torch.split(
++      hidden_states_B_C,
++      [self.intermediate_size, n_groups * N, n_groups * N],
++      dim=-1,
++  )
++
++  # 3. SSM transformation
++  A = -torch.exp(self.A_log.float())  # (H,)
++
++  if single_step:
++    # Single-token recurrence. Upstream `expand`s dt/A/B/C/D up to
++    # [bsz, heads, head_dim, state]; every one of those is a BROADCAST_TO, so
++    # use implicit (None-indexed) broadcasting instead — same rank-4 arithmetic,
++    # no BROADCAST_TO. n_groups == 1 broadcasts B/C over the head axis directly.
++    dt = F.softplus(dt[:, 0, :] + self.dt_bias)  # (b, H)
++    dt = torch.clamp(dt, self.time_step_limit[0], self.time_step_limit[1])
++    dA = torch.exp(dt * A)  # (b, H)
++
++    x = hidden_states.reshape(batch_size, H, P)  # (b, H, P)
++    if n_groups == 1:
++      # One group: leave the head axis at 1 and let the rank-4 arithmetic below
++      # broadcast it — cheaper than replicating, and no BROADCAST_TO either way.
++      Bh = B.reshape(batch_size, 1, N)
++      Ch = C.reshape(batch_size, 1, N)
++    elif rep > 1:
++      Bh = _repeat_groups_step(B, n_groups, rep, N)  # (b, H, N)
++      Ch = _repeat_groups_step(C, n_groups, rep, N)
++    else:
++      Bh = B.reshape(batch_size, H, N)  # one group per head
++      Ch = C.reshape(batch_size, H, N)
++
++    dBx = dt[:, :, None, None] * Bh[:, :, None, :] * x[:, :, :, None]  # (b,H,P,N)
++    prev = cache_params.layers[self.layer_idx].recurrent_states[0]
++    ssm_state = prev.to(dBx.dtype) * dA[:, :, None, None] + dBx  # rank-4 ADD
++    ssm_state = cache_params.update_recurrent_state(ssm_state, self.layer_idx)
++
++    y = (ssm_state.to(Ch.dtype) * Ch[:, :, None, :]).sum(-1)  # (b, H, P)
++    y = y + x * self.D[None, :, None]
++    y = y.reshape(batch_size, -1)[:, None, ...]  # (b, 1, intermediate)
++  else:
++    # Chunked scan. Same five contractions as upstream, written as batched
++    # matmuls with (batch, head, chunk) folded into one leading axis.
++    cl = self.chunk_size
++    pad_size = (cl - seq_len % cl) % cl
++    seq_p = seq_len + pad_size
++    c = seq_p // cl
++
++    dt = F.softplus(dt + self.dt_bias)  # (b, seq, H)
++    dt = torch.clamp(dt, self.time_step_limit[0], self.time_step_limit[1])
++
++    hidden_states = hidden_states.reshape(batch_size, seq_len, -1, P).float()
++    B = B.reshape(batch_size, seq_len, -1, N).float()
++    C = C.reshape(batch_size, seq_len, -1, N).float()
++    if rep > 1:
++      B = _repeat_groups(B, rep)
++      C = _repeat_groups(C, rep)
++
++    D_residual = self.D[..., None] * hidden_states  # (b, seq, H, P)
++    hidden_states = hidden_states * dt[..., None]
++    A = A.to(hidden_states.dtype) * dt  # (b, seq, H)
++
++    # Pad to a chunk boundary. Zero x contributes nothing and zero A decays
++    # nothing, so the real positions — and the stored end-of-chunk state — are
++    # unchanged; this is upstream's `reshape_into_chunks` pad, as a cat.
++    if pad_size > 0:
++      hidden_states = _zeros_cat(hidden_states, pad_size, 1)
++      B = _zeros_cat(B, pad_size, 1)
++      C = _zeros_cat(C, pad_size, 1)
++      A = _zeros_cat(A, pad_size, 1)
++
++    def fold(t, last):  # (b, seq_p, H, last) -> (b*H*c, cl, last)
++      return t.permute(0, 2, 1, 3).reshape(batch_size * H * c, cl, last)
++
++    xf = fold(hidden_states, P)
++    bf = fold(B, N)
++    cf = fold(C, N)
++    af = A.permute(0, 2, 1).reshape(batch_size * H * c, cl)
++
++    a_cumsum = _cumsum_last(af)  # (bhc, cl)
++    Lf = _exp_segment_sum_from_cumsum(a_cumsum)  # (bhc, cl, cl)
++
++    # 1. intra-chunk (diagonal blocks)
++    G = torch.matmul(cf, bf.transpose(1, 2))  # (bhc, cl, cl)
++    M = G * Lf
++    Y_diag = torch.matmul(M, xf)  # (bhc, cl, P)
++
++    # 2. per-chunk end state (kept as (N, P) — transposed against upstream's
++    # (P, N) — so the contraction is a plain matmul; transposed back at the
++    # cache boundary below).
++    decay_states = torch.exp(a_cumsum[:, -1:] - a_cumsum)  # (bhc, cl)
++    B_decay = bf * decay_states[..., None]
++    states = torch.matmul(B_decay.transpose(1, 2), xf)  # (bhc, N, P)
++
++    # 3. inter-chunk recurrence: a contraction over the chunk axis.
++    states_bh = states.reshape(batch_size * H, c, N * P)
++    if use_precomputed_states:
++      prev = cache_params.layers[self.layer_idx].recurrent_states[0]  # (b,H,P,N)
++      prev = (
++          prev.to(states_bh.dtype)
++          .permute(0, 1, 3, 2)
++          .reshape(batch_size * H, 1, N * P)
++      )
++    else:
++      prev = torch.zeros_like(states_bh[:, :1])
++    states_bh = torch.cat([prev, states_bh], dim=1)  # (bH, c+1, N*P)
++
++    chunk_tail = a_cumsum[:, -1].reshape(batch_size * H, c)
++    chunk_tail = torch.cat(
++        [torch.zeros_like(chunk_tail[:, :1]), chunk_tail], dim=1
++    )  # (bH, c+1)
++    decay_chunk = _exp_segment_sum_from_cumsum(
++        _cumsum_last(chunk_tail)
++    )  # (bH, c+1, c+1)
++    new_states = torch.matmul(decay_chunk, states_bh)  # (bH, c+1, N*P)
++    states_out, ssm_state = new_states[:, :-1], new_states[:, -1]
++
++    # 4. state -> output per chunk (off-diagonal blocks)
++    st = states_out.reshape(batch_size * H * c, N, P)
++    Y_off = torch.matmul(cf, st) * torch.exp(a_cumsum)[..., None]  # (bhc, cl, P)
++
++    y = Y_diag + Y_off
++    y = y.reshape(batch_size, H, seq_p, P).permute(0, 2, 1, 3)  # (b, seq_p, H, P)
++    if pad_size > 0:
++      y = y[:, :seq_len]
++    y = (y + D_residual).reshape(batch_size, seq_len, -1)
++
++    if cache_params is not None:
++      ssm_state = ssm_state.reshape(batch_size, H, N, P).permute(0, 1, 3, 2)
++      cache_params.update_recurrent_state(ssm_state, self.layer_idx)
++
++  scan_output = self.norm(y, gate)
++  return self.out_proj(scan_output.to(dtype))
++
++
++# ---------------------------------------------------------------------------
++# upstream scan + guard (bisect path), via anchored source replacement
++# ---------------------------------------------------------------------------
++
++
++def _build_guarded_torch_forward():
++  """Upstream `torch_forward` with the pad guard, generated from the installed
++  source via anchored replacements (the pre-rewrite export path)."""
++  src = inspect.getsource(
++      modeling_granitemoehybrid.GraniteMoeHybridMambaLayer.torch_forward
++  )
++  src = textwrap.dedent(src)
++
++  # NOTE: all anchors/replacements are in POST-DEDENT coordinates (the file's
++  # indentation minus 4: method body at 4, else-branch bodies at 8/12/16).
++
++  # (1) input zeroing + guard activation. The 2D mask only arrives on the
++  # prefill signatures (seq_len > 1); decode must NOT mask (a legitimately
++  # generated token id 0 would be zeroed).
++  anchor = ("    input_states = apply_mask_to_padding_states"
++            "(input_states, attention_mask)\n")
++  assert src.count(anchor) == 1, "pad-guard anchor 1 not found"
++  src = src.replace(
++      anchor,
++      "    valid = getattr(self, '_litert_valid', None)\n"
++      "    if valid is not None and input_states.shape[1] > 1:\n"
++      "        valid = valid.to(input_states.dtype)\n"
++      "        input_states = input_states * valid[..., None]\n"
++      "    else:\n"
++      "        valid = None\n",
++  )
++
++  # (2) dt identity on pads (pre-softplus -30 -> softplus ~ 0 -> exp(dt*A) ~ 1).
++  anchor = "    hidden_states_B_C = hidden_states_B_C.transpose(1,2)\n"
++  assert src.count(anchor) == 1, "pad-guard anchor 2 not found"
++  src = src.replace(
++      anchor,
++      anchor
++      + "    if valid is not None:\n"
++      "        dt = dt * valid[..., None] + (1.0 - valid[..., None]) * (-30.0)\n",
++  )
++
++  # (3) post-conv zeroing (x/B/C for the scan). Stock apply_mask... is a no-op
++  # at batch 1, so do it explicitly.
++  anchor = ("    hidden_states_B_C = apply_mask_to_padding_states("
++            "hidden_states_B_C, attention_mask)\n")
++  assert src.count(anchor) == 1, "pad-guard anchor 3 not found"
++  src = src.replace(
++      anchor,
++      "    if valid is not None:\n"
++      "        hidden_states_B_C = hidden_states_B_C * valid[..., None]\n",
++  )
++
++  # (4) conv window gathered at the last VALID column (one-hot matmul).
++  anchor = (
++      "        if cache_params is not None:\n"
++      "            conv_states = nn.functional.pad(\n"
++      "                hidden_states_B_C, (self.conv_kernel_size - "
++      "hidden_states_B_C.shape[-1], 0)\n"
++      "            )\n"
++      "            cache_params.update_conv_state(conv_states, self.layer_idx)\n"
++  )
++  assert src.count(anchor) == 1, "pad-guard anchor 4 not found"
++  src = src.replace(
++      anchor,
++      "        if cache_params is not None:\n"
++      "            if valid is not None:\n"
++      "                _w = hidden_states_B_C.shape[-1]\n"
++      "                _K = self.conv_kernel_size\n"
++      "                _padded = nn.functional.pad(hidden_states_B_C, (_K, 0))\n"
++      # float32 index arithmetic: an int64 CAST/ADD is refused by the OpenCL
++      # delegate and cuts the graph at every mamba layer (see the folded path).
++      "                _valid_len = valid.sum(-1)[0]\n"
++      "                _base = float(_w - valid.shape[-1]) + _valid_len\n"
++      "                _idx = _base + torch.arange(_K, device=_padded.device,\n"
++      "                                            dtype=_base.dtype)\n"
++      # relu(1 - |cols - idx|), not `==`: a bool EQUAL + CAST comes back
++      # all-false on the GPU delegates (see the folded path).
++      "                _cols = torch.arange(_w + _K, device=_padded.device,\n"
++      "                                     dtype=_base.dtype)\n"
++      "                _onehot = torch.relu(1.0 - torch.abs(\n"
++      "                    _cols[:, None] - _idx[None, :])).to(_padded.dtype)\n"
++      "                conv_states = _padded @ _onehot\n"
++      "            else:\n"
++      "                conv_states = nn.functional.pad(\n"
++      "                    hidden_states_B_C, (self.conv_kernel_size - "
++      "hidden_states_B_C.shape[-1], 0)\n"
++      "                )\n"
++      "            cache_params.update_conv_state(conv_states, self.layer_idx)\n",
++  )
++
++  namespace = dict(vars(modeling_granitemoehybrid))
++  namespace["torch"] = torch
++  exec(compile(src, "<granite_pad_guard>", "exec"), namespace)  # pylint: disable=exec-used
++  return namespace["torch_forward"]
++
++
++def _use_folded():
++  return os.environ.get("LITERT_GRANITE_SSD", "folded").lower() != "naive"
++
++
++class PatchedGraniteMoeHybridMambaLayer(
++    modeling_granitemoehybrid.GraniteMoeHybridMambaLayer
++):
++  torch_forward = (
++      _folded_torch_forward if _use_folded() else _build_guarded_torch_forward()
++  )
++
++
++# ---------------------------------------------------------------------------
++# patch-time self-check
++# ---------------------------------------------------------------------------
++
++
++def _selfcheck_folded_ssd(tol=2e-4):
++  """Run the rewritten scan against the installed transformers implementation.
++
++  Covers the cache-free chunked path at both a chunk multiple and a ragged
++  length. The cached/decode paths are covered by the model-level parity gate
++  (they need a real export cache), but this is what catches an upstream change
++  to the scan math — the anchored guard path asserts on its anchors instead.
++  """
++  from transformers.models.granitemoehybrid.configuration_granitemoehybrid import (
++      GraniteMoeHybridConfig,
++  )
++
++  torch.manual_seed(0)
++  cfg = GraniteMoeHybridConfig(
++      hidden_size=64,
++      num_hidden_layers=1,
++      mamba_n_heads=8,
++      mamba_d_head=16,
++      mamba_d_state=16,
++      mamba_expand=2,
++      mamba_chunk_size=8,
++      mamba_n_groups=2,
++  )
++  layer = modeling_granitemoehybrid.GraniteMoeHybridMambaLayer(cfg, layer_idx=0)
++  layer = layer.eval().float()
++  worst = 0.0
++  for seq in (16, 13):
++    x = torch.randn(1, seq, cfg.hidden_size)
++    with torch.no_grad():
++      ref = modeling_granitemoehybrid.GraniteMoeHybridMambaLayer.torch_forward(
++          layer, x
++      )
++      new = _folded_torch_forward(layer, x)
++    worst = max(worst, (ref - new).abs().max().item() / ref.abs().max().item())
++  if worst > tol:
++    raise AssertionError(
++        "granite folded SSD rewrite disagrees with the installed transformers "
++        f"implementation (relative max|diff| {worst:.2e} > {tol:.0e}). The "
++        "upstream scan changed; re-derive the folded form or export with "
++        "LITERT_GRANITE_SSD=naive."
++    )
++  return worst
++
++
++@patches_lib.register_patch(["granitemoehybrid"])
++@contextlib.contextmanager
++def granitemoehybrid_litert_patch():
++  if _use_folded():
++    rel = _selfcheck_folded_ssd()
++    print(
++        "Granite-4-h (granitemoehybrid) patch applied "
++        f"(pad guard + rank<=4 SSD; self-check rel {rel:.1e})."
++    )
++  else:
++    print(
++        "Granite-4-h (granitemoehybrid) patch applied "
++        "(pad guard, upstream SSD — LITERT_GRANITE_SSD=naive)."
++    )
++  original_model = modeling_granitemoehybrid.GraniteMoeHybridModel
++  original_mixer = modeling_granitemoehybrid.GraniteMoeHybridMambaLayer
++  modeling_granitemoehybrid.GraniteMoeHybridModel = PatchedGraniteMoeHybridModel
++  modeling_granitemoehybrid.GraniteMoeHybridMambaLayer = (
++      PatchedGraniteMoeHybridMambaLayer
++  )
++  try:
++    yield
++  finally:
++    modeling_granitemoehybrid.GraniteMoeHybridModel = original_model
++    modeling_granitemoehybrid.GraniteMoeHybridMambaLayer = original_mixer
+diff --git a/litert_torch/generative/export_hf/model_ext/nemotron_h/__init__.py b/litert_torch/generative/export_hf/model_ext/nemotron_h/__init__.py
+new file mode 100644
+index 0000000..c0f98a7
+--- /dev/null
++++ b/litert_torch/generative/export_hf/model_ext/nemotron_h/__init__.py
+@@ -0,0 +1,14 @@
++# Copyright 2026 The LiteRT Torch Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++# ==============================================================================
+diff --git a/litert_torch/generative/export_hf/model_ext/nemotron_h/patch.py b/litert_torch/generative/export_hf/model_ext/nemotron_h/patch.py
+new file mode 100644
+index 0000000..a65f310
+--- /dev/null
++++ b/litert_torch/generative/export_hf/model_ext/nemotron_h/patch.py
+@@ -0,0 +1,397 @@
++# Copyright 2026 The LiteRT Torch Authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++# ==============================================================================
++"""NemotronH (Mamba2 + MLP + full-attention hybrid) LiteRT export patch.
++
++NemotronH's `torch_forward` is an older spelling of the same Mamba2 SSD scan
++granite-4.0-h carries (granite's modeling descends from this code). The mixer
++attribute names match granite's exactly, so the folded rank<=4 rewrite ports
++with exactly TWO functional differences, both asserted/checked here:
++
++1. **dt clamp is min-only.** The installed reference clamps
++   `softplus(dt + dt_bias)` at `time_step_min` and leaves the max unclamped
++   (the `time_step_max` clamp is commented out upstream). Granite clamps to
++   `time_step_limit[0..1]`. The folded port follows the installed reference.
++2. **The in_proj split carries two `d_mlp` slices** which are width-0 on every
++   published NemotronH config (`projection_size = intermediate + conv_dim +
++   heads` forces `d_mlp == 0`). Asserted at patch time; the port uses the
++   granite 3-way split.
++
++Cache side (core/cache.py): NemotronH interleaves cache-less `mlp` layers —
++`LiteRTLMNoCacheLayer` holds their index so mamba/attention layers keep
++addressing `cache_params.layers[self.layer_idx]` absolutely — and its config
++spells the mamba geometry `mamba_num_heads`/`mamba_head_dim`/`ssm_state_size`/
++`conv_kernel`, which the shared shape inference now reads.
++
++Everything else (pad guard incl. the keepdim rank-0 trap, the one-hot conv
++window store, BROADCAST_TO-free repeats, cat-not-PAD) is granite's, imported
++from granitemoehybrid/patch.py — see that module for the derivation and the
++GPU-delegate traps.
++"""
++
++import contextlib
++import os
++
++import torch
++from litert_torch.generative.export_hf.model_ext import patches as patches_lib
++from litert_torch.generative.export_hf.model_ext.granitemoehybrid import (
++    patch as granite_patch,
++)
++from transformers.models.nemotron_h import modeling_nemotron_h
++
++nn = torch.nn
++F = torch.nn.functional
++
++_PAD_DT = -30.0  # pre-softplus dt on pad positions -> identity SSM step
++
++
++class PatchedNemotronHModel(modeling_nemotron_h.NemotronHModel):
++  """Export-friendly NemotronH model (class swap; persists on the instance)."""
++
++  # transformers >= 5.14 gates experts_implementation on a module-source
++  # heuristic that the swapped class fails; same shim as granite's.
++  _can_set_experts_implementation_cached_value = True
++
++  def forward(self, input_ids=None, **kwargs):
++    valid = (input_ids != 0).to(torch.float32) if input_ids is not None else None
++    n_patched = 0
++    for module in self.modules():
++      if isinstance(module, PatchedNemotronHMamba2Mixer):
++        module._litert_valid = valid
++        n_patched += 1
++    if n_patched == 0 and "linear_attention" in getattr(
++        self.config, "layer_types", ()
++    ):
++      # The silent-failure mode this patch once shipped with: mixers built
++      # from an import-time class registry are NOT instances of the patched
++      # class, the reference scan traces instead, and every parity gate still
++      # passes. Fail loudly instead.
++      raise AssertionError(
++          "No patched NemotronH mixers found on the model - the class swap "
++          "did not reach the instances (MIXER_TYPES registry?)."
++      )
++    return super().forward(input_ids=input_ids, **kwargs)
++
++
++def _folded_torch_forward_nemotron(
++    self, input_states, cache_params=None, attention_mask=None
++):
++  """granite's folded rank<=4 SSD scan, ported to NemotronHMamba2Mixer.
++
++  Identical to granitemoehybrid._folded_torch_forward except the dt clamp
++  (min-only, matching the installed NemotronH reference). Helper functions are
++  granite's own.
++  """
++  del attention_mask  # the pad mask arrives via `_litert_valid`
++  _ones_row = granite_patch._ones_row
++  _cumsum_last = granite_patch._cumsum_last
++  _exp_segment_sum_from_cumsum = granite_patch._exp_segment_sum_from_cumsum
++  _repeat_groups = granite_patch._repeat_groups
++  _repeat_groups_step = granite_patch._repeat_groups_step
++  _zeros_cat = granite_patch._zeros_cat
++
++  batch_size, seq_len, _ = input_states.shape
++  dtype = input_states.dtype
++  H, P, N = self.num_heads, self.head_dim, self.ssm_state_size
++  n_groups = self.n_groups
++  rep = H // n_groups
++
++  valid = getattr(self, "_litert_valid", None)
++  if valid is not None and seq_len > 1:
++    valid = valid.to(dtype)
++    input_states = input_states * valid[..., None]
++  else:
++    valid = None
++
++  projected_states = self.in_proj(input_states)
++  # NemotronH's 5-way split has two d_mlp slices that are width-0 on every
++  # published config (asserted at patch time) -> granite's 3-way split.
++  gate, hidden_states_B_C, dt = projected_states.split(
++      [self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
++  )
++  hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
++
++  if valid is not None:
++    dt = dt * valid[..., None] + (1.0 - valid[..., None]) * _PAD_DT
++
++  use_precomputed_states = cache_params is not None and cache_params.has_previous_state(
++      self.layer_idx
++  )
++  if use_precomputed_states:
++    conv_state = cache_params.layers[self.layer_idx].conv_states[0]
++
++  single_step = use_precomputed_states and seq_len == 1
++
++  # 2. Convolution sequence transformation
++  if single_step:
++    conv_states = cache_params.update_conv_state(hidden_states_B_C, self.layer_idx)[
++        ..., -self.conv_kernel_size :
++    ]
++    hidden_states_B_C = torch.sum(
++        conv_states * self.conv1d.weight.squeeze(1), dim=-1
++    )
++    if self.use_conv_bias:
++      hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
++    hidden_states_B_C = self.act(hidden_states_B_C)
++  else:
++    if use_precomputed_states:
++      hidden_states_B_C = torch.cat([conv_state, hidden_states_B_C], dim=-1)
++    if cache_params is not None:
++      if valid is not None:
++        _w = hidden_states_B_C.shape[-1]
++        _K = self.conv_kernel_size
++        _seq = valid.shape[-1]
++        _lead = torch.zeros(
++            hidden_states_B_C.shape[:-1] + (_K,),
++            device=hidden_states_B_C.device,
++            dtype=hidden_states_B_C.dtype,
++        )
++        _padded = torch.cat([_lead, hidden_states_B_C], dim=-1)
++        # KEEP THE BATCH DIMENSION (rank-0 in broadcast arithmetic is
++        # silently miscomputed on GPU delegates; float32 index math because
++        # int64 CAST/ADD is refused) — see granitemoehybrid/patch.py.
++        _valid_len = valid.sum(-1, keepdim=True).to(_padded.dtype)  # (B, 1)
++        _base = float(_w - _seq) + _valid_len  # (B, 1)
++        _idx = _base + torch.arange(
++            _K, device=_padded.device, dtype=_padded.dtype
++        )  # (B, K)
++        _cols = torch.arange(
++            _w + _K, device=_padded.device, dtype=_padded.dtype
++        )  # (P,)
++        _sel = torch.relu(
++            1.0 - torch.abs(_cols[None, :, None] - _idx[:, None, :])
++        )  # (B, P, K)
++        conv_states = torch.matmul(_padded, _sel)
++      else:
++        conv_states = F.pad(
++            hidden_states_B_C,
++            (self.conv_kernel_size - hidden_states_B_C.shape[-1], 0),
++        )
++      cache_params.update_conv_state(conv_states, self.layer_idx)
++
++    hidden_states_B_C = self.act(
++        self.conv1d(hidden_states_B_C)[..., : hidden_states_B_C.shape[-1]]
++    )
++    if use_precomputed_states:
++      hidden_states_B_C = hidden_states_B_C[..., -seq_len:]
++    hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
++
++  if valid is not None:
++    hidden_states_B_C = hidden_states_B_C * valid[..., None]
++
++  hidden_states, B, C = torch.split(
++      hidden_states_B_C,
++      [self.intermediate_size, n_groups * N, n_groups * N],
++      dim=-1,
++  )
++
++  # 3. SSM transformation
++  A = -torch.exp(self.A_log.float())  # (H,)
++
++  if single_step:
++    dt = F.softplus(dt[:, 0, :] + self.dt_bias)  # (b, H)
++    dt = torch.clamp(dt, self.time_step_min)  # NemotronH: min-only clamp
++    dA = torch.exp(dt * A)  # (b, H)
++
++    x = hidden_states.reshape(batch_size, H, P)  # (b, H, P)
++    if n_groups == 1:
++      Bh = B.reshape(batch_size, 1, N)
++      Ch = C.reshape(batch_size, 1, N)
++    elif rep > 1:
++      Bh = _repeat_groups_step(B, n_groups, rep, N)  # (b, H, N)
++      Ch = _repeat_groups_step(C, n_groups, rep, N)
++    else:
++      Bh = B.reshape(batch_size, H, N)
++      Ch = C.reshape(batch_size, H, N)
++
++    dBx = dt[:, :, None, None] * Bh[:, :, None, :] * x[:, :, :, None]  # (b,H,P,N)
++    prev = cache_params.layers[self.layer_idx].recurrent_states[0]
++    ssm_state = prev.to(dBx.dtype) * dA[:, :, None, None] + dBx
++    ssm_state = cache_params.update_recurrent_state(ssm_state, self.layer_idx)
++
++    y = (ssm_state.to(Ch.dtype) * Ch[:, :, None, :]).sum(-1)  # (b, H, P)
++    y = y + x * self.D[None, :, None]
++    y = y.reshape(batch_size, -1)[:, None, ...]  # (b, 1, intermediate)
++  else:
++    cl = self.chunk_size
++    pad_size = (cl - seq_len % cl) % cl
++    seq_p = seq_len + pad_size
++    c = seq_p // cl
++
++    dt = F.softplus(dt + self.dt_bias)  # (b, seq, H)
++    dt = torch.clamp(dt, self.time_step_min)  # NemotronH: min-only clamp
++    # Pad positions must be EXACT identity steps. The -30 pre-softplus trick
++    # (granite) is not enough here: granite clamps to time_step_limit[0]=0.0,
++    # but NemotronH's min-only clamp FLOORS pad dt at time_step_min (1e-3), so
++    # every pad decays the state by exp(time_step_min * A) — ~15% per 10 pads
++    # on A≈-16 heads, state-annihilating on large underfilled signatures.
++    # Post-clamp masking forces dA = exp(0) = 1 exactly on pads.
++    if valid is not None:
++      dt = dt * valid[..., None]
++
++    hidden_states = hidden_states.reshape(batch_size, seq_len, -1, P).float()
++    B = B.reshape(batch_size, seq_len, -1, N).float()
++    C = C.reshape(batch_size, seq_len, -1, N).float()
++    if rep > 1:
++      B = _repeat_groups(B, rep)
++      C = _repeat_groups(C, rep)
++
++    D_residual = self.D[..., None] * hidden_states  # (b, seq, H, P)
++    hidden_states = hidden_states * dt[..., None]
++    A = A.to(hidden_states.dtype) * dt  # (b, seq, H)
++
++    if pad_size > 0:
++      hidden_states = _zeros_cat(hidden_states, pad_size, 1)
++      B = _zeros_cat(B, pad_size, 1)
++      C = _zeros_cat(C, pad_size, 1)
++      A = _zeros_cat(A, pad_size, 1)
++
++    def fold(t, last):  # (b, seq_p, H, last) -> (b*H*c, cl, last)
++      return t.permute(0, 2, 1, 3).reshape(batch_size * H * c, cl, last)
++
++    xf = fold(hidden_states, P)
++    bf = fold(B, N)
++    cf = fold(C, N)
++    af = A.permute(0, 2, 1).reshape(batch_size * H * c, cl)
++
++    a_cumsum = _cumsum_last(af)  # (bhc, cl)
++    Lf = _exp_segment_sum_from_cumsum(a_cumsum)  # (bhc, cl, cl)
++
++    G = torch.matmul(cf, bf.transpose(1, 2))  # (bhc, cl, cl)
++    M = G * Lf
++    Y_diag = torch.matmul(M, xf)  # (bhc, cl, P)
++
++    decay_states = torch.exp(a_cumsum[:, -1:] - a_cumsum)  # (bhc, cl)
++    B_decay = bf * decay_states[..., None]
++    states = torch.matmul(B_decay.transpose(1, 2), xf)  # (bhc, N, P)
++
++    states_bh = states.reshape(batch_size * H, c, N * P)
++    if use_precomputed_states:
++      prev = cache_params.layers[self.layer_idx].recurrent_states[0]  # (b,H,P,N)
++      prev = (
++          prev.to(states_bh.dtype)
++          .permute(0, 1, 3, 2)
++          .reshape(batch_size * H, 1, N * P)
++      )
++    else:
++      prev = torch.zeros_like(states_bh[:, :1])
++    states_bh = torch.cat([prev, states_bh], dim=1)  # (bH, c+1, N*P)
++
++    chunk_tail = a_cumsum[:, -1].reshape(batch_size * H, c)
++    chunk_tail = torch.cat(
++        [torch.zeros_like(chunk_tail[:, :1]), chunk_tail], dim=1
++    )  # (bH, c+1)
++    decay_chunk = _exp_segment_sum_from_cumsum(
++        _cumsum_last(chunk_tail)
++    )  # (bH, c+1, c+1)
++    new_states = torch.matmul(decay_chunk, states_bh)  # (bH, c+1, N*P)
++    states_out, ssm_state = new_states[:, :-1], new_states[:, -1]
++
++    st = states_out.reshape(batch_size * H * c, N, P)
++    Y_off = torch.matmul(cf, st) * torch.exp(a_cumsum)[..., None]  # (bhc, cl, P)
++
++    y = Y_diag + Y_off
++    y = y.reshape(batch_size, H, seq_p, P).permute(0, 2, 1, 3)  # (b, seq_p, H, P)
++    if pad_size > 0:
++      y = y[:, :seq_len]
++    y = (y + D_residual).reshape(batch_size, seq_len, -1)
++
++    if cache_params is not None:
++      ssm_state = ssm_state.reshape(batch_size, H, N, P).permute(0, 1, 3, 2)
++      cache_params.update_recurrent_state(ssm_state, self.layer_idx)
++
++  scan_output = self.norm(y, gate)
++  return self.out_proj(scan_output.to(dtype))
++
++
++class PatchedNemotronHMamba2Mixer(modeling_nemotron_h.NemotronHMamba2Mixer):
++  torch_forward = _folded_torch_forward_nemotron
++
++
++def _assert_dmlp_zero():
++  """The 3-way split is valid only while projection carries no MLP slices."""
++  # projection_size = intermediate + conv_dim + heads  ->  d_mlp == 0
++  # (see NemotronHMamba2Mixer.__init__ and the d_mlp formula in torch_forward)
++  import inspect
++
++  src = inspect.getsource(modeling_nemotron_h.NemotronHMamba2Mixer.__init__)
++  if "projection_size = self.intermediate_size + self.conv_dim + self.num_heads" not in src:
++    raise AssertionError(
++        "NemotronHMamba2Mixer.in_proj projection layout changed upstream; "
++        "re-check the d_mlp slices before using the 3-way split."
++    )
++
++
++def _selfcheck_folded_nemotron(tol=2e-4):
++  """Run the ported folded scan against the installed NemotronH reference."""
++  from transformers.models.nemotron_h.configuration_nemotron_h import (
++      NemotronHConfig,
++  )
++
++  torch.manual_seed(0)
++  cfg = NemotronHConfig(
++      hidden_size=64,
++      num_hidden_layers=1,
++      hybrid_override_pattern="M",
++      mamba_num_heads=8,
++      mamba_head_dim=16,
++      ssm_state_size=16,
++      expand=2,
++      chunk_size=8,
++      n_groups=2,
++      conv_kernel=4,
++  )
++  layer = modeling_nemotron_h.NemotronHMamba2Mixer(cfg, layer_idx=0).eval().float()
++  worst = 0.0
++  for seq in (16, 13):
++    x = torch.randn(1, seq, cfg.hidden_size)
++    with torch.no_grad():
++      ref = modeling_nemotron_h.NemotronHMamba2Mixer.torch_forward(layer, x)
++      new = _folded_torch_forward_nemotron(layer, x)
++    worst = max(worst, (ref - new).abs().max().item() / ref.abs().max().item())
++  if worst > tol:
++    raise AssertionError(
++        "NemotronH folded SSD disagrees with the installed transformers "
++        f"implementation (relative max|diff| {worst:.2e} > {tol:.0e})."
++    )
++  return worst
++
++
++@patches_lib.register_patch(["nemotron_h"])
++@contextlib.contextmanager
++def nemotron_h_litert_patch():
++  _assert_dmlp_zero()
++  rel = _selfcheck_folded_nemotron()
++  print(
++      "NemotronH patch applied (granite folded rank<=4 SSD + pad guard, "
++      f"min-only dt clamp; self-check rel {rel:.1e})."
++  )
++  original_model = modeling_nemotron_h.NemotronHModel
++  original_mixer = modeling_nemotron_h.NemotronHMamba2Mixer
++  # ⚠ NemotronHBlock picks mixer classes from the MODULE-LEVEL dict
++  # MIXER_TYPES (bound at import time) — swapping the module attribute alone
++  # NEVER reaches instances. This bit missing meant the whole 4B exported the
++  # REFERENCE scan with no guard and no folded rewrite, and every parity gate
++  # passed anyway (the reference math is correct math; only the pad sweep and
++  # the GPU sieve can tell the difference). Swap the dict entry too.
++  original_dict_mixer = modeling_nemotron_h.MIXER_TYPES["linear_attention"]
++  modeling_nemotron_h.NemotronHModel = PatchedNemotronHModel
++  modeling_nemotron_h.NemotronHMamba2Mixer = PatchedNemotronHMamba2Mixer
++  modeling_nemotron_h.MIXER_TYPES["linear_attention"] = PatchedNemotronHMamba2Mixer
++  try:
++    yield
++  finally:
++    modeling_nemotron_h.NemotronHModel = original_model
++    modeling_nemotron_h.NemotronHMamba2Mixer = original_mixer
++    modeling_nemotron_h.MIXER_TYPES["linear_attention"] = original_dict_mixer

--- a/models/nemotron/nemotron_3_nano_4b/converted/verify_nemotron_3_nano_4b.py
+++ b/models/nemotron/nemotron_3_nano_4b/converted/verify_nemotron_3_nano_4b.py
@@ -1,0 +1,389 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality gate, metadata and model-specific checks for a converted Nemotron-3-Nano-4B bundle.
+
+Four modes:
+
+  gate (default) — asks 8 fixed, unambiguously checkable questions through the
+    `litert-lm` CLI (pip install litert-lm, >= 0.15 for the hybrid state
+    binding), greedy, one fresh session per question, and scores correctness
+    plus degeneracy. This is a reasoning model: the vendor template opens the
+    reply with `<think>`, so the answer is whatever follows the last
+    `</think>`; a reply whose thought never closes counts as no answer. Every
+    run passes `--cache no` — on this family the GPU path fails outright with
+    the compiled-graph cache (see --cache-ab), and on CPU the cache is a
+    weight-sized file written next to the model.
+
+      python verify_nemotron_3_nano_4b.py model.litertlm [--backend cpu|gpu]
+
+  --check-metadata — reads the bundle (no unpacking) and asserts the shape
+    this recipe produces: NO start_token, <|im_end|> (11) and the exported
+    id 2 among the stop ids, the vendor Jinja template embedded byte-equal to
+    the repo's chat_template.jinja, an ExecutorMetadata section with the 50
+    hybrid state buffers (42 mamba conv+SSM, 8 attention K/V),
+    `prefer_activation_type = fp32` declared on the model section, and a
+    bytes-per-parameter ratio in the int8 band. Needs litert-lm-builder.
+
+      python verify_nemotron_3_nano_4b.py model.litertlm --check-metadata
+
+  --cache-ab — the one-variable reproducer of the GPU trap: the same
+    question on the GPU backend with the runtime's default compiled-graph
+    cache and with `--cache no`. On litert-lm 0.16.0 the default arm dies
+    (WebGPU "Invalid BindGroup" validation errors) and the `--cache no` arm
+    answers. Any file the default arm writes next to the model is removed.
+
+      python verify_nemotron_3_nano_4b.py model.litertlm --cache-ab
+
+  --bos-ab — the BOS finding measured on the unquantized model: HF bf16
+    greedy decoding of the SAME rendered prompt with and without a leading
+    `<s>`, three probes. The recorded result is byte-identical on 2 of 3 and a
+    mid-thought divergence to the same final answer on the third — the
+    dropped start_token aligns the stream with training, it does not change
+    the verdict at this scale. Needs torch + transformers and the source
+    checkpoint (8 GB); `use_cache=False` because transformers' generic cache
+    has no `mlp` layer type for this architecture.
+
+      python verify_nemotron_3_nano_4b.py model.litertlm --bos-ab [--device cpu|mps]
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+PARAMS = 3_973_556_832  # every tensor in the checkpoint; embeddings are untied
+IM_END_ID, EXPORTED_EOS_ID = 11, 2
+# The repo's chat_template.jinja — the one AutoTokenizer resolves. (The same
+# repo's tokenizer_config.json carries a different, 10,497-byte copy.)
+TEMPLATE_BYTES = 10504
+STATE_LINEAR_ATTN, STATE_KV = 42, 8  # 21 mamba layers x2, 4 attention layers x2
+
+SUFFIX = " Answer briefly."
+# (label, question, answer-regex, wrong-answer-veto-regex-or-None).
+QUESTIONS = [
+    ("17+25=42", "What is 17 + 25?", r"\b42\b", None),
+    ("capital=Tokyo", "What is the capital of Japan?", r"tokyo", None),
+    ("opp(hot)=cold", 'What is the opposite of "hot"?', r"\bcold\b", None),
+    ("days/week=7", "How many days are in a week?", r"\bseven\b|\b7\b", None),
+    ("thanks(fr)=merci", 'How do you say "thank you" in French?', r"merci", None),
+    ("8*7=56", "What is 8 times 7?", r"\b56\b", None),
+    ("0.9>0.11", "Which is larger: 0.9 or 0.11?", r"0\.9\b",
+     r"0\.11\s*(is|>)\s*(the\s+)?(larg|great|bigg)"),
+    ("rhyme=blue", 'Complete the rhyme: "Roses are red, violets are ___"',
+     r"\bblue\b", None),
+]
+BOS_PROBES = ["What is 17 + 25?", "Name the capital of France.",
+              "Say 'hello' in Japanese."]
+
+
+def degenerate(text):
+  """True if the output loops or is special-token spam."""
+  words = text.split()
+  if len(words) >= 10:
+    grams = [" ".join(words[i:i + 5]) for i in range(len(words) - 4)]
+    top = Counter(grams).most_common(1)[0][1] if grams else 0
+    diversity = len(set(words)) / len(words)
+    if top >= 3 and (top >= 5 or diversity < 0.50):
+      return True
+    if diversity < 0.30:
+      return True
+  if len(text) >= 40 and len(set(text)) < 15:
+    return True
+  if text.count("<|") >= 5 or text.count("<pad>") >= 5 or text.count("<SPECIAL_") >= 5:
+    return True
+  return False
+
+
+def final_answer(text):
+  """The part of a reply after its thought. The template already emitted
+  `<think>`, so the stream is thought text, `</think>`, then the answer."""
+  if "</think>" in text:
+    return text.rsplit("</think>", 1)[1].strip()
+  if "<think>" in text or text.strip():
+    # a thought that never closed — no final answer was produced
+    return ""
+  return ""
+
+
+def run_cli(litert_lm, model, prompt, backend, timeout, cache="no"):
+  cmd = [litert_lm, "run", str(model), "--backend", backend,
+         "--temperature", "0", "--top-k", "1"]
+  if cache:
+    cmd += ["--cache", cache]
+  cmd += ["--prompt", prompt]
+  return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def run_one(litert_lm, model, prompt, backend, timeout):
+  proc = run_cli(litert_lm, model, prompt, backend, timeout)
+  if proc.returncode != 0:
+    raise RuntimeError(
+        f"litert-lm run failed (exit={proc.returncode}).\n"
+        f"--- stderr tail ---\n{proc.stderr[-1500:]}")
+  return proc.stdout.strip()
+
+
+def gate(args):
+  results = []
+  for label, q, pat, veto in QUESTIONS:
+    try:
+      raw = run_one(args.litert_lm, args.model, q + SUFFIX, args.backend, args.timeout)
+    except Exception as e:  # noqa: BLE001
+      print(f"FAIL (harness) on '{label}': {e}", file=sys.stderr)
+      return 2
+    ans = final_answer(raw)
+    low = ans.lower()
+    ok = bool(re.search(pat, low)) and not (veto and re.search(veto, low))
+    degen = (not ans) or degenerate(raw)
+    results.append({"label": label, "question": q, "ok": ok, "degenerate": degen,
+                    "answer": ans, "raw": raw})
+    shown = " ".join(ans.split())[:70] if ans else "(no answer — thought never closed)"
+    print(f"  [{'v' if ok else '.'}]{' DEGEN' if degen else '      '} "
+          f"{label:16s} -> {shown!r}  (thought {len(raw.split())} words)")
+
+  score = sum(r["ok"] for r in results)
+  any_degen = any(r["degenerate"] for r in results)
+  passed = (score >= args.min_correct) and (not any_degen)
+  print(f"\n  correct: {score}/8   degenerate: {'YES' if any_degen else 'no'}")
+  print(f"  VERDICT: {'PASS' if passed else 'FAIL'} "
+        f"(threshold {args.min_correct}/8, non-degenerate)")
+  if args.json:
+    Path(args.json).write_text(json.dumps({
+        "model": str(args.model), "backend": args.backend, "cache": "no",
+        "score": score, "of": 8, "degenerate": any_degen, "passed": passed,
+        "questions": results}, indent=2, ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if passed else 1
+
+
+def read_bundle(model, jinja_path=None):
+  """(LlmMetadata pbtext, ExecutorMetadata pbtext, [sections]) via peek."""
+  from litert_lm_builder import litertlm_peek  # pip install litert-lm-builder
+
+  buf = io.StringIO()
+  litertlm_peek.peek_litertlm_file(str(model), None, buf,
+                                   jinja_prompt_template_path=jinja_path)
+  text = buf.getvalue()
+  m = re.search(r"start of LlmMetadata\n(.*?)>{4,} end of LlmMetadata", text, re.S)
+  pbtext = m.group(1) if m else ""
+  m = re.search(r"start of ExecutorMetadata\n(.*?)>{4,} end of ExecutorMetadata", text, re.S)
+  exec_pbtext = m.group(1) if m else ""
+  sections = []
+  for sm in re.finditer(
+      r"Section (\d+):\n(.*?)Begin Offset:\s*(\d+)\n\s*End Offset:\s*(\d+)\n"
+      r"\s*Data Type:\s*(\S+)", text, re.S):
+    items = sm.group(2)
+    act = re.search(r"prefer_activation_type, Value \(String\): (\S+)", items)
+    sections.append({"index": int(sm.group(1)), "type": sm.group(5),
+                     "activation": act.group(1) if act else None,
+                     "bytes": int(sm.group(4)) - int(sm.group(3))})
+  return pbtext, exec_pbtext, sections
+
+
+def check_metadata(args):
+  with tempfile.TemporaryDirectory() as td:
+    jinja_path = os.path.join(td, "template.jinja")
+    pbtext, exec_pbtext, sections = read_bundle(args.model, jinja_path)
+    embedded = Path(jinja_path).read_bytes() if os.path.exists(jinja_path) else b""
+  if not pbtext:
+    print("FAIL: no LlmMetadata section found")
+    return 1
+  checks = []
+
+  def check(name, ok, detail=""):
+    checks.append(ok)
+    print(f"  [{'v' if ok else 'X'}] {name}{(': ' + detail) if detail else ''}")
+
+  check("no start_token (add_bos_token False; template opens with <|im_start|>)",
+        not re.search(r"^\s*start_token\s*\{", pbtext, re.M))
+  stop_ids = {int(x) for x in re.findall(r"ids:\s*(\d+)", pbtext)}
+  check(f"<|im_end|> ({IM_END_ID}) and the exported eos ({EXPORTED_EOS_ID}) are stop ids",
+        {IM_END_ID, EXPORTED_EOS_ID} <= stop_ids, f"stop ids {sorted(stop_ids)}")
+
+  md5 = hashlib.md5(embedded).hexdigest()
+  detail = f"{len(embedded)} B, md5 {md5[:8]}…"
+  try:
+    from huggingface_hub import hf_hub_download
+    repo_tpl = Path(hf_hub_download(MODEL_ID, "chat_template.jinja")).read_bytes()
+    check("embedded Jinja is byte-equal to the repo's chat_template.jinja",
+          embedded == repo_tpl, detail + f" vs repo {len(repo_tpl)} B")
+  except Exception as e:  # noqa: BLE001
+    check("embedded Jinja has the repo chat_template.jinja's length",
+          len(embedded) == TEMPLATE_BYTES, detail + f" (Hub unreachable: {type(e).__name__})")
+  ctx = re.search(r"max_num_tokens:\s*(\d+)", pbtext)
+  check("max_num_tokens 4096", bool(ctx) and int(ctx.group(1)) == 4096,
+        ctx.group(1) if ctx else "missing")
+
+  types = [s["type"] for s in sections]
+  check("ExecutorMetadata section present (litert-lm >= 0.15 binds hybrid state through it)",
+        "ExecutorMetadataProto" in types, str(types))
+  la = len(re.findall(r"type:\s*TYPE_LINEAR_ATTENTION", exec_pbtext))
+  kv = len(re.findall(r"type:\s*TYPE_GLOBAL_(?:KEY|VALUE)_CACHE", exec_pbtext))
+  check(f"{STATE_LINEAR_ATTN} mamba conv+SSM buffers + {STATE_KV} attention K/V buffers",
+        (la, kv) == (STATE_LINEAR_ATTN, STATE_KV), f"{la} + {kv}")
+  seq = {int(x) for x in re.findall(r"maximum_sequence_length:\s*(\d+)", exec_pbtext)}
+  check("attention caches sized to the 4096 budget", seq == {4096}, str(sorted(seq)))
+  act = [s["activation"] for s in sections if s["type"] == "TFLiteModel"]
+  check("prefer_activation_type = fp32 on the model section (GPU keeps the scan in range)",
+        act == ["fp32"], str(act))
+
+  total = os.path.getsize(args.model)
+  bpp = total / PARAMS
+  check("bytes per parameter in the int8 band (0.9–1.35)", 0.9 <= bpp <= 1.35,
+        f"{total:,} B / {PARAMS:,} params = {bpp:.2f}")
+  print("  (i) sections: " + ", ".join(
+      f"{s['type']}:{s['bytes'] / 1024 ** 3:.2f} GiB" for s in sections)
+      + " — the weights sit in one section (this recipe does not externalize "
+        "the embedder); phone loading is not measured for this bundle")
+
+  ok = all(checks)
+  print(f"\n  {'PASS' if ok else 'FAIL'}: {sum(checks)}/{len(checks)} metadata checks")
+  return 0 if ok else 1
+
+
+def cache_ab(args):
+  q = QUESTIONS[0][1] + SUFFIX
+  model = Path(args.model)
+  before = set(os.listdir(model.parent))
+  rows = {}
+  for arm, cache in (("default cache", None), ("--cache no", "no")):
+    try:
+      proc = run_cli(args.litert_lm, model, q, "gpu", args.timeout, cache=cache)
+      out = proc.stdout.strip()
+      err = proc.stderr
+      ans = final_answer(out)
+      ok = proc.returncode == 0 and bool(re.search(r"\b42\b", ans)) and not degenerate(out)
+      rows[arm] = {"exit": proc.returncode, "ok": ok, "answer": ans[:80],
+                   "stderr_tail": err[-600:]}
+      why = "" if ok else (" — " + (next((l for l in err.splitlines()
+                                          if "BindGroup" in l or "rror" in l), "")[:110]))
+      print(f"  [{'v' if ok else 'X'}] GPU, {arm:14s} exit={proc.returncode} "
+            f"answer={ans[:40]!r}{why}")
+    except subprocess.TimeoutExpired:
+      rows[arm] = {"exit": None, "ok": False, "answer": "", "stderr_tail": "timeout"}
+      print(f"  [X] GPU, {arm:14s} timeout")
+  new = sorted(set(os.listdir(model.parent)) - before)
+  for f in new:
+    p = model.parent / f
+    print(f"  removed cache artifact written by the default arm: {f} "
+          f"({os.path.getsize(p) / 1e6:.0f} MB)")
+    p.unlink() if p.is_file() else None
+  a, b = rows["default cache"]["ok"], rows["--cache no"]["ok"]
+  verdict = ("trap reproduces: GPU works only with --cache no" if b and not a else
+             "both arms answer — the cache trap no longer reproduces on this runtime"
+             if a and b else "GPU answers with the default cache but not with --cache no"
+             if a and not b else "GPU fails on both arms")
+  print(f"\n  VERDICT: {verdict}")
+  if args.json:
+    Path(args.json).write_text(json.dumps({"model": str(model), "verdict": verdict,
+                                           "arms": rows}, indent=2) + "\n")
+    print(f"  wrote {args.json}")
+  return 0 if b else 1
+
+
+def bos_ab(args):
+  import torch
+  from transformers import AutoModelForCausalLM, AutoTokenizer
+
+  device = args.device
+  if device == "auto":
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+  tok = AutoTokenizer.from_pretrained(MODEL_ID)
+  model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16).to(device).eval()
+  assert tok.bos_token == "<s>" and tok.bos_token_id is not None
+  rows, identical = [], 0
+  for q in BOS_PROBES:
+    text = tok.apply_chat_template([{"role": "user", "content": q}], tokenize=False,
+                                   add_generation_prompt=True)
+    assert not text.startswith(tok.bos_token), "template now renders a BOS itself"
+    ids = tok(text, add_special_tokens=False, return_tensors="pt").input_ids
+    arms = {"no_bos": ids,
+            "with_bos": torch.cat([torch.tensor([[tok.bos_token_id]]), ids], dim=1)}
+    row = {"q": q}
+    for name, inp in arms.items():
+      with torch.no_grad():
+        out = model.generate(inp.to(device), max_new_tokens=args.max_new, do_sample=False,
+                             use_cache=False, pad_token_id=tok.pad_token_id or 0)
+      new = out[0, inp.shape[1]:].tolist()
+      row[name] = {"ids": new, "text": tok.decode(new)}
+    same = row["no_bos"]["ids"] == row["with_bos"]["ids"]
+    row["identical"] = same
+    if not same:
+      row["diverge_at_token"] = next(i for i, (a, b) in enumerate(
+          zip(row["no_bos"]["ids"], row["with_bos"]["ids"])) if a != b)
+    fa, fb = final_answer(row["no_bos"]["text"]), final_answer(row["with_bos"]["text"])
+    row["same_final_answer"] = fa.split("<|im_end|>")[0].strip() == fb.split("<|im_end|>")[0].strip()
+    identical += same
+    rows.append(row)
+    print(f"  {q:32s} identical={'yes' if same else 'no '}"
+          + ("" if same else f" (diverges at token {row['diverge_at_token']}, "
+             f"same final answer: {'yes' if row['same_final_answer'] else 'NO'})"))
+    print(f"      no BOS  : {row['no_bos']['text'][:150]!r}")
+    print(f"      with BOS: {row['with_bos']['text'][:150]!r}")
+  robust = all(r["identical"] or r["same_final_answer"] for r in rows)
+  print(f"\n  byte-identical: {identical}/{len(rows)}; same final answer on all: "
+        f"{'yes' if robust else 'NO'}")
+  print("  VERDICT: " + ("robust to the leading <s> at this scale — dropping the "
+                         "start_token is a stream-fidelity fix, not a rescue" if robust
+                         else "the leading <s> changes an answer — the start_token "
+                         "drop is load-bearing here"))
+  if args.json:
+    Path(args.json).write_text(json.dumps({"device": device, "rows": rows}, indent=1,
+                                          ensure_ascii=False) + "\n")
+    print(f"  wrote {args.json}")
+  return 0
+
+
+def main():
+  ap = argparse.ArgumentParser(
+      description="Quality gate / metadata / GPU-cache / BOS checks for Nemotron-3-Nano-4B")
+  ap.add_argument("model", help="path to model.litertlm")
+  ap.add_argument("--backend", choices=["cpu", "gpu"], default="cpu")
+  ap.add_argument("--min-correct", type=int, default=6)
+  ap.add_argument("--timeout", type=int, default=900,
+                  help="seconds per question (engine init is paid every run; ~25 s "
+                       "on CPU for this 4B)")
+  ap.add_argument("--litert-lm", default="litert-lm",
+                  help="path to the litert-lm CLI (pip install litert-lm)")
+  ap.add_argument("--device", default="auto", help="--bos-ab: cpu|mps|auto")
+  ap.add_argument("--max-new", type=int, default=96, help="--bos-ab: tokens per arm")
+  ap.add_argument("--json", help="write a JSON report here")
+  ap.add_argument("--check-metadata", action="store_true")
+  ap.add_argument("--cache-ab", action="store_true")
+  ap.add_argument("--bos-ab", action="store_true")
+  args = ap.parse_args()
+
+  if not args.bos_ab and not Path(args.model).exists():
+    print(f"ERROR: model not found: {args.model}", file=sys.stderr)
+    return 2
+  if args.check_metadata:
+    return check_metadata(args)
+  if args.cache_ab:
+    return cache_ab(args)
+  if args.bos_ab:
+    return bos_ab(args)
+  return gate(args)
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Adds two LLM conversion recipes in the `models/<family>/<model>/converted` layout — the same shape as the Granite-4.1-3B recipe (#280) and the four dense recipes (#282): a build script that goes HF checkpoint → `.litertlm`, a verify script with an 8-question quality gate through the `litert-lm` CLI, `--check-metadata`, and model-specific checks, and a README with the measurements. Both are published at `litert-community`; each recipe documents something the checkpoint's config, template, or architecture makes necessary, and what was measured to establish it.

| recipe | source | build | the finding |
|---|---|---|---|
| `models/hunyuan/hy_mt2_1_8b` | [tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B) (Apache-2.0, 33-language translation model, dense `HunYuanDenseV1ForCausalLM`) | stock litert-torch 0.9.3 export, dynamic int8 on linears + embedding, 1.82 GB | The config's `rope_scaling: {type: dynamic, alpha: 1000}` is static in practice — transformers resolves it once at init — but the leftover data-dependent growth branch kills `torch.export`. The build bakes the resolved base into `rope_theta` (11,158,839.925) and drops `rope_scaling`; `--rope-ab` shows `inv_freq` and teacher-forced logits **bitwise-equal** to the HF reference. Second finding: the template renders `<｜hy_begin▁of▁sentence｜>` as a literal and the LiteRT-LM engine prepends the metadata `start_token` unconditionally, so the default export fed BOS twice. That is proved *inside the runtime* (`--bos-discriminator`: `[start_token]+rest` ≡ `[template BOS]+rest` byte-for-byte on 3/3 probes), not inferred from outputs — int8 greedy divergence had mimicked the wrong arm. The bundle ships without the field; the README says plainly that the double-BOS variant happened to score 8/8 on the gate against the faithful bundle's 6/8. |
| `models/nemotron/nemotron_3_nano_4b` | [nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16) (NVIDIA Nemotron Open Model License, reasoning model; 21 Mamba2 + 17 MLP + 4 attention layers) | pinned litert-torch `115a1360` + `nemotron_h_litert_torch.patch`, float export → post-hoc int8 on linears + embedding (convs and the scan stay float), `ExecutorMetadata` with the 50 state buffers, fp32 activations, 4.13 GB | No released litert-torch carries a Mamba2 cache layer, so the recipe ships the patch (Apache-2.0 headers; the folded SSD scan port, a cache-less layer type for the MLP blocks, the hybrid cache) and a six-step build with the measured reason for each step. The operational finding is a **GPU trap isolated as a one-variable comparison**: with the runtime's default compiled-graph cache, `litert-lm run --backend gpu` returns an empty reply with WebGPU `Invalid BindGroup` validation errors; the same file with `--cache no` answers 8/8 (`--cache-ab` reproduces it in two runs and cleans up the 3.97 GB weight cache the default arm writes). Three evaluation facts are recorded: `auto_map` in a config is not proof of remote code (transformers 5.14 registers `nemotron_h` natively), the ≥3B reduced 7-signature prefill ladder, and a spurious `start_token` (`<s>` on an `add_bos_token: False` tokenizer) that this 4B tolerates — `--bos-ab` shows HF bf16 greedy byte-identical with and without it on 2 of 3 probes and the same final answer on the third — so the drop is stream fidelity, not a rescue. |

## Verification

All numbers below are measured on the published bundles (litert-lm 0.16.0, Mac M4 Max); the READMEs carry the details and the qualifiers.

- **Quality gates re-run 2026-08-30** with the verify scripts in this PR: Hy-MT2-1.8B CPU 6/8 / GPU 6/8 (same two misses on both backends — "Cool" for the opposite of hot, "pink" for the rhyme — a property of this translation-tuned checkpoint, not a backend; the model's own task is checked by `--translate`, byte-identical to HF bf16 greedy on 1 of 3 probes and fluent int8-class alternates on the other two). Nemotron-3-Nano-4B CPU 7/8 (the rhyme item, "purple") / GPU with `--cache no` 8/8, thoughts 17–48 words. `--check-metadata` passes on both (7/7 and 9/9); `--rope-ab`, `--bos-discriminator`, `--cache-ab` and `--bos-ab` reproduce the README tables.
- **The build scripts were run end to end on the pinned stacks (2026-08-30).** Hy-MT2-1.8B rebuilds **byte-identical to the published bundle in every section** (LlmMetadata, tokenizer, model; only the header's uuid and timestamp differ). Nemotron-3-Nano-4B rebuilds byte-identical too — LlmMetadata, ExecutorMetadata (all 50 state buffers), tokenizer and the 4.12 GB model section all match the published bundle exactly; only the file header's uuid, timestamp and an `Authors` key differ.
- **Mac M4 Max** (`litert-lm benchmark -p 256 -d 256 --runs 3 --cache no`, two runs per cell): Hy-MT2 GPU 2008/2003 prefill, 105.8/105.4 decode tok/s, TTFT 0.137 s; CPU 211/210 prefill, 34.0/32.4 decode. Nemotron-3-Nano-4B GPU (`--cache no`) 803/792 prefill, 83.3/82.4 decode, TTFT 0.33 s; CPU 99.6/113.3 prefill, 22.7/22.5 decode (host not idle for the CPU cell; the README says so).
- **Not measured on a phone**, either bundle. The Nemotron README carries the sibling Nemotron-H-4B's 8 GB-Android result as an expectation, labelled as such, not as a measurement of this file.

## CI note

This PR only adds files under `models/` (Python scripts, Markdown, and one `.patch` against a pinned litert-torch commit, all with Apache-2.0 headers).
