### PR TITLE
Add SAM 2.1 Hiera-Tiny video-tracking Tensor API implementation (five-signature video stack, host tracking loop, verification suite)

### DIFF
--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/README.md
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/README.md
@@ -1,0 +1,120 @@
+# SAM 2.1 Video Tracking — Tensor API Implementation
+
+SAM 2.1 Hiera-Tiny video tracking implemented by authoring the graphs
+directly with the
+[LiteRT Tensor API](https://github.com/google-ai-edge/LiteRT/tree/main/tensor)
+(C++, no converter), plus a C++ reference host loop. Companion to the
+`converted/` recipe in the parent directory (the litert-torch export of
+the same four per-frame graphs) and to
+[litert-tensor-vision-examples](https://github.com/john-rocky/litert-tensor-vision-examples)
+(the same code as a LiteRT `tensor/examples/` overlay, with the findings
+ledger).
+
+## This project demonstrates:
+
+1.  The full SAM 2.1 video stack authored as five signatures in ONE
+    flatbuffer sharing weights: `encode` (Hiera encoder at the native
+    1024, emitting the raw top-level feature map plus the two high-res
+    skips), `memcond7` / `memcond2` (memory attention over a fixed bank
+    of 7 or 2 spatial memory slots + 64 object-pointer tokens, unused
+    entries masked additively — numerically identical to the reference's
+    variable-length bank), `decode` (video mask decoder: sparse prompt
+    and a no-memory scalar as inputs; all four mask tokens, IoU scores,
+    object pointers and the object score out), `memorize` (mask
+    downsampler + ConvNeXt fuser memory encoder with an occlusion
+    input).
+2.  Rotary position embedding without a RoPE op: SAM2's
+    pairwise-interleaved RoPE is turned into the rotate-half form by
+    permuting the q/k projection rows at weight-export time (q'.k' ==
+    q.k exactly), with deinterleaved cos/sin tables baked as constants —
+    no new op class anywhere in the video stack.
+3.  A per-frame host loop (`sam2v_main.cc`) that mirrors the numpy
+    specification in `verify/verify_video_1024.py`: bank bookkeeping,
+    temporal position rows, object-pointer sine encoding, best-mask
+    pick, no-object handling and mask_for_mem construction.
+4.  Layer-for-layer verification tooling: an end-to-end chained-state
+    parity harness against the `transformers` `Sam2VideoModel` streaming
+    reference, per-graph isolation probes (each signature run on inputs
+    captured from the HF modules themselves), and a block-by-block
+    encoder mirror.
+
+## Directory layout
+
+*   `sam2_image/` — the image-path encoder/decoder library the video
+    graphs build on (Hiera encoder, prompt encoder in-graph, mask
+    decoder) plus its standalone 512 sample (`sam2_main.cc`) and PyTorch
+    parity script.
+*   `sam2_video/` — the video graphs (`sam2v_graph.cc`), the video-stack
+    weight loader (`sam2v_weights.cc`), the host tracking loop
+    (`sam2v_main.cc`), and `verify/` (fp32 weight export from
+    `facebook/sam2.1-hiera-tiny`, HF streaming reference, per-frame
+    compare, isolation probes).
+
+## Prerequisites
+
+1.  **Bazel** via bazelisk (version pinned by `.bazelversion`).
+2.  **Python 3** with torch, transformers >= 5, safetensors, numpy and
+    Pillow for `verify/`.
+3.  **Weights**: `facebook/sam2.1-hiera-tiny` from Hugging Face — not
+    included. `sam2_video/verify/export_weights_1024.py` produces the
+    single fp32 safetensors file both binaries consume (the video stack
+    included, conv layouts pre-permuted, RoPE bake self-checked in-run).
+    `sam2v_main` runs without `--weights` using synthetic weights (shape
+    and routing smoke test only).
+
+## Build Instructions
+
+All commands are run from the repository root (the workspace pulls LiteRT
+`main` as `@litert_archive`).
+
+```bash
+# macOS (Apple silicon)
+bazel build --config=macos_arm64 \
+  //models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video:sam2v_main
+
+# The image-path 512 sample
+bazel build --config=macos_arm64 \
+  //models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_main
+```
+
+Runtime behavior was validated at LiteRT commit `a19d8fa` plus the
+PR #8796 runner change.
+
+## Run
+
+```bash
+# One-time: weights + synthetic clip + HF reference
+python3 sam2_video/verify/export_weights_1024.py --out sam2_tiny_1024_video.safetensors
+python3 sam2_video/verify/verify_video_1024.py clip
+python3 sam2_video/verify/verify_video_1024.py ref
+
+# Track 10 frames on Metal, dump per-frame outputs, compare
+sam2v_main --weights=sam2_tiny_1024_video.safetensors \
+  --frames_file=<out>/frames.f32 --frames=10 --nmm=7 \
+  --accelerator=gpu --gpu_precision=fp16 --gpu_buffer_storage=buffer \
+  --dump_dir=<dir> [--bench_loops=3]
+python3 sam2_video/verify/verify_video_1024.py compare --dump_dir=<dir> --nmm 7
+```
+
+GPU runs on macOS need `libLiteRtMetalAccelerator.dylib` (shipped in the
+target's runfiles) in the working directory. The Metal delegate's default
+compute precision is fp16; set `--gpu_precision` explicitly when
+comparing against fp32 references, and use `--gpu_buffer_storage=buffer`
+(texture storage silently falls back to CPU on these tensor sizes).
+
+## Measured highlights
+
+*   Parity vs the HF streaming reference (fp32, 10-frame synthetic clip,
+    chained state): **min mask-IoU 1.0000** on CPU fp32 and Metal fp32
+    for both bank sizes; 0.9950 at Metal fp16 over the chained loop.
+*   M4 Max Metal fp16, per tracked frame end to end (host loop
+    included): **94 ms** with the 7-slot bank, **64 ms** with 2 slots
+    (encode 33.7 ms, memory attention 53.5 / 23.2 ms, decode 1.7 ms,
+    memory encoder 1.4 ms). fp32: 117 / 78 ms. CPU fp32: 1505 ms.
+*   The memory bank is host-side per-frame signature I/O (the memory
+    attention itself is in-graph). Moving the bank in-graph as signature
+    state (`odml.cache_update` + the PR #8796 feedback-loop runner) is
+    the intended next step; it is currently blocked on Metal by the
+    second-Run input-buffer re-registration failure ("The given buffer
+    type is not supported") that also blocks the audio-side cache
+    adoption.

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/BUILD
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/BUILD
@@ -1,0 +1,92 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(
+    "@litert_archive//litert/build_common:special_rule.bzl",
+    "litert_android_linkopts",
+    "litert_gpu_accelerator_prebuilts",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "sam2_config",
+    hdrs = ["sam2_config.h"],
+)
+
+cc_library(
+    name = "sam2_graph",
+    srcs = ["sam2_graph.cc"],
+    hdrs = ["sam2_graph.h"],
+    deps = [
+        ":sam2_config",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/strings",
+        "@flatbuffers",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+    ],
+)
+
+cc_library(
+    name = "sam2_weights",
+    srcs = ["sam2_weights.cc"],
+    hdrs = ["sam2_weights.h"],
+    deps = [
+        ":sam2_config",
+        ":sam2_graph",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor/examples/gemma3:safetensor_loader",
+    ],
+)
+
+cc_binary(
+    name = "sam2_main",
+    srcs = ["sam2_main.cc"],
+    copts = ["-DGOOGLE_COMMANDLINEFLAGS_FULL_API=1"] + select({
+        "@litert_archive//litert:android": ["-DABSL_FLAGS_STRIP_NAMES=0"],
+        "//conditions:default": [],
+    }),
+    data = litert_gpu_accelerator_prebuilts(),
+    linkopts = litert_android_linkopts(),
+    deps = [
+        ":sam2_config",
+        ":sam2_graph",
+        ":sam2_weights",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@litert_archive//litert/cc:litert_common",
+        "@litert_archive//litert/cc:litert_environment",
+        "@litert_archive//litert/cc:litert_options",
+        "@litert_archive//litert/cc/options:litert_gpu_options",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+        "@litert_archive//tensor/backends/tflite:tflite_flatbuffer_conversion",
+        "@litert_archive//tensor/runners/litert:litert_dynamic_runner",
+    ],
+)

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/BUILD
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/BUILD
@@ -56,7 +56,10 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@litert_archive//tensor",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
         "@litert_archive//tensor/examples/gemma3:safetensor_loader",
+        "@litert_archive//tensor/examples/gemma3:safetensors",
     ],
 )
 

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h
@@ -1,0 +1,128 @@
+// SAM2.1 hiera-tiny image path on the C++ Tensor API — configuration.
+//
+// Matches the reference pipelines this port is verified against:
+// the mlx-swift app (LiteRT-Models/sam2-mlx-ios, corr 0.9999 vs PyTorch at
+// 512) and transformers' facebook/sam2.1-hiera-tiny. Sizes are for the
+// 512x512 input the apps run (token grid 128, image embeddings 32x32).
+
+#ifndef MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_CONFIG_H_
+#define MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_CONFIG_H_
+
+#include <set>
+#include <vector>
+
+namespace litert::tensor::examples::sam2 {
+
+struct Sam2Config {
+  int image_size = 512;
+
+  // Hiera-tiny trunk.
+  int embed_dim = 96;
+  int num_heads = 1;
+  std::vector<int> stages{1, 2, 7, 2};
+  std::vector<int> window_spec{8, 4, 14, 7};
+  std::set<int> global_blocks{5, 7, 9};
+  int q_pool = 3;
+  int q_stride = 2;
+  float dim_mul = 2.0f;
+  float head_mul = 2.0f;
+  int mlp_ratio = 4;
+
+  // Neck / SAM.
+  int d_model = 256;
+
+  // Eps values from the reference implementations (Hiera LN explicit 1e-6;
+  // decoder LayerNorm = torch/mlx default 1e-5; LayerNorm2d = 1e-6).
+  float ln_eps_hiera = 1e-6f;
+  float ln_eps_decoder = 1e-5f;
+  float ln_eps_2d = 1e-6f;
+
+  // Emission toggles (raw decompositions and composites are numerically
+  // identical on CPU; composites unlock fused delegate kernels).
+  bool use_sdpa_composite = false;
+  // odml.runtime_bmm pair per attention (QK + AV composites with an int32
+  // [1,1,1,7] control input, element 2 = full length — SAM2 shapes are
+  // static, so both sides are bounded at full fill, which is complete
+  // computation; the audio-side stale-tail hazard needs active < S).
+  bool use_rbmm_attention = false;
+  // The hypernetwork mask projection (activation x activation) as a single
+  // dst-bounded odml.runtime_bmm at rank 4.
+  bool use_rbmm_hypernet = false;
+  bool use_layer_norm_composite = false;
+  // Mask upsampler form: TRANSPOSE_CONV directly, or the exact
+  // 4x(1x1)+concat+DepthToSpace expansion (k2/s2 transposed conv has zero
+  // tap overlap, so the two are the same sums) for delegates that reject
+  // TRANSPOSE_CONV (Mali ML Drift).
+  bool use_d2s_upsampler = false;
+
+  int token_grid() const { return image_size / 4; }
+  int embed_grid() const { return image_size / 16; }  // 32 at 512
+  int mask_grid() const { return image_size / 4; }    // 128 at 512
+
+  struct BlockSpec {
+    int dim;
+    int dim_out;
+    int heads;
+    int window;    // 0 = global attention
+    int q_stride;  // 0 = no query pooling
+    int grid_in;
+    int grid_out;
+  };
+
+  // Per-block specs following the reference construction exactly: the
+  // window size uses the CURRENT stage spec fixed before the stage
+  // increment, dim/heads scale at stage boundaries, q-pool hits the first
+  // block of stages 2..4.
+  std::vector<BlockSpec> Blocks() const {
+    int depth = 0;
+    for (int s : stages) depth += s;
+    std::vector<int> ends;  // last block index of each stage
+    int acc = 0;
+    for (int s : stages) {
+      acc += s;
+      ends.push_back(acc - 1);
+    }
+    std::set<int> end_set(ends.begin(), ends.end());
+    std::set<int> pool_blocks;
+    for (int i = 0; i + 1 < static_cast<int>(ends.size()) && i < q_pool; ++i) {
+      pool_blocks.insert(ends[i] + 1);
+    }
+
+    std::vector<BlockSpec> specs;
+    int ed = embed_dim;
+    int nh = num_heads;
+    int cur_stage = 1;
+    int grid = token_grid();
+    for (int i = 0; i < depth; ++i) {
+      int dim_out = ed;
+      int ws = window_spec[cur_stage - 1];
+      if (global_blocks.count(i)) ws = 0;
+      if (i > 0 && end_set.count(i - 1)) {
+        dim_out = static_cast<int>(ed * dim_mul);
+        nh = static_cast<int>(nh * head_mul);
+        ++cur_stage;
+      }
+      int qs = pool_blocks.count(i) ? q_stride : 0;
+      int grid_out = qs ? grid / qs : grid;
+      specs.push_back({ed, dim_out, nh, ws, qs, grid, grid_out});
+      ed = dim_out;
+      grid = grid_out;
+    }
+    return specs;
+  }
+
+  // Stage-end block indices (whose outputs feed the FPN neck).
+  std::vector<int> StageEnds() const {
+    std::vector<int> ends;
+    int acc = 0;
+    for (int s : stages) {
+      acc += s;
+      ends.push_back(acc - 1);
+    }
+    return ends;
+  }
+};
+
+}  // namespace litert::tensor::examples::sam2
+
+#endif  // MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_CONFIG_H_

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h
@@ -31,6 +31,13 @@ struct Sam2Config {
   // Neck / SAM.
   int d_model = 256;
 
+  // Fold no_mem_embed (the "no memory" image-only conditioning) into the
+  // encoder's image_embeddings output — the image path's contract. The video
+  // pipeline clears it: its encoder then emits the raw top-level feature map
+  // and the video decoder adds the row itself, on the conditioning frame
+  // only, through its nomem input.
+  bool fold_no_mem_embed = true;
+
   // Eps values from the reference implementations (Hiera LN explicit 1e-6;
   // decoder LayerNorm = torch/mlx default 1e-5; LayerNorm2d = 1e-6).
   float ln_eps_hiera = 1e-6f;

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.cc
@@ -1,0 +1,853 @@
+// SAM2.1 hiera-tiny image path — graph construction. See sam2_graph.h.
+
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/log/absl_check.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+#include "tensor/arithmetic.h"
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::sam2 {
+
+namespace {
+
+constexpr float kTwoPi = 6.283185307179586f;
+
+TfTensor ConstScalar(float value) {
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>({value})});
+}
+
+TfTensor ConstFloats(const std::vector<float>& values,
+                     const std::vector<int>& shape,
+                     const std::string& name = "") {
+  return TfTensor({.name = name,
+                   .type = Type::kFP32,
+                   .shape = shape,
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>(values)});
+}
+
+const TfTensor& W(const WeightMap& weights, const std::string& name) {
+  auto it = weights.find(name);
+  ABSL_CHECK(it != weights.end()) << "missing weight: " << name;
+  return it->second;
+}
+
+// Reads a loaded fp32 weight back to host floats (for build-time baking).
+std::vector<float> HostFloats(const TfTensor& tensor) {
+  auto buffer = tensor.GetBuffer();
+  ABSL_CHECK(buffer.ok()) << "weight has no buffer";
+  auto lock = buffer->Lock();
+  const float* data = reinterpret_cast<const float*>(lock.data());
+  return std::vector<float>(data, data + lock.size() / sizeof(float));
+}
+
+// NHWC zero padding on H and W.
+TfTensor PadHW(const TfTensor& x, int top, int bottom, int left, int right) {
+  TfTensor paddings(
+      {.type = Type::kI32,
+       .shape = {4, 2},
+       .buffer = OwningCpuBuffer::Copy<Type::kI32>(
+           {0, 0, top, bottom, left, right, 0, 0})});
+  return Pad(x, paddings);
+}
+
+// Emission toggles (single-threaded graph construction, mirrored from the
+// talker example's pattern).
+bool g_layer_norm_composite = false;
+bool g_sdpa_composite = false;
+bool g_rbmm_attention = false;
+bool g_rbmm_hypernet = false;
+
+// odml.runtime_bmm control inputs for the CURRENT Build*() call, one per
+// distinct bound length S. The ml_drift parser requires the control tensor
+// to be a RUNTIME input (GetNumberOfRuntimeInputsForNode != 3 rejects the
+// node outright), so these are graph inputs, not constants.
+std::vector<std::pair<int, TfTensor>> g_rbmm_params;
+
+TfTensor GetRbmmParam(int s) {
+  for (const auto& [len, tensor] : g_rbmm_params) {
+    if (len == s) return tensor;
+  }
+  TfTensor param({.name = absl::StrCat("rbmm_s", s),
+                  .type = Type::kI32,
+                  .shape = {1, 1, 1, 7}});
+  g_rbmm_params.emplace_back(s, param);
+  return param;
+}
+
+std::vector<uint8_t> RuntimeBmmAttributes(bool is_src) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() {
+    fbb.Bool("is_global", true);
+    fbb.Bool("is_src", is_src);
+    fbb.Bool("rhs_cache_update", false);
+  });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// The runtime_bmm contract (parser: transpose_right=true): LHS [B,H,M,K] x
+// RHS [B,H,N,K] -> [B,H,M,N]; the batch dim merges into H on the delegate
+// when B > 1 (window attention). Decompositions are plain BatchMatMuls that
+// ignore the control tensor, so CPU execution equals the raw path.
+TfTensor RuntimeBmm(const TfTensor& lhs, const TfTensor& rhs,
+                    const TfTensor& param, bool is_src) {
+  StableHLOCompositeOptions opts{
+      .name = "odml.runtime_bmm",
+      .composite_attributes = RuntimeBmmAttributes(is_src)};
+  return StableHLOComposite(
+      opts,
+      [](TfTensor l, TfTensor r, TfTensor /*p*/) {
+        return BatchMatMul(l, r, /*adj_x=*/false, /*adj_y=*/true);
+      },
+      lhs, rhs, param);
+}
+
+std::vector<uint8_t> EpsilonAttributes(float eps) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() { fbb.Float("epsilon", eps); });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// Last-axis LayerNorm with weight+bias. In NHWC this also covers the
+// reference's LayerNorm2d (channelwise over NCHW == last axis here).
+TfTensor LayerNormRaw(const TfTensor& x, const TfTensor& weight,
+                      const TfTensor& bias, float eps) {
+  int last = static_cast<int>(x.GetShape().size()) - 1;
+  TfTensor mean = Mean(x, {last}, /*keep_dims=*/true);
+  TfTensor centered = Sub(x, mean);
+  TfTensor var = Mean(Mul(centered, centered), {last}, /*keep_dims=*/true);
+  TfTensor normed = Mul(centered, Rsqrt(Add(var, ConstScalar(eps))));
+  return Add(Mul(normed, weight), bias);
+}
+
+TfTensor LayerNorm(const TfTensor& x, const TfTensor& weight,
+                   const TfTensor& bias, float eps) {
+  if (!g_layer_norm_composite) return LayerNormRaw(x, weight, bias, eps);
+  StableHLOCompositeOptions opts{.name = "odml.layer_norm",
+                                 .composite_attributes =
+                                     EpsilonAttributes(eps)};
+  return StableHLOComposite(
+      opts,
+      [eps](TfTensor dx, TfTensor dw, TfTensor db) {
+        return LayerNormRaw(dx, dw, db, eps);
+      },
+      x, weight, bias);
+}
+
+std::vector<uint8_t> SdpaAttributes(float scale) {
+  flexbuffers::Builder fbb;
+  fbb.Map([&]() { fbb.Float("scale", scale); });
+  fbb.Finish();
+  return fbb.GetBuffer();
+}
+
+// Rank-4 BNSD attention core: q [B,H,Nq,D], k/v [B,H,Nk,D] -> [B,H,Nq,D].
+// Batch dim is always kept (the rank-3 form is silently mis-computed by the
+// ML Drift GPU delegate — converted-path finding, decoder v2).
+TfTensor AttentionRaw(const TfTensor& q, const TfTensor& k, const TfTensor& v,
+                      float scale) {
+  TfTensor scores = BatchMatMul(q, k, /*adj_x=*/false, /*adj_y=*/true);
+  scores = Mul(scores, ConstScalar(scale));
+  TfTensor attn = Softmax(scores);
+  return BatchMatMul(attn, v);
+}
+
+// Multi-head attention over token tensors. q [B,Nq,C], k/v [B,Nk,C] with C
+// = heads * head_dim -> [B,Nq,C]. Composite emission presents BSND operands
+// ([B,N,H,D], the odml.scaled_dot_product_attention delegate contract); the
+// decomposition transposes to BNSD and runs the same math, so CPU execution
+// is identical either way.
+TfTensor Mha(const TfTensor& q, const TfTensor& k, const TfTensor& v,
+             int heads) {
+  const auto& qs = q.GetShape();
+  const auto& ks = k.GetShape();
+  int b = qs[0];
+  int nq = qs[1];
+  int nk = ks[1];
+  int c = qs[2];
+  int hd = c / heads;
+  float scale = 1.0f / std::sqrt(static_cast<float>(hd));
+
+  TfTensor q4 = Reshape(q, {b, nq, heads, hd});
+  TfTensor k4 = Reshape(k, {b, nk, heads, hd});
+  TfTensor v4 = Reshape(v, {b, nk, heads, hd});
+
+  TfTensor out;
+  if (g_sdpa_composite) {
+    StableHLOCompositeOptions opts{
+        .name = "odml.scaled_dot_product_attention",
+        .composite_attributes = SdpaAttributes(scale)};
+    out = StableHLOComposite(
+        opts,
+        [scale](TfTensor dq, TfTensor dk, TfTensor dv) {
+          TfTensor qt = Transpose(dq, {0, 2, 1, 3});
+          TfTensor kt = Transpose(dk, {0, 2, 1, 3});
+          TfTensor vt = Transpose(dv, {0, 2, 1, 3});
+          TfTensor o = AttentionRaw(qt, kt, vt, scale);
+          return Transpose(o, {0, 2, 1, 3});
+        },
+        q4, k4, v4);
+  } else if (g_rbmm_attention) {
+    // QK + AV odml.runtime_bmm pair with in-graph scale + softmax between.
+    // Both sides bound at the full length (elem2 = nk): dst-bounded QK
+    // writes every column and src-bounded AV reduces every position, so
+    // the composition is complete computation — no stale-tail hazard at
+    // full fill (that needs active < S).
+    TfTensor qt = Transpose(q4, {0, 2, 1, 3});   // [B,H,M,D]
+    TfTensor kt = Transpose(k4, {0, 2, 1, 3});   // [B,H,N,D]
+    TfTensor param = GetRbmmParam(nk);
+    TfTensor scores = RuntimeBmm(qt, kt, param, /*is_src=*/false);
+    scores = Mul(scores, ConstScalar(scale));
+    TfTensor attn = Softmax(scores);             // [B,H,M,N]
+    TfTensor v4t = Transpose(v4, {0, 2, 3, 1});  // [B,H,D,N] (positions on
+                                                 // channels — the AV layout)
+    TfTensor o = RuntimeBmm(attn, v4t, param, /*is_src=*/true);  // [B,H,M,D]
+    out = Transpose(o, {0, 2, 1, 3});
+  } else {
+    TfTensor qt = Transpose(q4, {0, 2, 1, 3});
+    TfTensor kt = Transpose(k4, {0, 2, 1, 3});
+    TfTensor vt = Transpose(v4, {0, 2, 1, 3});
+    TfTensor o = AttentionRaw(qt, kt, vt, scale);
+    out = Transpose(o, {0, 2, 1, 3});
+  }
+  return Reshape(out, {b, nq, c});
+}
+
+// <=4-D window partition: [1,H,W,C] -> [nH*nW, ws, ws, C] (+pad). Splits H
+// into the batch, transposes, then splits W — this transposes row/col
+// WITHIN each window, which WindowUnpartition exactly inverts; window
+// attention (position already added) and the square symmetric query pooling
+// are order-equivariant, so results are numerically identical to the 6-D
+// reference form (proven at corr 1.0 in the converted-path work).
+TfTensor WindowPartition(const TfTensor& x, int h, int w, int c, int ws,
+                         int* n_h, int* n_w) {
+  int pad_h = (ws - h % ws) % ws;
+  int pad_w = (ws - w % ws) % ws;
+  TfTensor t = x;
+  if (pad_h > 0 || pad_w > 0) t = PadHW(t, 0, pad_h, 0, pad_w);
+  int hp = h + pad_h;
+  int wp = w + pad_w;
+  *n_h = hp / ws;
+  *n_w = wp / ws;
+  t = Reshape(t, {*n_h, ws, wp, c});
+  t = Transpose(t, {0, 2, 1, 3});  // [nH, Wp, ws, C]
+  return Reshape(t, {(*n_h) * (*n_w), ws, ws, c});
+}
+
+// Exact inverse of WindowPartition at (possibly pooled) window size ws2,
+// cropping any padding down to [1, h, w, C].
+TfTensor WindowUnpartition(const TfTensor& windows, int n_h, int n_w, int ws2,
+                           int h, int w, int c) {
+  TfTensor t = Reshape(windows, {n_h, n_w * ws2, ws2, c});
+  t = Transpose(t, {0, 2, 1, 3});  // [nH, ws2, nW*ws2, C]
+  int hp = n_h * ws2;
+  int wp = n_w * ws2;
+  t = Reshape(t, {1, hp, wp, c});
+  if (hp > h || wp > w) t = Slice(t, {0, 0, 0, 0}, {1, h, w, c});
+  return t;
+}
+
+// One Hiera multi-scale block on an NHWC grid tensor.
+TfTensor MultiScaleBlock(const Sam2Config& config,
+                         const Sam2Config::BlockSpec& spec, const TfTensor& x,
+                         const std::string& prefix, const WeightMap& weights) {
+  const int dim = spec.dim;
+  const int dim_out = spec.dim_out;
+  const int h = spec.grid_in;
+
+  TfTensor shortcut = x;
+  TfTensor xn = LayerNorm(x, W(weights, prefix + ".norm1.weight"),
+                          W(weights, prefix + ".norm1.bias"),
+                          config.ln_eps_hiera);
+  if (dim != dim_out) {
+    shortcut = FullyConnected(xn, W(weights, prefix + ".proj.weight"),
+                              W(weights, prefix + ".proj.bias"));
+    if (spec.q_stride > 0) {
+      shortcut = MaxPool2D(shortcut, spec.q_stride, spec.q_stride,
+                           spec.q_stride, spec.q_stride, kPaddingValid);
+    }
+  }
+
+  // Tokens for attention: windows into the batch axis, or the full grid.
+  TfTensor tokens = xn;
+  int n_h = 1;
+  int n_w = 1;
+  int batch = 1;
+  int n = h * h;
+  int win = spec.window;
+  if (win > 0) {
+    tokens = WindowPartition(tokens, h, h, dim, win, &n_h, &n_w);
+    batch = n_h * n_w;
+    n = win * win;
+  }
+  tokens = Reshape(tokens, {batch, n, dim});
+
+  TfTensor qkv = FullyConnected(tokens, W(weights, prefix + ".attn.qkv.weight"),
+                                W(weights, prefix + ".attn.qkv.bias"));
+  TfTensor q = Slice(qkv, {0, 0, 0}, {batch, n, dim_out});
+  TfTensor k = Slice(qkv, {0, 0, dim_out}, {batch, n, dim_out});
+  TfTensor v = Slice(qkv, {0, 0, 2 * dim_out}, {batch, n, dim_out});
+
+  int nq = n;
+  if (spec.q_stride > 0) {
+    int side = win > 0 ? win : h;
+    q = Reshape(q, {batch, side, side, dim_out});
+    q = MaxPool2D(q, spec.q_stride, spec.q_stride, spec.q_stride,
+                  spec.q_stride, kPaddingValid);
+    int side2 = side / spec.q_stride;
+    nq = side2 * side2;
+    q = Reshape(q, {batch, nq, dim_out});
+  }
+
+  TfTensor attn = Mha(q, k, v, spec.heads);
+  attn = FullyConnected(attn, W(weights, prefix + ".attn.proj.weight"),
+                        W(weights, prefix + ".attn.proj.bias"));
+
+  int grid_out = spec.grid_out;
+  if (win > 0) {
+    int ws2 = spec.q_stride > 0 ? win / spec.q_stride : win;
+    attn = Reshape(attn, {batch, ws2, ws2, dim_out});
+    attn = WindowUnpartition(attn, n_h, n_w, ws2, grid_out, grid_out, dim_out);
+  } else {
+    attn = Reshape(attn, {1, grid_out, grid_out, dim_out});
+  }
+
+  TfTensor merged = Add(shortcut, attn);
+  TfTensor m = LayerNorm(merged, W(weights, prefix + ".norm2.weight"),
+                         W(weights, prefix + ".norm2.bias"),
+                         config.ln_eps_hiera);
+  m = FullyConnected(m, W(weights, prefix + ".mlp.layers.0.weight"),
+                     W(weights, prefix + ".mlp.layers.0.bias"));
+  m = Gelu(m);
+  m = FullyConnected(m, W(weights, prefix + ".mlp.layers.1.weight"),
+                     W(weights, prefix + ".mlp.layers.1.bias"));
+  return Add(merged, m);
+}
+
+// SAM decoder attention wrapper: separate q/k/v/out projections (+bias),
+// internal dim from the weight shapes (cross attention downsamples to 128).
+TfTensor SamAttention(const TfTensor& q_in, const TfTensor& k_in,
+                      const TfTensor& v_in, const std::string& prefix,
+                      const WeightMap& weights, int heads) {
+  TfTensor q = FullyConnected(q_in, W(weights, prefix + ".q_proj.weight"),
+                              W(weights, prefix + ".q_proj.bias"));
+  TfTensor k = FullyConnected(k_in, W(weights, prefix + ".k_proj.weight"),
+                              W(weights, prefix + ".k_proj.bias"));
+  TfTensor v = FullyConnected(v_in, W(weights, prefix + ".v_proj.weight"),
+                              W(weights, prefix + ".v_proj.bias"));
+  TfTensor out = Mha(q, k, v, heads);
+  return FullyConnected(out, W(weights, prefix + ".out_proj.weight"),
+                        W(weights, prefix + ".out_proj.bias"));
+}
+
+// 3-layer SamMLP (ReLU between layers; optional sigmoid on the output).
+TfTensor SamMlp3(const TfTensor& x, const std::string& prefix,
+                 const WeightMap& weights, bool sigmoid_output) {
+  TfTensor h = FullyConnected(x, W(weights, prefix + ".layers.0.weight"),
+                              W(weights, prefix + ".layers.0.bias"), kActRelu);
+  h = FullyConnected(h, W(weights, prefix + ".layers.1.weight"),
+                     W(weights, prefix + ".layers.1.bias"), kActRelu);
+  h = FullyConnected(h, W(weights, prefix + ".layers.2.weight"),
+                     W(weights, prefix + ".layers.2.bias"));
+  return sigmoid_output ? Logistic(h) : h;
+}
+
+// 2x transposed conv (k=2, s=2, VALID). `transpose_conv` emits
+// TRANSPOSE_CONV; otherwise the exact expansion: with k==s the taps never
+// overlap, so out[2y+dy, 2x+dx, o] = sum_i x[y,x,i] * W[o,dy,dx,i] — four
+// 1x1 projections interleaved by DepthToSpace (channel order (dy*2+dx)*O+o
+// = the TFLite D2S contract). Same sums, bit-identical on CPU; for
+// delegates that reject TRANSPOSE_CONV (Mali ML Drift).
+TfTensor Upsample2x(const TfTensor& x, const TfTensor& weight,
+                    const TfTensor& bias, int out_h, int out_w, int out_c,
+                    bool transpose_conv) {
+  if (transpose_conv) {
+    return TransposeConv(weight, x, bias, {1, out_h, out_w, out_c},
+                         kPaddingValid, 2, 2);
+  }
+  std::vector<float> w = HostFloats(weight);  // [O, 2, 2, I]
+  const auto& ws = weight.GetShape();
+  int o_ch = ws[0];
+  int i_ch = ws[3];
+  std::vector<TfTensor> taps;
+  for (int dy = 0; dy < 2; ++dy) {
+    for (int dx = 0; dx < 2; ++dx) {
+      std::vector<float> tap(static_cast<size_t>(o_ch) * i_ch);
+      for (int o = 0; o < o_ch; ++o) {
+        for (int i = 0; i < i_ch; ++i) {
+          tap[static_cast<size_t>(o) * i_ch + i] =
+              w[((static_cast<size_t>(o) * 2 + dy) * 2 + dx) * i_ch + i];
+        }
+      }
+      taps.push_back(FullyConnected(
+          x, ConstFloats(tap, {o_ch, i_ch}), std::optional<TfTensor>()));
+    }
+  }
+  TfTensor packed = Concatenation({taps[0], taps[1], taps[2], taps[3]},
+                                  /*axis=*/3);  // [1,H,W,4*O]
+  TfTensor up = DepthToSpace(packed, /*block_size=*/2);
+  return Add(up, bias);
+}
+
+// Dense positional-encoding grid [1, G*G, 256] baked from the prompt
+// encoder's Gaussian matrix (identical math to the reference denseGrid).
+TfTensor BakeDensePeGrid(const std::vector<float>& gaussian, int grid) {
+  std::vector<float> out(static_cast<size_t>(grid) * grid * 256);
+  for (int y = 0; y < grid; ++y) {
+    for (int x = 0; x < grid; ++x) {
+      float cx = 2.0f * ((x + 0.5f) / grid) - 1.0f;
+      float cy = 2.0f * ((y + 0.5f) / grid) - 1.0f;
+      size_t base = (static_cast<size_t>(y) * grid + x) * 256;
+      for (int i = 0; i < 128; ++i) {
+        float phase = kTwoPi * (cx * gaussian[i] + cy * gaussian[128 + i]);
+        out[base + i] = std::sin(phase);
+        out[base + 128 + i] = std::cos(phase);
+      }
+    }
+  }
+  return ConstFloats(out, {1, grid * grid, 256}, "dense_pe_grid");
+}
+
+}  // namespace
+
+std::vector<WeightSpec> GetWeightSpecs(const Sam2Config& config) {
+  std::vector<WeightSpec> specs;
+  auto add = [&](const std::string& name, const std::vector<int>& shape,
+                 float scale = 0.02f) {
+    specs.push_back({name, shape, scale});
+  };
+
+  // Trunk.
+  add("trunk.patch_embed.proj.weight", {config.embed_dim, 7, 7, 3});
+  add("trunk.patch_embed.proj.bias", {config.embed_dim});
+  add("trunk.pos_embed_full",
+      {1, config.token_grid(), config.token_grid(), config.embed_dim});
+  auto blocks = config.Blocks();
+  for (int i = 0; i < static_cast<int>(blocks.size()); ++i) {
+    const auto& b = blocks[i];
+    std::string p = absl::StrCat("trunk.blocks.", i);
+    add(p + ".norm1.weight", {b.dim}, 1.0f);
+    add(p + ".norm1.bias", {b.dim}, 0.0f);
+    add(p + ".attn.qkv.weight", {3 * b.dim_out, b.dim});
+    add(p + ".attn.qkv.bias", {3 * b.dim_out}, 0.0f);
+    add(p + ".attn.proj.weight", {b.dim_out, b.dim_out});
+    add(p + ".attn.proj.bias", {b.dim_out}, 0.0f);
+    if (b.dim != b.dim_out) {
+      add(p + ".proj.weight", {b.dim_out, b.dim});
+      add(p + ".proj.bias", {b.dim_out}, 0.0f);
+    }
+    add(p + ".norm2.weight", {b.dim_out}, 1.0f);
+    add(p + ".norm2.bias", {b.dim_out}, 0.0f);
+    int hidden = b.dim_out * config.mlp_ratio;
+    add(p + ".mlp.layers.0.weight", {hidden, b.dim_out});
+    add(p + ".mlp.layers.0.bias", {hidden}, 0.0f);
+    add(p + ".mlp.layers.1.weight", {b.dim_out, hidden});
+    add(p + ".mlp.layers.1.bias", {b.dim_out}, 0.0f);
+  }
+
+  // Neck (convs.0 = deepest stage, per the reference ordering).
+  std::vector<int> stage_ends = config.StageEnds();
+  std::vector<int> backbone_channels;
+  for (auto it = stage_ends.rbegin(); it != stage_ends.rend(); ++it) {
+    backbone_channels.push_back(blocks[*it].dim_out);
+  }
+  for (int i = 0; i < static_cast<int>(backbone_channels.size()); ++i) {
+    add(absl::StrCat("neck.convs.", i, ".weight"),
+        {config.d_model, 1, 1, backbone_channels[i]});
+    add(absl::StrCat("neck.convs.", i, ".bias"), {config.d_model}, 0.0f);
+  }
+  add("no_mem_embed", {1, 1, config.d_model}, 0.0f);
+
+  // Prompt encoder (point path only).
+  add("sam_prompt_encoder.pe_layer.positional_encoding_gaussian_matrix",
+      {2, 128}, 1.0f);
+  for (int i = 0; i < 4; ++i) {
+    add(absl::StrCat("sam_prompt_encoder.point_embeddings.", i, ".weight"),
+        {1, config.d_model});
+  }
+  add("sam_prompt_encoder.not_a_point_embed.weight", {1, config.d_model});
+  add("sam_prompt_encoder.no_mask_embed.weight", {1, config.d_model});
+
+  // Mask decoder.
+  add("sam_mask_decoder.conv_s0.weight", {32, 1, 1, config.d_model});
+  add("sam_mask_decoder.conv_s0.bias", {32}, 0.0f);
+  add("sam_mask_decoder.conv_s1.weight", {64, 1, 1, config.d_model});
+  add("sam_mask_decoder.conv_s1.bias", {64}, 0.0f);
+  add("sam_mask_decoder.iou_token.weight", {1, config.d_model});
+  add("sam_mask_decoder.mask_tokens.weight", {4, config.d_model});
+  add("sam_mask_decoder.obj_score_token.weight", {1, config.d_model});
+  for (int l = 0; l < 2; ++l) {
+    std::string p = absl::StrCat("sam_mask_decoder.transformer.layers.", l);
+    for (const std::string& attn :
+         {std::string(".self_attn"), std::string(".cross_attn_token_to_image"),
+          std::string(".cross_attn_image_to_token")}) {
+      int internal = attn == ".self_attn" ? 256 : 128;
+      for (const std::string& proj : {std::string("q"), std::string("k"),
+                                      std::string("v")}) {
+        add(p + attn + "." + proj + "_proj.weight", {internal, 256});
+        add(p + attn + "." + proj + "_proj.bias", {internal}, 0.0f);
+      }
+      add(p + attn + ".out_proj.weight", {256, internal});
+      add(p + attn + ".out_proj.bias", {256}, 0.0f);
+    }
+    add(p + ".mlp.layers.0.weight", {2048, 256});
+    add(p + ".mlp.layers.0.bias", {2048}, 0.0f);
+    add(p + ".mlp.layers.1.weight", {256, 2048});
+    add(p + ".mlp.layers.1.bias", {256}, 0.0f);
+    for (int n = 1; n <= 4; ++n) {
+      add(absl::StrCat(p, ".norm", n, ".weight"), {256}, 1.0f);
+      add(absl::StrCat(p, ".norm", n, ".bias"), {256}, 0.0f);
+    }
+  }
+  for (const std::string& proj :
+       {std::string("q"), std::string("k"), std::string("v")}) {
+    add("sam_mask_decoder.transformer.final_attn_token_to_image." + proj +
+            "_proj.weight",
+        {128, 256});
+    add("sam_mask_decoder.transformer.final_attn_token_to_image." + proj +
+            "_proj.bias",
+        {128}, 0.0f);
+  }
+  add("sam_mask_decoder.transformer.final_attn_token_to_image.out_proj.weight",
+      {256, 128});
+  add("sam_mask_decoder.transformer.final_attn_token_to_image.out_proj.bias",
+      {256}, 0.0f);
+  add("sam_mask_decoder.transformer.norm_final_attn.weight", {256}, 1.0f);
+  add("sam_mask_decoder.transformer.norm_final_attn.bias", {256}, 0.0f);
+  add("sam_mask_decoder.output_upscaling_0.weight", {64, 2, 2, 256});
+  add("sam_mask_decoder.output_upscaling_0.bias", {64}, 0.0f);
+  add("sam_mask_decoder.output_upscaling_1.weight", {64}, 1.0f);
+  add("sam_mask_decoder.output_upscaling_1.bias", {64}, 0.0f);
+  add("sam_mask_decoder.output_upscaling_3.weight", {32, 2, 2, 64});
+  add("sam_mask_decoder.output_upscaling_3.bias", {32}, 0.0f);
+  for (int i = 1; i <= 3; ++i) {  // hypernetwork 0 feeds the dropped mask
+    std::string p =
+        absl::StrCat("sam_mask_decoder.output_hypernetworks_mlps.", i);
+    add(p + ".layers.0.weight", {256, 256});
+    add(p + ".layers.0.bias", {256}, 0.0f);
+    add(p + ".layers.1.weight", {256, 256});
+    add(p + ".layers.1.bias", {256}, 0.0f);
+    add(p + ".layers.2.weight", {32, 256});
+    add(p + ".layers.2.bias", {32}, 0.0f);
+  }
+  for (const std::string& head :
+       {std::string("sam_mask_decoder.iou_prediction_head"),
+        std::string("sam_mask_decoder.pred_obj_score_head")}) {
+    int out = head == "sam_mask_decoder.iou_prediction_head" ? 4 : 1;
+    add(head + ".layers.0.weight", {256, 256});
+    add(head + ".layers.0.bias", {256}, 0.0f);
+    add(head + ".layers.1.weight", {256, 256});
+    add(head + ".layers.1.bias", {256}, 0.0f);
+    add(head + ".layers.2.weight", {out, 256});
+    add(head + ".layers.2.bias", {out}, 0.0f);
+  }
+  return specs;
+}
+
+WeightMap MakeSyntheticWeights(const Sam2Config& config, unsigned seed) {
+  WeightMap weights;
+  unsigned state = seed;
+  for (const WeightSpec& spec : GetWeightSpecs(config)) {
+    size_t count = 1;
+    for (int d : spec.shape) count *= static_cast<size_t>(d);
+    std::vector<float> data(count);
+    for (size_t i = 0; i < count; ++i) {
+      state = state * 1664525u + 1013904223u;
+      data[i] = spec.init_scale * (static_cast<float>(state >> 8) /
+                                       static_cast<float>(1u << 24) * 2.0f -
+                                   1.0f);
+    }
+    weights[spec.name] = ConstFloats(data, spec.shape, spec.name);
+  }
+  return weights;
+}
+
+EncoderInputs MakeEncoderInputs(const Sam2Config& config) {
+  EncoderInputs inputs;
+  inputs.pixels =
+      TfTensor({.name = "pixels",
+                .type = Type::kFP32,
+                .shape = {1, config.image_size, config.image_size, 3}});
+  return inputs;
+}
+
+DecoderInputs MakeDecoderInputs(const Sam2Config& config) {
+  DecoderInputs inputs;
+  int eg = config.embed_grid();
+  int mg = config.mask_grid();
+  inputs.image_embeddings = TfTensor({.name = "image_embeddings",
+                                      .type = Type::kFP32,
+                                      .shape = {1, eg, eg, config.d_model}});
+  inputs.feat_s1 = TfTensor({.name = "feat_s1",
+                             .type = Type::kFP32,
+                             .shape = {1, mg / 2, mg / 2, 64}});
+  inputs.feat_s0 = TfTensor(
+      {.name = "feat_s0", .type = Type::kFP32, .shape = {1, mg, mg, 32}});
+  inputs.point_coords = TfTensor(
+      {.name = "point_coords", .type = Type::kFP32, .shape = {1, 1, 2}});
+  return inputs;
+}
+
+std::vector<std::pair<int, TfTensor>> TakeRbmmParams() {
+  std::vector<std::pair<int, TfTensor>> params = std::move(g_rbmm_params);
+  g_rbmm_params.clear();
+  return params;
+}
+
+EncoderOutputs BuildEncoder(const Sam2Config& config,
+                            const EncoderInputs& inputs,
+                            const WeightMap& weights) {
+  g_layer_norm_composite = config.use_layer_norm_composite;
+  g_sdpa_composite = config.use_sdpa_composite;
+  g_rbmm_attention = config.use_rbmm_attention;
+  g_rbmm_hypernet = config.use_rbmm_hypernet;
+
+  // Patch embed: explicit 3px pad + VALID 7x7/s4 (torch padding semantics —
+  // TFLite SAME would pad 1+2 at stride 4 and shift the sampling grid).
+  TfTensor x = PadHW(inputs.pixels, 3, 3, 3, 3);
+  x = Conv2D(x, W(weights, "trunk.patch_embed.proj.weight"),
+             W(weights, "trunk.patch_embed.proj.bias"), /*stride_h=*/4,
+             /*stride_w=*/4, kPaddingValid);
+  x = Add(x, W(weights, "trunk.pos_embed_full"));
+
+  auto blocks = config.Blocks();
+  auto stage_ends = config.StageEnds();
+  std::vector<TfTensor> stage_outputs;
+  for (int i = 0; i < static_cast<int>(blocks.size()); ++i) {
+    x = MultiScaleBlock(config, blocks[i], x, absl::StrCat("trunk.blocks.", i),
+                        weights);
+    for (int e : stage_ends) {
+      if (e == i) stage_outputs.push_back(x);
+    }
+  }
+
+  // FPN neck: convs.0 pairs with the deepest stage. Only the second-deepest
+  // level receives a top-down add (fpn_top_down_levels = {2,3}; the deepest
+  // is its own start). scalp=1 drops the deepest output.
+  int n_levels = static_cast<int>(stage_outputs.size());  // 4
+  std::vector<TfTensor> laterals(n_levels);
+  for (int i = 0; i < n_levels; ++i) {
+    // stage_outputs is shallow->deep; convs index is deep->shallow.
+    laterals[i] =
+        Conv2D(stage_outputs[i],
+               W(weights, absl::StrCat("neck.convs.", n_levels - 1 - i,
+                                       ".weight")),
+               W(weights, absl::StrCat("neck.convs.", n_levels - 1 - i,
+                                       ".bias")),
+               1, 1, kPaddingValid);
+  }
+  int eg = config.embed_grid();
+  TfTensor size_const({.type = Type::kI32,
+                       .shape = {2},
+                       .buffer = OwningCpuBuffer::Copy<Type::kI32>({eg, eg})});
+  TfTensor top_down = ResizeNearestNeighbor(laterals[3], size_const);
+  TfTensor fpn2 = Add(laterals[2], top_down);
+
+  EncoderOutputs outputs;
+  // no_mem_embed folded in (the "no memory" image-only conditioning).
+  // Re-baked at the broadcast shape: a graph Reshape of a constant is
+  // rejected by the GPU delegate ("expected 1 runtime input").
+  TfTensor no_mem = ConstFloats(HostFloats(W(weights, "no_mem_embed")),
+                                {1, 1, 1, config.d_model}, "no_mem_row");
+  outputs.image_embeddings = Add(fpn2, no_mem);
+  outputs.image_embeddings.SetName("image_embeddings");
+  outputs.feat_s1 =
+      Conv2D(laterals[1], W(weights, "sam_mask_decoder.conv_s1.weight"),
+             W(weights, "sam_mask_decoder.conv_s1.bias"), 1, 1, kPaddingValid);
+  outputs.feat_s1.SetName("feat_s1");
+  outputs.feat_s0 =
+      Conv2D(laterals[0], W(weights, "sam_mask_decoder.conv_s0.weight"),
+             W(weights, "sam_mask_decoder.conv_s0.bias"), 1, 1, kPaddingValid);
+  outputs.feat_s0.SetName("feat_s0");
+  return outputs;
+}
+
+DecoderOutputs BuildDecoder(const Sam2Config& config,
+                            const DecoderInputs& inputs,
+                            const WeightMap& weights) {
+  g_layer_norm_composite = config.use_layer_norm_composite;
+  g_sdpa_composite = config.use_sdpa_composite;
+  g_rbmm_attention = config.use_rbmm_attention;
+  g_rbmm_hypernet = config.use_rbmm_hypernet;
+
+  const int eg = config.embed_grid();
+  const int mg = config.mask_grid();
+  const int n_img = eg * eg;
+  const float eps = config.ln_eps_decoder;
+  const std::string dec = "sam_mask_decoder";
+  const std::string tr = dec + ".transformer";
+
+  // --- Sparse prompt: one positive point + the baked not_a_point pad ---
+  // (the reference embed_points with the label logic constant-folded for
+  // the fixed [positive, pad] layout; matches upstream to float rounding).
+  std::vector<float> gaussian = HostFloats(W(
+      weights, "sam_prompt_encoder.pe_layer.positional_encoding_gaussian_matrix"));
+  // FC weight [128, 2]: out k = x * g[0][k] + y * g[1][k].
+  std::vector<float> gauss_t(256);
+  for (int k = 0; k < 128; ++k) {
+    gauss_t[2 * k] = gaussian[k];
+    gauss_t[2 * k + 1] = gaussian[128 + k];
+  }
+  TfTensor c = Mul(Add(inputs.point_coords, ConstScalar(0.5f)),
+                   ConstScalar(1.0f / config.image_size));
+  c = Add(Mul(c, ConstScalar(2.0f)), ConstScalar(-1.0f));
+  TfTensor proj =
+      FullyConnected(c, ConstFloats(gauss_t, {128, 2}, "pe_gaussian_t"),
+                     std::optional<TfTensor>());
+  proj = Mul(proj, ConstScalar(kTwoPi));
+  TfTensor pe = Concatenation({Sin(proj), Cos(proj)}, /*axis=*/2);
+  // Constant rows re-baked at rank 3 (constant-input Reshape is rejected
+  // by the GPU delegate).
+  TfTensor tok0 = Add(
+      pe, ConstFloats(
+              HostFloats(
+                  W(weights, "sam_prompt_encoder.point_embeddings.1.weight")),
+              {1, 1, config.d_model}, "point_embed_pos"));
+  TfTensor tok1 = ConstFloats(
+      HostFloats(W(weights, "sam_prompt_encoder.not_a_point_embed.weight")),
+      {1, 1, config.d_model}, "not_a_point");
+  TfTensor sparse = Concatenation({tok0, tok1}, /*axis=*/1);  // [1,2,256]
+
+  // --- Tokens: [obj_score | iou | mask x4 | sparse x2] ---
+  std::vector<float> token_data;
+  for (const char* name :
+       {"sam_mask_decoder.obj_score_token.weight",
+        "sam_mask_decoder.iou_token.weight",
+        "sam_mask_decoder.mask_tokens.weight"}) {
+    std::vector<float> rows = HostFloats(W(weights, name));
+    token_data.insert(token_data.end(), rows.begin(), rows.end());
+  }
+  TfTensor output_tokens =
+      ConstFloats(token_data, {1, 6, config.d_model}, "output_tokens");
+  TfTensor tokens = Concatenation({output_tokens, sparse}, /*axis=*/1);
+
+  // --- Image side: += no-mask dense prompt row; flatten; baked dense PE ---
+  std::vector<float> no_mask =
+      HostFloats(W(weights, "sam_prompt_encoder.no_mask_embed.weight"));
+  TfTensor src = Add(inputs.image_embeddings,
+                     ConstFloats(no_mask, {1, 1, 1, config.d_model},
+                                 "no_mask_dense"));
+  TfTensor keys = Reshape(src, {1, n_img, config.d_model});
+  TfTensor kpe = BakeDensePeGrid(gaussian, eg);
+
+  // --- Two-way transformer (2 blocks + final token->image attention) ---
+  TfTensor queries = tokens;
+  const TfTensor& qpe = tokens;
+  for (int l = 0; l < 2; ++l) {
+    std::string p = absl::StrCat(tr, ".layers.", l);
+    if (l == 0) {
+      // skip_first_layer_pe: plain self-attention REPLACES the queries.
+      queries = SamAttention(queries, queries, queries, p + ".self_attn",
+                            weights, 8);
+    } else {
+      TfTensor q = Add(queries, qpe);
+      queries = Add(queries,
+                    SamAttention(q, q, queries, p + ".self_attn", weights, 8));
+    }
+    queries = LayerNorm(queries, W(weights, p + ".norm1.weight"),
+                        W(weights, p + ".norm1.bias"), eps);
+
+    TfTensor q = Add(queries, qpe);
+    TfTensor k = Add(keys, kpe);
+    queries = Add(queries, SamAttention(q, k, keys,
+                                        p + ".cross_attn_token_to_image",
+                                        weights, 8));
+    queries = LayerNorm(queries, W(weights, p + ".norm2.weight"),
+                        W(weights, p + ".norm2.bias"), eps);
+
+    TfTensor m = FullyConnected(queries, W(weights, p + ".mlp.layers.0.weight"),
+                                W(weights, p + ".mlp.layers.0.bias"), kActRelu);
+    m = FullyConnected(m, W(weights, p + ".mlp.layers.1.weight"),
+                       W(weights, p + ".mlp.layers.1.bias"));
+    queries = LayerNorm(Add(queries, m), W(weights, p + ".norm3.weight"),
+                        W(weights, p + ".norm3.bias"), eps);
+
+    q = Add(queries, qpe);
+    k = Add(keys, kpe);
+    keys = Add(keys, SamAttention(k, q, queries,
+                                  p + ".cross_attn_image_to_token", weights,
+                                  8));
+    keys = LayerNorm(keys, W(weights, p + ".norm4.weight"),
+                     W(weights, p + ".norm4.bias"), eps);
+  }
+  TfTensor q_final = Add(queries, qpe);
+  TfTensor k_final = Add(keys, kpe);
+  queries = Add(queries, SamAttention(q_final, k_final, keys,
+                                      tr + ".final_attn_token_to_image",
+                                      weights, 8));
+  queries = LayerNorm(queries, W(weights, tr + ".norm_final_attn.weight"),
+                      W(weights, tr + ".norm_final_attn.bias"), eps);
+
+  // --- Mask upscaling (transposed convs; LayerNorm2d == last-axis LN in
+  // NHWC) with the high-res skip features ---
+  TfTensor src_img = Reshape(keys, {1, eg, eg, config.d_model});
+  const bool tc = !config.use_d2s_upsampler;
+  TfTensor up = Upsample2x(src_img, W(weights, dec + ".output_upscaling_0.weight"),
+                           W(weights, dec + ".output_upscaling_0.bias"),
+                           2 * eg, 2 * eg, 64, tc);
+  up = Add(up, inputs.feat_s1);
+  up = LayerNorm(up, W(weights, dec + ".output_upscaling_1.weight"),
+                 W(weights, dec + ".output_upscaling_1.bias"),
+                 config.ln_eps_2d);
+  up = Gelu(up);
+  up = Upsample2x(up, W(weights, dec + ".output_upscaling_3.weight"),
+                  W(weights, dec + ".output_upscaling_3.bias"), mg, mg, 32, tc);
+  up = Add(up, inputs.feat_s0);
+  up = Gelu(up);  // [1, mg, mg, 32]
+
+  // --- Heads ---
+  TfTensor obj_tok = Slice(queries, {0, 0, 0}, {1, 1, config.d_model});
+  TfTensor iou_tok = Slice(queries, {0, 1, 0}, {1, 1, config.d_model});
+  std::vector<TfTensor> hyper;
+  for (int i = 1; i <= 3; ++i) {
+    TfTensor mask_tok =
+        Slice(queries, {0, 2 + i, 0}, {1, 1, config.d_model});
+    hyper.push_back(SamMlp3(
+        mask_tok, absl::StrCat(dec, ".output_hypernetworks_mlps.", i), weights,
+        /*sigmoid_output=*/false));  // [1,1,32]
+  }
+  TfTensor hyper_all = Concatenation({hyper[0], hyper[1], hyper[2]},
+                                     /*axis=*/1);  // [1,3,32]
+  TfTensor up_flat = Reshape(up, {1, mg * mg, 32});
+  TfTensor masks;
+  if (g_rbmm_hypernet) {
+    // The activation x activation projection as one dst-bounded
+    // runtime_bmm at rank 4 (elem2 = mg*mg = full width).
+    TfTensor h4 = Reshape(hyper_all, {1, 1, 3, 32});
+    TfTensor u4 = Reshape(up_flat, {1, 1, mg * mg, 32});
+    TfTensor param = GetRbmmParam(mg * mg);
+    TfTensor m4 = RuntimeBmm(h4, u4, param, /*is_src=*/false);
+    masks = Reshape(m4, {1, 3, mg * mg});
+  } else {
+    masks = BatchMatMul(hyper_all, up_flat, /*adj_x=*/false,
+                        /*adj_y=*/true);  // [1,3,mg*mg]
+  }
+
+  DecoderOutputs outputs;
+  outputs.masks = Reshape(masks, {1, 3, mg, mg});
+  outputs.masks.SetName("masks");
+  TfTensor iou4 = SamMlp3(iou_tok, dec + ".iou_prediction_head", weights,
+                          /*sigmoid_output=*/true);  // [1,1,4]
+  outputs.iou_scores = Reshape(Slice(iou4, {0, 0, 1}, {1, 1, 3}), {1, 3});
+  outputs.iou_scores.SetName("iou_scores");
+  TfTensor obj = SamMlp3(obj_tok, dec + ".pred_obj_score_head", weights,
+                         /*sigmoid_output=*/false);  // [1,1,1]
+  outputs.object_score = Reshape(obj, {1, 1});
+  outputs.object_score.SetName("object_score");
+  return outputs;
+}
+
+}  // namespace litert::tensor::examples::sam2

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.cc
@@ -62,29 +62,30 @@ TfTensor PadHW(const TfTensor& x, int top, int bottom, int left, int right) {
   return Pad(x, paddings);
 }
 
-// Emission toggles (single-threaded graph construction, mirrored from the
-// talker example's pattern).
-bool g_layer_norm_composite = false;
-bool g_sdpa_composite = false;
-bool g_rbmm_attention = false;
-bool g_rbmm_hypernet = false;
+// Build-scoped state, one instance per Build*() call, threaded through the
+// helpers below in place of globals: the config whose emission toggles pick
+// composite vs raw forms, and the odml.runtime_bmm control inputs created so
+// far for this graph.
+struct BuildContext {
+  const Sam2Config& config;
 
-// odml.runtime_bmm control inputs for the CURRENT Build*() call, one per
-// distinct bound length S. The ml_drift parser requires the control tensor
-// to be a RUNTIME input (GetNumberOfRuntimeInputsForNode != 3 rejects the
-// node outright), so these are graph inputs, not constants.
-std::vector<std::pair<int, TfTensor>> g_rbmm_params;
+  // One int32 [1,1,1,7] graph input per distinct bound length S. The
+  // ml_drift parser requires the control tensor to be a RUNTIME input
+  // (GetNumberOfRuntimeInputsForNode != 3 rejects the node outright), so
+  // these are graph inputs, not constants.
+  std::vector<std::pair<int, TfTensor>> rbmm_params;
 
-TfTensor GetRbmmParam(int s) {
-  for (const auto& [len, tensor] : g_rbmm_params) {
-    if (len == s) return tensor;
+  TfTensor RbmmParam(int s) {
+    for (const auto& [len, tensor] : rbmm_params) {
+      if (len == s) return tensor;
+    }
+    TfTensor param({.name = absl::StrCat("rbmm_s", s),
+                    .type = Type::kI32,
+                    .shape = {1, 1, 1, 7}});
+    rbmm_params.emplace_back(s, param);
+    return param;
   }
-  TfTensor param({.name = absl::StrCat("rbmm_s", s),
-                  .type = Type::kI32,
-                  .shape = {1, 1, 1, 7}});
-  g_rbmm_params.emplace_back(s, param);
-  return param;
-}
+};
 
 std::vector<uint8_t> RuntimeBmmAttributes(bool is_src) {
   flexbuffers::Builder fbb;
@@ -133,9 +134,11 @@ TfTensor LayerNormRaw(const TfTensor& x, const TfTensor& weight,
   return Add(Mul(normed, weight), bias);
 }
 
-TfTensor LayerNorm(const TfTensor& x, const TfTensor& weight,
-                   const TfTensor& bias, float eps) {
-  if (!g_layer_norm_composite) return LayerNormRaw(x, weight, bias, eps);
+TfTensor LayerNorm(const BuildContext& ctx, const TfTensor& x,
+                   const TfTensor& weight, const TfTensor& bias, float eps) {
+  if (!ctx.config.use_layer_norm_composite) {
+    return LayerNormRaw(x, weight, bias, eps);
+  }
   StableHLOCompositeOptions opts{.name = "odml.layer_norm",
                                  .composite_attributes =
                                      EpsilonAttributes(eps)};
@@ -170,8 +173,8 @@ TfTensor AttentionRaw(const TfTensor& q, const TfTensor& k, const TfTensor& v,
 // ([B,N,H,D], the odml.scaled_dot_product_attention delegate contract); the
 // decomposition transposes to BNSD and runs the same math, so CPU execution
 // is identical either way.
-TfTensor Mha(const TfTensor& q, const TfTensor& k, const TfTensor& v,
-             int heads) {
+TfTensor Mha(BuildContext& ctx, const TfTensor& q, const TfTensor& k,
+             const TfTensor& v, int heads) {
   const auto& qs = q.GetShape();
   const auto& ks = k.GetShape();
   int b = qs[0];
@@ -186,7 +189,7 @@ TfTensor Mha(const TfTensor& q, const TfTensor& k, const TfTensor& v,
   TfTensor v4 = Reshape(v, {b, nk, heads, hd});
 
   TfTensor out;
-  if (g_sdpa_composite) {
+  if (ctx.config.use_sdpa_composite) {
     StableHLOCompositeOptions opts{
         .name = "odml.scaled_dot_product_attention",
         .composite_attributes = SdpaAttributes(scale)};
@@ -200,7 +203,7 @@ TfTensor Mha(const TfTensor& q, const TfTensor& k, const TfTensor& v,
           return Transpose(o, {0, 2, 1, 3});
         },
         q4, k4, v4);
-  } else if (g_rbmm_attention) {
+  } else if (ctx.config.use_rbmm_attention) {
     // QK + AV odml.runtime_bmm pair with in-graph scale + softmax between.
     // Both sides bound at the full length (elem2 = nk): dst-bounded QK
     // writes every column and src-bounded AV reduces every position, so
@@ -208,7 +211,7 @@ TfTensor Mha(const TfTensor& q, const TfTensor& k, const TfTensor& v,
     // full fill (that needs active < S).
     TfTensor qt = Transpose(q4, {0, 2, 1, 3});   // [B,H,M,D]
     TfTensor kt = Transpose(k4, {0, 2, 1, 3});   // [B,H,N,D]
-    TfTensor param = GetRbmmParam(nk);
+    TfTensor param = ctx.RbmmParam(nk);
     TfTensor scores = RuntimeBmm(qt, kt, param, /*is_src=*/false);
     scores = Mul(scores, ConstScalar(scale));
     TfTensor attn = Softmax(scores);             // [B,H,M,N]
@@ -261,17 +264,17 @@ TfTensor WindowUnpartition(const TfTensor& windows, int n_h, int n_w, int ws2,
 }
 
 // One Hiera multi-scale block on an NHWC grid tensor.
-TfTensor MultiScaleBlock(const Sam2Config& config,
-                         const Sam2Config::BlockSpec& spec, const TfTensor& x,
-                         const std::string& prefix, const WeightMap& weights) {
+TfTensor MultiScaleBlock(BuildContext& ctx, const Sam2Config::BlockSpec& spec,
+                         const TfTensor& x, const std::string& prefix,
+                         const WeightMap& weights) {
   const int dim = spec.dim;
   const int dim_out = spec.dim_out;
   const int h = spec.grid_in;
 
   TfTensor shortcut = x;
-  TfTensor xn = LayerNorm(x, W(weights, prefix + ".norm1.weight"),
+  TfTensor xn = LayerNorm(ctx, x, W(weights, prefix + ".norm1.weight"),
                           W(weights, prefix + ".norm1.bias"),
-                          config.ln_eps_hiera);
+                          ctx.config.ln_eps_hiera);
   if (dim != dim_out) {
     shortcut = FullyConnected(xn, W(weights, prefix + ".proj.weight"),
                               W(weights, prefix + ".proj.bias"));
@@ -312,7 +315,7 @@ TfTensor MultiScaleBlock(const Sam2Config& config,
     q = Reshape(q, {batch, nq, dim_out});
   }
 
-  TfTensor attn = Mha(q, k, v, spec.heads);
+  TfTensor attn = Mha(ctx, q, k, v, spec.heads);
   attn = FullyConnected(attn, W(weights, prefix + ".attn.proj.weight"),
                         W(weights, prefix + ".attn.proj.bias"));
 
@@ -326,9 +329,9 @@ TfTensor MultiScaleBlock(const Sam2Config& config,
   }
 
   TfTensor merged = Add(shortcut, attn);
-  TfTensor m = LayerNorm(merged, W(weights, prefix + ".norm2.weight"),
+  TfTensor m = LayerNorm(ctx, merged, W(weights, prefix + ".norm2.weight"),
                          W(weights, prefix + ".norm2.bias"),
-                         config.ln_eps_hiera);
+                         ctx.config.ln_eps_hiera);
   m = FullyConnected(m, W(weights, prefix + ".mlp.layers.0.weight"),
                      W(weights, prefix + ".mlp.layers.0.bias"));
   m = Gelu(m);
@@ -339,16 +342,17 @@ TfTensor MultiScaleBlock(const Sam2Config& config,
 
 // SAM decoder attention wrapper: separate q/k/v/out projections (+bias),
 // internal dim from the weight shapes (cross attention downsamples to 128).
-TfTensor SamAttention(const TfTensor& q_in, const TfTensor& k_in,
-                      const TfTensor& v_in, const std::string& prefix,
-                      const WeightMap& weights, int heads) {
+TfTensor SamAttention(BuildContext& ctx, const TfTensor& q_in,
+                      const TfTensor& k_in, const TfTensor& v_in,
+                      const std::string& prefix, const WeightMap& weights,
+                      int heads) {
   TfTensor q = FullyConnected(q_in, W(weights, prefix + ".q_proj.weight"),
                               W(weights, prefix + ".q_proj.bias"));
   TfTensor k = FullyConnected(k_in, W(weights, prefix + ".k_proj.weight"),
                               W(weights, prefix + ".k_proj.bias"));
   TfTensor v = FullyConnected(v_in, W(weights, prefix + ".v_proj.weight"),
                               W(weights, prefix + ".v_proj.bias"));
-  TfTensor out = Mha(q, k, v, heads);
+  TfTensor out = Mha(ctx, q, k, v, heads);
   return FullyConnected(out, W(weights, prefix + ".out_proj.weight"),
                         W(weights, prefix + ".out_proj.bias"));
 }
@@ -601,19 +605,10 @@ DecoderInputs MakeDecoderInputs(const Sam2Config& config) {
   return inputs;
 }
 
-std::vector<std::pair<int, TfTensor>> TakeRbmmParams() {
-  std::vector<std::pair<int, TfTensor>> params = std::move(g_rbmm_params);
-  g_rbmm_params.clear();
-  return params;
-}
-
 EncoderOutputs BuildEncoder(const Sam2Config& config,
                             const EncoderInputs& inputs,
                             const WeightMap& weights) {
-  g_layer_norm_composite = config.use_layer_norm_composite;
-  g_sdpa_composite = config.use_sdpa_composite;
-  g_rbmm_attention = config.use_rbmm_attention;
-  g_rbmm_hypernet = config.use_rbmm_hypernet;
+  BuildContext ctx{config};
 
   // Patch embed: explicit 3px pad + VALID 7x7/s4 (torch padding semantics —
   // TFLite SAME would pad 1+2 at stride 4 and shift the sampling grid).
@@ -627,7 +622,7 @@ EncoderOutputs BuildEncoder(const Sam2Config& config,
   auto stage_ends = config.StageEnds();
   std::vector<TfTensor> stage_outputs;
   for (int i = 0; i < static_cast<int>(blocks.size()); ++i) {
-    x = MultiScaleBlock(config, blocks[i], x, absl::StrCat("trunk.blocks.", i),
+    x = MultiScaleBlock(ctx, blocks[i], x, absl::StrCat("trunk.blocks.", i),
                         weights);
     for (int e : stage_ends) {
       if (e == i) stage_outputs.push_back(x);
@@ -672,16 +667,14 @@ EncoderOutputs BuildEncoder(const Sam2Config& config,
       Conv2D(laterals[0], W(weights, "sam_mask_decoder.conv_s0.weight"),
              W(weights, "sam_mask_decoder.conv_s0.bias"), 1, 1, kPaddingValid);
   outputs.feat_s0.SetName("feat_s0");
+  outputs.rbmm_params = std::move(ctx.rbmm_params);
   return outputs;
 }
 
 DecoderOutputs BuildDecoder(const Sam2Config& config,
                             const DecoderInputs& inputs,
                             const WeightMap& weights) {
-  g_layer_norm_composite = config.use_layer_norm_composite;
-  g_sdpa_composite = config.use_sdpa_composite;
-  g_rbmm_attention = config.use_rbmm_attention;
-  g_rbmm_hypernet = config.use_rbmm_hypernet;
+  BuildContext ctx{config};
 
   const int eg = config.embed_grid();
   const int mg = config.mask_grid();
@@ -750,45 +743,45 @@ DecoderOutputs BuildDecoder(const Sam2Config& config,
     std::string p = absl::StrCat(tr, ".layers.", l);
     if (l == 0) {
       // skip_first_layer_pe: plain self-attention REPLACES the queries.
-      queries = SamAttention(queries, queries, queries, p + ".self_attn",
-                            weights, 8);
+      queries = SamAttention(ctx, queries, queries, queries,
+                             p + ".self_attn", weights, 8);
     } else {
       TfTensor q = Add(queries, qpe);
-      queries = Add(queries,
-                    SamAttention(q, q, queries, p + ".self_attn", weights, 8));
+      queries = Add(queries, SamAttention(ctx, q, q, queries,
+                                          p + ".self_attn", weights, 8));
     }
-    queries = LayerNorm(queries, W(weights, p + ".norm1.weight"),
+    queries = LayerNorm(ctx, queries, W(weights, p + ".norm1.weight"),
                         W(weights, p + ".norm1.bias"), eps);
 
     TfTensor q = Add(queries, qpe);
     TfTensor k = Add(keys, kpe);
-    queries = Add(queries, SamAttention(q, k, keys,
+    queries = Add(queries, SamAttention(ctx, q, k, keys,
                                         p + ".cross_attn_token_to_image",
                                         weights, 8));
-    queries = LayerNorm(queries, W(weights, p + ".norm2.weight"),
+    queries = LayerNorm(ctx, queries, W(weights, p + ".norm2.weight"),
                         W(weights, p + ".norm2.bias"), eps);
 
     TfTensor m = FullyConnected(queries, W(weights, p + ".mlp.layers.0.weight"),
                                 W(weights, p + ".mlp.layers.0.bias"), kActRelu);
     m = FullyConnected(m, W(weights, p + ".mlp.layers.1.weight"),
                        W(weights, p + ".mlp.layers.1.bias"));
-    queries = LayerNorm(Add(queries, m), W(weights, p + ".norm3.weight"),
+    queries = LayerNorm(ctx, Add(queries, m), W(weights, p + ".norm3.weight"),
                         W(weights, p + ".norm3.bias"), eps);
 
     q = Add(queries, qpe);
     k = Add(keys, kpe);
-    keys = Add(keys, SamAttention(k, q, queries,
+    keys = Add(keys, SamAttention(ctx, k, q, queries,
                                   p + ".cross_attn_image_to_token", weights,
                                   8));
-    keys = LayerNorm(keys, W(weights, p + ".norm4.weight"),
+    keys = LayerNorm(ctx, keys, W(weights, p + ".norm4.weight"),
                      W(weights, p + ".norm4.bias"), eps);
   }
   TfTensor q_final = Add(queries, qpe);
   TfTensor k_final = Add(keys, kpe);
-  queries = Add(queries, SamAttention(q_final, k_final, keys,
+  queries = Add(queries, SamAttention(ctx, q_final, k_final, keys,
                                       tr + ".final_attn_token_to_image",
                                       weights, 8));
-  queries = LayerNorm(queries, W(weights, tr + ".norm_final_attn.weight"),
+  queries = LayerNorm(ctx, queries, W(weights, tr + ".norm_final_attn.weight"),
                       W(weights, tr + ".norm_final_attn.bias"), eps);
 
   // --- Mask upscaling (transposed convs; LayerNorm2d == last-axis LN in
@@ -799,7 +792,7 @@ DecoderOutputs BuildDecoder(const Sam2Config& config,
                            W(weights, dec + ".output_upscaling_0.bias"),
                            2 * eg, 2 * eg, 64, tc);
   up = Add(up, inputs.feat_s1);
-  up = LayerNorm(up, W(weights, dec + ".output_upscaling_1.weight"),
+  up = LayerNorm(ctx, up, W(weights, dec + ".output_upscaling_1.weight"),
                  W(weights, dec + ".output_upscaling_1.bias"),
                  config.ln_eps_2d);
   up = Gelu(up);
@@ -823,12 +816,12 @@ DecoderOutputs BuildDecoder(const Sam2Config& config,
                                      /*axis=*/1);  // [1,3,32]
   TfTensor up_flat = Reshape(up, {1, mg * mg, 32});
   TfTensor masks;
-  if (g_rbmm_hypernet) {
+  if (config.use_rbmm_hypernet) {
     // The activation x activation projection as one dst-bounded
     // runtime_bmm at rank 4 (elem2 = mg*mg = full width).
     TfTensor h4 = Reshape(hyper_all, {1, 1, 3, 32});
     TfTensor u4 = Reshape(up_flat, {1, 1, mg * mg, 32});
-    TfTensor param = GetRbmmParam(mg * mg);
+    TfTensor param = ctx.RbmmParam(mg * mg);
     TfTensor m4 = RuntimeBmm(h4, u4, param, /*is_src=*/false);
     masks = Reshape(m4, {1, 3, mg * mg});
   } else {
@@ -847,6 +840,7 @@ DecoderOutputs BuildDecoder(const Sam2Config& config,
                          /*sigmoid_output=*/false);  // [1,1,1]
   outputs.object_score = Reshape(obj, {1, 1});
   outputs.object_score.SetName("object_score");
+  outputs.rbmm_params = std::move(ctx.rbmm_params);
   return outputs;
 }
 

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.cc
@@ -652,12 +652,16 @@ EncoderOutputs BuildEncoder(const Sam2Config& config,
   TfTensor fpn2 = Add(laterals[2], top_down);
 
   EncoderOutputs outputs;
-  // no_mem_embed folded in (the "no memory" image-only conditioning).
-  // Re-baked at the broadcast shape: a graph Reshape of a constant is
-  // rejected by the GPU delegate ("expected 1 runtime input").
-  TfTensor no_mem = ConstFloats(HostFloats(W(weights, "no_mem_embed")),
-                                {1, 1, 1, config.d_model}, "no_mem_row");
-  outputs.image_embeddings = Add(fpn2, no_mem);
+  if (config.fold_no_mem_embed) {
+    // no_mem_embed folded in (the "no memory" image-only conditioning).
+    // Re-baked at the broadcast shape: a graph Reshape of a constant is
+    // rejected by the GPU delegate ("expected 1 runtime input").
+    TfTensor no_mem = ConstFloats(HostFloats(W(weights, "no_mem_embed")),
+                                  {1, 1, 1, config.d_model}, "no_mem_row");
+    outputs.image_embeddings = Add(fpn2, no_mem);
+  } else {
+    outputs.image_embeddings = fpn2;  // the raw top-level feature map
+  }
   outputs.image_embeddings.SetName("image_embeddings");
   outputs.feat_s1 =
       Conv2D(laterals[1], W(weights, "sam_mask_decoder.conv_s1.weight"),

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h
@@ -1,0 +1,103 @@
+// SAM2.1 hiera-tiny image path authored on the C++ Tensor API.
+//
+// Two signatures in one flatbuffer:
+//   encode_image: pixels [1,512,512,3] NHWC (ImageNet-normalized) ->
+//     image_embeddings [1,32,32,256] (no_mem_embed folded in),
+//     feat_s1 [1,64,64,64], feat_s0 [1,128,128,32] (conv_s1/conv_s0 folded
+//     into the encoder — the decoder-ready layout the published converted
+//     models use).
+//   decode_mask: image_embeddings + feat_s1 + feat_s0 + point_coords
+//     [1,1,2] (x,y in image space, one positive point; the not_a_point pad
+//     token is a baked constant) -> masks [1,3,128,128] multimask logits,
+//     iou_scores [1,3], object_score [1,1].
+//
+// Layout is NHWC end to end (TFLite conv layout; the MLX checkpoint's conv
+// weights are already OHWI so every weight loads without transposition).
+// Constants baked at build time: the 128-grid re-composed pos_embed_full,
+// the dense image positional-encoding grid, the no-mask dense prompt row,
+// the output tokens, and the prompt-encoder point/pad embeddings. All
+// attention is rank-4; window partition/unpartition stays <=4-D (the
+// order-equivariant split-H-then-W form proven in the converted-path work).
+
+#ifndef MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_GRAPH_H_
+#define MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_GRAPH_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "tensor/backends/tflite/arithmetic_tflite.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::sam2 {
+
+using TfTensor = ::litert::tensor::Tensor<::litert::tensor::TfLiteMixinTag>;
+using WeightMap = absl::flat_hash_map<std::string, TfTensor>;
+
+struct EncoderInputs {
+  TfTensor pixels;  // [1, S, S, 3] kFP32 NHWC, ImageNet-normalized
+  std::vector<TfTensor> AsList() const { return {pixels}; }
+};
+
+struct EncoderOutputs {
+  TfTensor image_embeddings;  // [1, S/16, S/16, 256]
+  TfTensor feat_s1;           // [1, S/8, S/8, 64]
+  TfTensor feat_s0;           // [1, S/4, S/4, 32]
+  std::vector<TfTensor> AsList() const {
+    return {image_embeddings, feat_s1, feat_s0};
+  }
+};
+
+struct DecoderInputs {
+  TfTensor image_embeddings;  // [1, S/16, S/16, 256]
+  TfTensor feat_s1;           // [1, S/8, S/8, 64]
+  TfTensor feat_s0;           // [1, S/4, S/4, 32]
+  TfTensor point_coords;      // [1, 1, 2] kFP32 (x, y) in image space
+  std::vector<TfTensor> AsList() const {
+    return {image_embeddings, feat_s1, feat_s0, point_coords};
+  }
+};
+
+struct DecoderOutputs {
+  TfTensor masks;         // [1, 3, S/4, S/4] multimask logits
+  TfTensor iou_scores;    // [1, 3]
+  TfTensor object_score;  // [1, 1]
+  std::vector<TfTensor> AsList() const {
+    return {masks, iou_scores, object_score};
+  }
+};
+
+// Every weight the two graphs consume, under the checkpoint's MLX naming
+// (trunk./neck./sam_prompt_encoder./sam_mask_decoder./no_mem_embed).
+// Single source of truth for the synthetic generator and the loader.
+struct WeightSpec {
+  std::string name;
+  std::vector<int> shape;
+  float init_scale;  // synthetic init only
+};
+std::vector<WeightSpec> GetWeightSpecs(const Sam2Config& config);
+
+WeightMap MakeSyntheticWeights(const Sam2Config& config, unsigned seed);
+
+EncoderInputs MakeEncoderInputs(const Sam2Config& config);
+DecoderInputs MakeDecoderInputs(const Sam2Config& config);
+
+// odml.runtime_bmm control inputs created during the LAST Build*() call
+// (one int32 [1,1,1,7] graph input per distinct bound length S, named
+// "rbmm_s<S>"). The caller appends the tensors to that signature's input
+// list and feeds each with seven int32 copies of S at runtime (the proven
+// attn_bench fill pattern). Returns and clears the registry.
+std::vector<std::pair<int, TfTensor>> TakeRbmmParams();
+
+EncoderOutputs BuildEncoder(const Sam2Config& config,
+                            const EncoderInputs& inputs,
+                            const WeightMap& weights);
+DecoderOutputs BuildDecoder(const Sam2Config& config,
+                            const DecoderInputs& inputs,
+                            const WeightMap& weights);
+
+}  // namespace litert::tensor::examples::sam2
+
+#endif  // MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_GRAPH_H_

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h
@@ -41,10 +41,18 @@ struct EncoderInputs {
   std::vector<TfTensor> AsList() const { return {pixels}; }
 };
 
+// odml.runtime_bmm control inputs a graph consumes: one int32 [1,1,1,7]
+// graph input per distinct bound length S, named "rbmm_s<S>". Empty unless a
+// use_rbmm_* toggle is set. The caller appends them to the signature's input
+// list and feeds each with seven int32 copies of S at runtime (the proven
+// attn_bench fill pattern).
+using RbmmParams = std::vector<std::pair<int, TfTensor>>;
+
 struct EncoderOutputs {
   TfTensor image_embeddings;  // [1, S/16, S/16, 256]
   TfTensor feat_s1;           // [1, S/8, S/8, 64]
   TfTensor feat_s0;           // [1, S/4, S/4, 32]
+  RbmmParams rbmm_params;
   std::vector<TfTensor> AsList() const {
     return {image_embeddings, feat_s1, feat_s0};
   }
@@ -64,6 +72,7 @@ struct DecoderOutputs {
   TfTensor masks;         // [1, 3, S/4, S/4] multimask logits
   TfTensor iou_scores;    // [1, 3]
   TfTensor object_score;  // [1, 1]
+  RbmmParams rbmm_params;
   std::vector<TfTensor> AsList() const {
     return {masks, iou_scores, object_score};
   }
@@ -83,13 +92,6 @@ WeightMap MakeSyntheticWeights(const Sam2Config& config, unsigned seed);
 
 EncoderInputs MakeEncoderInputs(const Sam2Config& config);
 DecoderInputs MakeDecoderInputs(const Sam2Config& config);
-
-// odml.runtime_bmm control inputs created during the LAST Build*() call
-// (one int32 [1,1,1,7] graph input per distinct bound length S, named
-// "rbmm_s<S>"). The caller appends the tensors to that signature's input
-// list and feeds each with seven int32 copies of S at runtime (the proven
-// attn_bench fill pattern). Returns and clears the registry.
-std::vector<std::pair<int, TfTensor>> TakeRbmmParams();
 
 EncoderOutputs BuildEncoder(const Sam2Config& config,
                             const EncoderInputs& inputs,

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h
@@ -2,7 +2,8 @@
 //
 // Two signatures in one flatbuffer:
 //   encode_image: pixels [1,512,512,3] NHWC (ImageNet-normalized) ->
-//     image_embeddings [1,32,32,256] (no_mem_embed folded in),
+//     image_embeddings [1,32,32,256] (no_mem_embed folded in while
+//     Sam2Config::fold_no_mem_embed is set — the default),
 //     feat_s1 [1,64,64,64], feat_s0 [1,128,128,32] (conv_s1/conv_s0 folded
 //     into the encoder — the decoder-ready layout the published converted
 //     models use).

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_main.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_main.cc
@@ -1,0 +1,456 @@
+// SAM2.1 hiera-tiny image path — build, serialize, run, verify, bench.
+//
+// Usage (from the LiteRT repo root; GPU runs need cwd =
+// litert/prebuilt/macos_arm64 so the Metal accelerator dylib resolves):
+//   bazel build --config=macos_arm64 //models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_main
+//   sam2_main --weights=.../sam2_tiny_512.safetensors \
+//     --accelerator=gpu --gpu_precision=fp16 --gpu_buffer_storage=buffer
+//
+// Runs the same fixture as the reference apps: a white circle on black
+// (radius size/4-8), one positive point at the center, ImageNet
+// normalization. Prints iou_scores / object_score / best-mask foreground
+// exactly like the mlx-swift app's SAM2MLXBENCH block, plus warm medians.
+// --dump_dir writes every I/O tensor raw for the PyTorch parity check
+// (verify/sam2_torch_ref.py).
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "tensor/backends/tflite/tflite_flatbuffer_conversion.h"
+#include "tensor/datatypes.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h"
+#include "tensor/runners/litert/litert_dynamic_runner.h"
+#include "tensor/tensor.h"
+
+ABSL_FLAG(std::string, weights, "",
+          "sam2_tiny_512.safetensors path (empty = synthetic weights for a "
+          "shape/route check)");
+ABSL_FLAG(std::string, tflite_path, "/tmp/sam2_image.tflite",
+          "Where to write the serialized two-signature model");
+ABSL_FLAG(std::string, accelerator, "cpu", "cpu|gpu");
+ABSL_FLAG(std::string, gpu_precision, "fp16",
+          "fp16|fp32 — GPU calculation precision (fp16 is the delegate "
+          "default; fp32 for CPU-parity verification)");
+ABSL_FLAG(std::string, gpu_buffer_storage, "default",
+          "default|buffer|texture2d — GPU tensor storage (texture limits "
+          "can silently push large graphs to CPU; probe with buffer)");
+ABSL_FLAG(std::string, attention, "raw",
+          "raw|sdpa|rbmm — plain ops, the odml.scaled_dot_product_attention "
+          "composite, or the odml.runtime_bmm QK+AV pair (int32 control "
+          "inputs bound at the full static length)");
+ABSL_FLAG(std::string, hypernet, "raw",
+          "raw|rbmm — the hypernetwork mask projection as a plain "
+          "BatchMatMul or one dst-bounded odml.runtime_bmm");
+ABSL_FLAG(std::string, norms, "raw",
+          "raw|composite — plain ops or the odml.layer_norm composite");
+ABSL_FLAG(std::string, upsampler, "transpose",
+          "transpose|d2s — mask upsampler as TRANSPOSE_CONV or the exact "
+          "4x(1x1)+DepthToSpace expansion (for delegates that reject "
+          "TRANSPOSE_CONV, e.g. Mali ML Drift)");
+ABSL_FLAG(int, runs, 20, "Timed iterations per stage");
+ABSL_FLAG(int, warmup, 5, "Warmup iterations");
+ABSL_FLAG(double, point_x, -1.0, "Prompt x in image space (-1 = center)");
+ABSL_FLAG(double, point_y, -1.0, "Prompt y in image space (-1 = center)");
+ABSL_FLAG(std::string, input_file, "",
+          "Raw fp32 NHWC [1,512,512,3] normalized input (empty = the "
+          "synthetic circle fixture)");
+ABSL_FLAG(std::string, dump_dir, "",
+          "If set, write pixels/image_embeddings/feat_s1/feat_s0/masks/"
+          "iou_scores/object_score as raw fp32 for the parity check");
+ABSL_FLAG(std::string, split_dir, "",
+          "If set, ALSO serialize single-signature models "
+          "sam2_encoder_512.tflite / sam2_decoder_512.tflite there (for "
+          "harnesses that only run a model's first signature, e.g. the "
+          "on-device gpu_test binary)");
+
+namespace {
+
+using ::litert::tensor::Create;
+using ::litert::tensor::LitertDynamicRunner;
+using ::litert::tensor::ModelFactory;
+using ::litert::tensor::Type;
+namespace sam2 = ::litert::tensor::examples::sam2;
+
+// The reference fixture: white circle (1.0) on black, radius size/4 - 8,
+// ImageNet-normalized, NHWC.
+std::vector<float> CircleInput(int size) {
+  const float mean[3] = {0.485f, 0.456f, 0.406f};
+  const float stddev[3] = {0.229f, 0.224f, 0.225f};
+  std::vector<float> out(static_cast<size_t>(size) * size * 3);
+  const int cx = size / 2;
+  const int cy = size / 2;
+  const int r = size / 4 - 8;
+  const int r2 = r * r;
+  for (int y = 0; y < size; ++y) {
+    for (int x = 0; x < size; ++x) {
+      const int dx = x - cx;
+      const int dy = y - cy;
+      const float value = (dx * dx + dy * dy <= r2) ? 1.0f : 0.0f;
+      size_t base = (static_cast<size_t>(y) * size + x) * 3;
+      for (int ch = 0; ch < 3; ++ch) {
+        out[base + ch] = (value - mean[ch]) / stddev[ch];
+      }
+    }
+  }
+  return out;
+}
+
+double Median(std::vector<double> v) {
+  std::sort(v.begin(), v.end());
+  return v[v.size() / 2];
+}
+
+absl::Status ReadFloats(LitertDynamicRunner& runner, const std::string& sig,
+                        const std::string& name, std::vector<float>& out) {
+  auto t = runner.GetOutput(sig, name);
+  if (!t.ok()) return t.status();
+  auto buffer = t->GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->Lock();
+  const float* data = reinterpret_cast<const float*>(lock.data());
+  out.assign(data, data + lock.size() / sizeof(float));
+  return absl::OkStatus();
+}
+
+absl::Status DumpFile(const std::string& dir, const std::string& name,
+                      const std::vector<float>& data) {
+  std::ofstream out(absl::StrCat(dir, "/", name, ".f32"), std::ios::binary);
+  if (!out) return absl::InternalError(absl::StrCat("cannot write ", name));
+  out.write(reinterpret_cast<const char*>(data.data()),
+            data.size() * sizeof(float));
+  return absl::OkStatus();
+}
+
+absl::Status Run() {
+  sam2::Sam2Config config;
+  const std::string attention = absl::GetFlag(FLAGS_attention);
+  if (attention != "raw" && attention != "sdpa" && attention != "rbmm") {
+    return absl::InvalidArgumentError("--attention must be raw|sdpa|rbmm");
+  }
+  config.use_sdpa_composite = attention == "sdpa";
+  config.use_rbmm_attention = attention == "rbmm";
+  const std::string hypernet = absl::GetFlag(FLAGS_hypernet);
+  if (hypernet != "raw" && hypernet != "rbmm") {
+    return absl::InvalidArgumentError("--hypernet must be raw|rbmm");
+  }
+  config.use_rbmm_hypernet = hypernet == "rbmm";
+  const std::string norms = absl::GetFlag(FLAGS_norms);
+  if (norms != "raw" && norms != "composite") {
+    return absl::InvalidArgumentError("--norms must be raw|composite");
+  }
+  config.use_layer_norm_composite = norms == "composite";
+  const std::string upsampler = absl::GetFlag(FLAGS_upsampler);
+  if (upsampler != "transpose" && upsampler != "d2s") {
+    return absl::InvalidArgumentError("--upsampler must be transpose|d2s");
+  }
+  config.use_d2s_upsampler = upsampler == "d2s";
+
+  sam2::WeightMap weights;
+  const std::string weights_path = absl::GetFlag(FLAGS_weights);
+  if (weights_path.empty()) {
+    weights = sam2::MakeSyntheticWeights(config, /*seed=*/42);
+    std::cout << "weights: synthetic (seed 42) — shape/route check only"
+              << std::endl;
+  } else {
+    auto weights_or = sam2::LoadCheckpointWeights(config, weights_path);
+    if (!weights_or.ok()) return weights_or.status();
+    weights = std::move(*weights_or);
+    std::cout << "weights: " << weights_path << " (" << weights.size()
+              << " tensors, fp16->fp32)" << std::endl;
+  }
+  if (config.use_sdpa_composite) {
+    std::cout << "attention: odml.scaled_dot_product_attention composite"
+              << std::endl;
+  }
+  if (config.use_rbmm_attention) {
+    std::cout << "attention: odml.runtime_bmm QK+AV pair" << std::endl;
+  }
+  if (config.use_rbmm_hypernet) {
+    std::cout << "hypernet: odml.runtime_bmm" << std::endl;
+  }
+  if (config.use_layer_norm_composite) {
+    std::cout << "norms: odml.layer_norm composite" << std::endl;
+  }
+
+  sam2::EncoderInputs enc_in = sam2::MakeEncoderInputs(config);
+  sam2::EncoderOutputs enc_out = sam2::BuildEncoder(config, enc_in, weights);
+  auto enc_rbmm = sam2::TakeRbmmParams();
+  sam2::DecoderInputs dec_in = sam2::MakeDecoderInputs(config);
+  sam2::DecoderOutputs dec_out = sam2::BuildDecoder(config, dec_in, weights);
+  auto dec_rbmm = sam2::TakeRbmmParams();
+
+  ModelFactory factory;
+  {
+    std::vector<::litert::tensor::TensorHandle> ins, outs;
+    for (auto& t : enc_in.AsList()) ins.push_back(t);
+    for (auto& [s, t] : enc_rbmm) ins.push_back(t);
+    for (auto& t : enc_out.AsList()) outs.push_back(t);
+    auto status = factory.AddSignature(ins, outs, "encode_image");
+    if (!status.ok()) return status;
+  }
+  {
+    std::vector<::litert::tensor::TensorHandle> ins, outs;
+    for (auto& t : dec_in.AsList()) ins.push_back(t);
+    for (auto& [s, t] : dec_rbmm) ins.push_back(t);
+    for (auto& t : dec_out.AsList()) outs.push_back(t);
+    auto status = factory.AddSignature(ins, outs, "decode_mask");
+    if (!status.ok()) return status;
+  }
+  const std::string tflite_path = absl::GetFlag(FLAGS_tflite_path);
+  auto save_status = factory.Save(tflite_path);
+  if (!save_status.ok()) return save_status;
+  std::cout << "Serialized: " << tflite_path << std::endl;
+
+  const std::string split_dir = absl::GetFlag(FLAGS_split_dir);
+  if (!split_dir.empty()) {
+    sam2::EncoderInputs enc_in2 = sam2::MakeEncoderInputs(config);
+    sam2::EncoderOutputs enc_out2 = sam2::BuildEncoder(config, enc_in2, weights);
+    auto enc_rbmm2 = sam2::TakeRbmmParams();
+    ModelFactory enc_factory;
+    std::vector<::litert::tensor::TensorHandle> ins, outs;
+    for (auto& t : enc_in2.AsList()) ins.push_back(t);
+    for (auto& [s, t] : enc_rbmm2) ins.push_back(t);
+    for (auto& t : enc_out2.AsList()) outs.push_back(t);
+    auto st1 = enc_factory.AddSignature(ins, outs, "encode_image");
+    if (!st1.ok()) return st1;
+    st1 = enc_factory.Save(split_dir + "/sam2_encoder_512.tflite");
+    if (!st1.ok()) return st1;
+
+    sam2::DecoderInputs dec_in2 = sam2::MakeDecoderInputs(config);
+    sam2::DecoderOutputs dec_out2 = sam2::BuildDecoder(config, dec_in2, weights);
+    auto dec_rbmm2 = sam2::TakeRbmmParams();
+    ModelFactory dec_factory;
+    ins.clear();
+    outs.clear();
+    for (auto& t : dec_in2.AsList()) ins.push_back(t);
+    for (auto& [s, t] : dec_rbmm2) ins.push_back(t);
+    for (auto& t : dec_out2.AsList()) outs.push_back(t);
+    auto st2 = dec_factory.AddSignature(ins, outs, "decode_mask");
+    if (!st2.ok()) return st2;
+    st2 = dec_factory.Save(split_dir + "/sam2_decoder_512.tflite");
+    if (!st2.ok()) return st2;
+    std::cout << "Split models serialized to " << split_dir << std::endl;
+  }
+
+  auto env = ::litert::Environment::Create({});
+  if (!env) return absl::InternalError("Environment::Create failed");
+  auto options = ::litert::Options::Create();
+  if (!options) return absl::InternalError("Options::Create failed");
+  const bool use_gpu = absl::GetFlag(FLAGS_accelerator) == "gpu";
+  options->SetHardwareAccelerators(use_gpu ? ::litert::HwAccelerators::kGpu
+                                           : ::litert::HwAccelerators::kCpu);
+  if (use_gpu) {
+    auto gpu_options = options->GetGpuOptions();
+    if (gpu_options.HasValue()) {
+      const std::string precision = absl::GetFlag(FLAGS_gpu_precision);
+      if (precision == "fp32") {
+        gpu_options->SetPrecision(::litert::GpuOptions::Precision::kFp32);
+      } else if (precision != "fp16") {
+        return absl::InvalidArgumentError("--gpu_precision must be fp16|fp32");
+      }
+      const std::string storage = absl::GetFlag(FLAGS_gpu_buffer_storage);
+      if (storage == "buffer") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kBuffer);
+      } else if (storage == "texture2d") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kTexture2D);
+      } else if (storage != "default") {
+        return absl::InvalidArgumentError(
+            "--gpu_buffer_storage must be default|buffer|texture2d");
+      }
+      std::cout << "gpu precision: " << precision << ", storage: " << storage
+                << std::endl;
+    }
+  }
+  auto runner_or = LitertDynamicRunner::Create(*env, tflite_path, *options);
+  if (!runner_or.ok()) return runner_or.status();
+  auto runner = std::move(*runner_or);
+
+  // --- Stage input ---
+  const int size = config.image_size;
+  std::vector<float> pixels;
+  const std::string input_file = absl::GetFlag(FLAGS_input_file);
+  if (input_file.empty()) {
+    pixels = CircleInput(size);
+  } else {
+    pixels.resize(static_cast<size_t>(size) * size * 3);
+    std::ifstream in(input_file, std::ios::binary);
+    if (!in) return absl::NotFoundError("input_file: " + input_file);
+    in.read(reinterpret_cast<char*>(pixels.data()),
+            pixels.size() * sizeof(float));
+    if (static_cast<size_t>(in.gcount()) != pixels.size() * sizeof(float)) {
+      return absl::InvalidArgumentError("input_file wrong size");
+    }
+  }
+  auto set_pixels = [&]() -> absl::Status {
+    return runner.SetInput(
+        "encode_image", "pixels",
+        Create("pixels", Type::kFP32, {1, size, size, 3},
+               std::vector<float>(pixels)));
+  };
+
+  float px = static_cast<float>(absl::GetFlag(FLAGS_point_x));
+  float py = static_cast<float>(absl::GetFlag(FLAGS_point_y));
+  if (px < 0) px = size / 2.0f;
+  if (py < 0) py = size / 2.0f;
+  auto set_decoder_inputs = [&]() -> absl::Status {
+    for (const std::string& name :
+         {std::string("image_embeddings"), std::string("feat_s1"),
+          std::string("feat_s0")}) {
+      auto t = runner.GetOutput("encode_image", name);
+      if (!t.ok()) return t.status();
+      auto st = runner.SetInput("decode_mask", name, *t);
+      if (!st.ok()) return st;
+    }
+    return runner.SetInput("decode_mask", "point_coords",
+                           Create("point_coords", Type::kFP32, {1, 1, 2},
+                                  std::vector<float>{px, py}));
+  };
+
+  // odml.runtime_bmm control inputs: seven int32 copies of the bound
+  // length S per input (the proven attn_bench fill pattern; element 2 is
+  // the one the kernels read). Set once — inputs persist across Run().
+  auto set_rbmm_params =
+      [&](const std::string& sig,
+          const std::vector<std::pair<int, sam2::TfTensor>>& params)
+      -> absl::Status {
+    for (const auto& [s, t] : params) {
+      const std::string name = absl::StrCat("rbmm_s", s);
+      auto st = runner.SetInput(
+          sig, name,
+          Create(name, Type::kI32, {1, 1, 1, 7},
+                 std::vector<int32_t>(7, s)));
+      if (!st.ok()) return st;
+    }
+    return absl::OkStatus();
+  };
+  {
+    auto st = set_rbmm_params("encode_image", enc_rbmm);
+    if (!st.ok()) return st;
+    st = set_rbmm_params("decode_mask", dec_rbmm);
+    if (!st.ok()) return st;
+  }
+
+  // --- Warmup + correctness pass ---
+  auto st = set_pixels();
+  if (!st.ok()) return st;
+  st = runner.Run("encode_image");
+  if (!st.ok()) return st;
+  st = set_decoder_inputs();
+  if (!st.ok()) return st;
+  st = runner.Run("decode_mask");
+  if (!st.ok()) return st;
+
+  const int warmup = absl::GetFlag(FLAGS_warmup);
+  const int runs = absl::GetFlag(FLAGS_runs);
+  for (int i = 0; i < warmup; ++i) {
+    st = runner.Run("encode_image");
+    if (!st.ok()) return st;
+    st = runner.Run("decode_mask");
+    if (!st.ok()) return st;
+  }
+
+  std::vector<double> enc_ms, dec_ms;
+  for (int i = 0; i < runs; ++i) {
+    auto t0 = std::chrono::steady_clock::now();
+    st = runner.Run("encode_image");
+    if (!st.ok()) return st;
+    enc_ms.push_back(std::chrono::duration<double, std::milli>(
+                         std::chrono::steady_clock::now() - t0)
+                         .count());
+  }
+  for (int i = 0; i < runs; ++i) {
+    auto t0 = std::chrono::steady_clock::now();
+    st = runner.Run("decode_mask");
+    if (!st.ok()) return st;
+    dec_ms.push_back(std::chrono::duration<double, std::milli>(
+                         std::chrono::steady_clock::now() - t0)
+                         .count());
+  }
+
+  // --- Outputs ---
+  std::vector<float> masks, iou, obj;
+  st = ReadFloats(runner, "decode_mask", "masks", masks);
+  if (!st.ok()) return st;
+  st = ReadFloats(runner, "decode_mask", "iou_scores", iou);
+  if (!st.ok()) return st;
+  st = ReadFloats(runner, "decode_mask", "object_score", obj);
+  if (!st.ok()) return st;
+
+  const int mg = config.mask_grid();
+  const int plane = mg * mg;
+  int best = 0;
+  for (int j = 1; j < 3; ++j) {
+    if (iou[j] > iou[best]) best = j;
+  }
+  auto fg_count = [&](int m) {
+    int fg = 0;
+    for (int i = 0; i < plane; ++i) {
+      if (masks[static_cast<size_t>(m) * plane + i] > 0.0f) ++fg;
+    }
+    return fg;
+  };
+
+  std::cout << absl::StrCat(
+      "SAM2 hiera-tiny · LiteRT Tensor API (",
+      use_gpu ? absl::StrCat("gpu ", absl::GetFlag(FLAGS_gpu_precision))
+              : "cpu fp32",
+      ", ", size, "x", size, ")\n", "enc_median=",
+      absl::StrCat(Median(enc_ms)), "ms  dec_median=",
+      absl::StrCat(Median(dec_ms)), "ms  (runs=", runs, ")\n", "iou_scores=[",
+      iou[0], ", ", iou[1], ", ", iou[2], "]  object_score=", obj[0], "\n",
+      "best mask = [", best, "]: fg=", fg_count(best), "/", plane,
+      "   (mask[0] fg=", fg_count(0), "/", plane, ")\n");
+
+  const std::string dump_dir = absl::GetFlag(FLAGS_dump_dir);
+  if (!dump_dir.empty()) {
+    st = DumpFile(dump_dir, "pixels", pixels);
+    if (!st.ok()) return st;
+    for (const std::string& name :
+         {std::string("image_embeddings"), std::string("feat_s1"),
+          std::string("feat_s0")}) {
+      std::vector<float> data;
+      st = ReadFloats(runner, "encode_image", name, data);
+      if (!st.ok()) return st;
+      st = DumpFile(dump_dir, name, data);
+      if (!st.ok()) return st;
+    }
+    st = DumpFile(dump_dir, "masks", masks);
+    if (!st.ok()) return st;
+    st = DumpFile(dump_dir, "iou_scores", iou);
+    if (!st.ok()) return st;
+    st = DumpFile(dump_dir, "object_score", obj);
+    if (!st.ok()) return st;
+    std::cout << "dumped raw outputs to " << dump_dir << std::endl;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  absl::Status status = Run();
+  if (!status.ok()) {
+    std::cerr << "FAIL: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_main.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_main.cc
@@ -190,16 +190,14 @@ absl::Status Run() {
 
   sam2::EncoderInputs enc_in = sam2::MakeEncoderInputs(config);
   sam2::EncoderOutputs enc_out = sam2::BuildEncoder(config, enc_in, weights);
-  auto enc_rbmm = sam2::TakeRbmmParams();
   sam2::DecoderInputs dec_in = sam2::MakeDecoderInputs(config);
   sam2::DecoderOutputs dec_out = sam2::BuildDecoder(config, dec_in, weights);
-  auto dec_rbmm = sam2::TakeRbmmParams();
 
   ModelFactory factory;
   {
     std::vector<::litert::tensor::TensorHandle> ins, outs;
     for (auto& t : enc_in.AsList()) ins.push_back(t);
-    for (auto& [s, t] : enc_rbmm) ins.push_back(t);
+    for (auto& [s, t] : enc_out.rbmm_params) ins.push_back(t);
     for (auto& t : enc_out.AsList()) outs.push_back(t);
     auto status = factory.AddSignature(ins, outs, "encode_image");
     if (!status.ok()) return status;
@@ -207,7 +205,7 @@ absl::Status Run() {
   {
     std::vector<::litert::tensor::TensorHandle> ins, outs;
     for (auto& t : dec_in.AsList()) ins.push_back(t);
-    for (auto& [s, t] : dec_rbmm) ins.push_back(t);
+    for (auto& [s, t] : dec_out.rbmm_params) ins.push_back(t);
     for (auto& t : dec_out.AsList()) outs.push_back(t);
     auto status = factory.AddSignature(ins, outs, "decode_mask");
     if (!status.ok()) return status;
@@ -221,11 +219,10 @@ absl::Status Run() {
   if (!split_dir.empty()) {
     sam2::EncoderInputs enc_in2 = sam2::MakeEncoderInputs(config);
     sam2::EncoderOutputs enc_out2 = sam2::BuildEncoder(config, enc_in2, weights);
-    auto enc_rbmm2 = sam2::TakeRbmmParams();
     ModelFactory enc_factory;
     std::vector<::litert::tensor::TensorHandle> ins, outs;
     for (auto& t : enc_in2.AsList()) ins.push_back(t);
-    for (auto& [s, t] : enc_rbmm2) ins.push_back(t);
+    for (auto& [s, t] : enc_out2.rbmm_params) ins.push_back(t);
     for (auto& t : enc_out2.AsList()) outs.push_back(t);
     auto st1 = enc_factory.AddSignature(ins, outs, "encode_image");
     if (!st1.ok()) return st1;
@@ -234,12 +231,11 @@ absl::Status Run() {
 
     sam2::DecoderInputs dec_in2 = sam2::MakeDecoderInputs(config);
     sam2::DecoderOutputs dec_out2 = sam2::BuildDecoder(config, dec_in2, weights);
-    auto dec_rbmm2 = sam2::TakeRbmmParams();
     ModelFactory dec_factory;
     ins.clear();
     outs.clear();
     for (auto& t : dec_in2.AsList()) ins.push_back(t);
-    for (auto& [s, t] : dec_rbmm2) ins.push_back(t);
+    for (auto& [s, t] : dec_out2.rbmm_params) ins.push_back(t);
     for (auto& t : dec_out2.AsList()) outs.push_back(t);
     auto st2 = dec_factory.AddSignature(ins, outs, "decode_mask");
     if (!st2.ok()) return st2;
@@ -327,10 +323,8 @@ absl::Status Run() {
   // odml.runtime_bmm control inputs: seven int32 copies of the bound
   // length S per input (the proven attn_bench fill pattern; element 2 is
   // the one the kernels read). Set once — inputs persist across Run().
-  auto set_rbmm_params =
-      [&](const std::string& sig,
-          const std::vector<std::pair<int, sam2::TfTensor>>& params)
-      -> absl::Status {
+  auto set_rbmm_params = [&](const std::string& sig,
+                             const sam2::RbmmParams& params) -> absl::Status {
     for (const auto& [s, t] : params) {
       const std::string name = absl::StrCat("rbmm_s", s);
       auto st = runner.SetInput(
@@ -342,9 +336,9 @@ absl::Status Run() {
     return absl::OkStatus();
   };
   {
-    auto st = set_rbmm_params("encode_image", enc_rbmm);
+    auto st = set_rbmm_params("encode_image", enc_out.rbmm_params);
     if (!st.ok()) return st;
-    st = set_rbmm_params("decode_mask", dec_rbmm);
+    st = set_rbmm_params("decode_mask", dec_out.rbmm_params);
     if (!st.ok()) return st;
   }
 

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.cc
@@ -1,0 +1,67 @@
+// Real-checkpoint weight loading. See sam2_weights.h.
+
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/strings/match.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/str_join.h"  // from @com_google_absl
+#include "tensor/examples/gemma3/safetensor_loader.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::sam2 {
+
+namespace {
+
+// Guard against the gemma3 loader's Gemma-norm +1.0 heuristic silently
+// firing on a future key (none of the current SAM2 keys match it).
+bool LoaderWouldAddGemmaOffset(const std::string& name) {
+  return absl::StrContains(name, "layernorm") ||
+         absl::EndsWith(name, "norm.weight");
+}
+
+}  // namespace
+
+absl::StatusOr<WeightMap> LoadCheckpointWeights(const Sam2Config& config,
+                                                const std::string& path) {
+  auto loader_or = SafetensorLoader::Load(path);
+  if (!loader_or.ok()) return loader_or.status();
+  auto loader = std::move(*loader_or);
+
+  WeightMap weights;
+  for (const WeightSpec& spec : GetWeightSpecs(config)) {
+    if (LoaderWouldAddGemmaOffset(spec.name)) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          spec.name,
+          ": matches the gemma3 loader's norm-offset predicate; a +1.0 "
+          "would corrupt this weight — handle explicitly before loading"));
+    }
+    auto handle_or = loader.LoadTensor(
+        spec.name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
+    if (!handle_or.ok()) {
+      return absl::NotFoundError(absl::StrCat("checkpoint missing ",
+                                              spec.name, ": ",
+                                              handle_or.status().message()));
+    }
+    TfTensor tensor(*handle_or);
+    const auto& loaded_shape = tensor.GetShape();
+    std::vector<int> loaded(loaded_shape.begin(), loaded_shape.end());
+    if (loaded != spec.shape) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          spec.name, ": checkpoint shape [", absl::StrJoin(loaded, ","),
+          "] != expected [", absl::StrJoin(spec.shape, ","), "]"));
+    }
+    tensor.SetName(spec.name);
+    weights[spec.name] = std::move(tensor);
+  }
+  return weights;
+}
+
+}  // namespace litert::tensor::examples::sam2

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.cc
@@ -2,16 +2,21 @@
 
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
-#include "absl/strings/match.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/strings/str_join.h"  // from @com_google_absl
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
 #include "tensor/examples/gemma3/safetensor_loader.h"
+#include "tensor/examples/gemma3/safetensors.h"
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
 #include "tensor/tensor.h"
@@ -20,47 +25,93 @@ namespace litert::tensor::examples::sam2 {
 
 namespace {
 
-// Guard against the gemma3 loader's Gemma-norm +1.0 heuristic silently
-// firing on a future key (none of the current SAM2 keys match it).
-bool LoaderWouldAddGemmaOffset(const std::string& name) {
-  return absl::StrContains(name, "layernorm") ||
-         absl::EndsWith(name, "norm.weight");
+// Reads one stored tensor as host fp32, straight from the mapped file: F32
+// is copied as-is, F16 / BF16 are widened. No other dtype appears in the SAM2
+// exports.
+absl::StatusOr<std::vector<float>> ReadAsFp32(const SafetensorTensorInfo& info) {
+  const TensorStorageInfo* storage = info.storage.get();
+  if (storage == nullptr || storage->data_base == nullptr) {
+    return absl::FailedPreconditionError(
+        absl::StrCat(info.name, ": safetensor storage is invalid"));
+  }
+  if (info.data_end < info.data_start || info.data_end > storage->data_size) {
+    return absl::DataLossError(
+        absl::StrCat(info.name, ": tensor data out of range"));
+  }
+  const std::byte* src = storage->data_base + info.data_start;
+  const size_t bytes = info.data_end - info.data_start;
+  size_t count = 1;
+  for (int64_t d : info.shape) count *= static_cast<size_t>(d);
+
+  std::vector<float> out(count);
+  switch (info.dtype) {
+    case safetensors::dtype::kFLOAT32:
+      if (bytes != count * sizeof(float)) {
+        return absl::DataLossError(
+            absl::StrCat(info.name, ": F32 byte size mismatch"));
+      }
+      std::memcpy(out.data(), src, bytes);
+      break;
+    case safetensors::dtype::kFLOAT16:
+    case safetensors::dtype::kBFLOAT16: {
+      if (bytes != count * sizeof(uint16_t)) {
+        return absl::DataLossError(
+            absl::StrCat(info.name, ": 16-bit byte size mismatch"));
+      }
+      std::vector<uint16_t> raw(count);  // memcpy: offsets need not align
+      std::memcpy(raw.data(), src, bytes);
+      const bool bf16 = info.dtype == safetensors::dtype::kBFLOAT16;
+      for (size_t i = 0; i < count; ++i) {
+        out[i] = bf16 ? safetensors::bfloat16_to_float(raw[i])
+                      : safetensors::fp16_to_float(raw[i]);
+      }
+      break;
+    }
+    default:
+      return absl::InvalidArgumentError(absl::StrCat(
+          info.name, ": dtype ", safetensors::get_dtype_str(info.dtype),
+          " is not a float weight"));
+  }
+  return out;
 }
 
 }  // namespace
 
-absl::StatusOr<WeightMap> LoadCheckpointWeights(const Sam2Config& config,
-                                                const std::string& path) {
+absl::Status LoadWeightSpecs(const std::string& path,
+                             const std::vector<WeightSpec>& specs,
+                             WeightMap& weights) {
   auto loader_or = SafetensorLoader::Load(path);
   if (!loader_or.ok()) return loader_or.status();
   auto loader = std::move(*loader_or);
 
-  WeightMap weights;
-  for (const WeightSpec& spec : GetWeightSpecs(config)) {
-    if (LoaderWouldAddGemmaOffset(spec.name)) {
-      return absl::FailedPreconditionError(absl::StrCat(
-          spec.name,
-          ": matches the gemma3 loader's norm-offset predicate; a +1.0 "
-          "would corrupt this weight — handle explicitly before loading"));
+  for (const WeightSpec& spec : specs) {
+    auto info_or = loader.GetTensorInfo(spec.name);
+    if (!info_or.ok()) {
+      return absl::NotFoundError(absl::StrCat("checkpoint missing ", spec.name,
+                                              ": ", info_or.status().message()));
     }
-    auto handle_or = loader.LoadTensor(
-        spec.name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
-    if (!handle_or.ok()) {
-      return absl::NotFoundError(absl::StrCat("checkpoint missing ",
-                                              spec.name, ": ",
-                                              handle_or.status().message()));
-    }
-    TfTensor tensor(*handle_or);
-    const auto& loaded_shape = tensor.GetShape();
-    std::vector<int> loaded(loaded_shape.begin(), loaded_shape.end());
+    std::vector<int> loaded(info_or->shape.begin(), info_or->shape.end());
     if (loaded != spec.shape) {
       return absl::FailedPreconditionError(absl::StrCat(
           spec.name, ": checkpoint shape [", absl::StrJoin(loaded, ","),
           "] != expected [", absl::StrJoin(spec.shape, ","), "]"));
     }
-    tensor.SetName(spec.name);
-    weights[spec.name] = std::move(tensor);
+    auto values_or = ReadAsFp32(*info_or);
+    if (!values_or.ok()) return values_or.status();
+    weights[spec.name] =
+        TfTensor({.name = spec.name,
+                  .type = Type::kFP32,
+                  .shape = spec.shape,
+                  .buffer = OwningCpuBuffer::Copy<Type::kFP32>(*values_or)});
   }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<WeightMap> LoadCheckpointWeights(const Sam2Config& config,
+                                                const std::string& path) {
+  WeightMap weights;
+  auto status = LoadWeightSpecs(path, GetWeightSpecs(config), weights);
+  if (!status.ok()) return status;
   return weights;
 }
 

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h
@@ -1,0 +1,26 @@
+// Real-checkpoint weight loading for the SAM2 image-path graphs.
+//
+// Loads the 512-baked MLX-naming safetensors set
+// (mlboydaisuke/SAM2-hiera-tiny-LiteRT mlx/sam2_tiny_512.safetensors,
+// fp16 -> fp32; trunk.pos_embed_full already re-composed at the 128x128
+// token grid — the corr-0.9999 fix). Every tensor is shape-checked against
+// GetWeightSpecs. No SAM2 key matches the gemma3 loader's Gemma-norm
+// (+1.0) predicate, so weights load unmodified.
+
+#ifndef MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_WEIGHTS_H_
+#define MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_WEIGHTS_H_
+
+#include <string>
+
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
+
+namespace litert::tensor::examples::sam2 {
+
+absl::StatusOr<WeightMap> LoadCheckpointWeights(const Sam2Config& config,
+                                                const std::string& path);
+
+}  // namespace litert::tensor::examples::sam2
+
+#endif  // MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_WEIGHTS_H_

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h
@@ -4,19 +4,33 @@
 // (mlboydaisuke/SAM2-hiera-tiny-LiteRT mlx/sam2_tiny_512.safetensors,
 // fp16 -> fp32; trunk.pos_embed_full already re-composed at the 128x128
 // token grid — the corr-0.9999 fix). Every tensor is shape-checked against
-// GetWeightSpecs. No SAM2 key matches the gemma3 loader's Gemma-norm
-// (+1.0) predicate, so weights load unmodified.
+// GetWeightSpecs.
+//
+// Tensors are read through SafetensorLoader's file handling and metadata,
+// not through its LoadTensor(): that path adds a Gemma-specific +1.0 to every
+// tensor whose name contains "layernorm" or ends in "norm.weight", and SAM2's
+// norms are plain LayerNorms. Values are taken exactly as stored; no
+// name-based rewriting happens anywhere in this loader.
 
 #ifndef MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_WEIGHTS_H_
 #define MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_IMAGE_SAM2_WEIGHTS_H_
 
 #include <string>
+#include <vector>
 
+#include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
 
 namespace litert::tensor::examples::sam2 {
+
+// Loads every spec from the safetensors file at `path` into `weights` as fp32
+// (F32 copied as stored, F16 / BF16 widened), each shape-checked against its
+// spec. Shared by the image and video loaders.
+absl::Status LoadWeightSpecs(const std::string& path,
+                             const std::vector<WeightSpec>& specs,
+                             WeightMap& weights);
 
 absl::StatusOr<WeightMap> LoadCheckpointWeights(const Sam2Config& config,
                                                 const std::string& path);

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/verify/sam2_torch_ref.py
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/verify/sam2_torch_ref.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""PyTorch parity check for the Tensor API SAM2 image path.
+
+Loads the raw dumps written by `sam2_main --dump_dir`, runs the official
+`facebook/sam2.1-hiera-tiny` (transformers, fp32) on the SAME input at 512
+(prompt-encoder/backbone size attributes adjusted to 512 exactly the way the
+mlx-swift port was verified), and reports correlations.
+
+The bar (set by the MLX port): masks corr >= 0.9999, iou_scores within
+0.002, identical best-mask selection.
+
+Usage:
+    python sam2_torch_ref.py --dump_dir /path/to/dump [--size 512]
+"""
+import argparse
+import sys
+import types
+
+import numpy as np
+
+# macOS: stub scipy's broken propack entry point if present (same guard as
+# tools/make_512_weights.py).
+_svdp = types.ModuleType("scipy.sparse.linalg._svdp")
+_svdp._svdp = lambda *a, **k: None
+sys.modules["scipy.sparse.linalg._svdp"] = _svdp
+
+
+def load(dump_dir, name, shape):
+    data = np.fromfile(f"{dump_dir}/{name}.f32", dtype=np.float32)
+    return data.reshape(shape)
+
+
+def corr(a, b):
+    a = a.flatten().astype(np.float64)
+    b = b.flatten().astype(np.float64)
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dump_dir", required=True)
+    parser.add_argument("--size", type=int, default=512)
+    args = parser.parse_args()
+    size = args.size
+    grid = size // 16   # 32
+    mg = size // 4      # 128
+
+    pixels = load(args.dump_dir, "pixels", (1, size, size, 3))
+    ours_ie = load(args.dump_dir, "image_embeddings", (1, grid, grid, 256))
+    ours_s1 = load(args.dump_dir, "feat_s1", (1, grid * 2, grid * 2, 64))
+    ours_s0 = load(args.dump_dir, "feat_s0", (1, mg, mg, 32))
+    ours_masks = load(args.dump_dir, "masks", (1, 3, mg, mg))
+    ours_iou = load(args.dump_dir, "iou_scores", (1, 3))
+    ours_obj = load(args.dump_dir, "object_score", (1, 1))
+
+    import torch
+    from transformers import Sam2Model
+
+    model = Sam2Model.from_pretrained("facebook/sam2.1-hiera-tiny").eval()
+    # Adjust the size-derived attributes to the 512 run (the vision encoder
+    # and its positional embedding are size-dynamic already).
+    model.prompt_encoder.input_image_size = size
+    model.prompt_encoder.image_embedding_size = (grid, grid)
+    model.backbone_feature_sizes = [[mg, mg], [grid * 2, grid * 2], [grid, grid]]
+
+    chw = torch.from_numpy(pixels.transpose(0, 3, 1, 2)).contiguous()
+
+    with torch.no_grad():
+        feats = model.get_image_embeddings(chw)  # [s0, s1, ie] (no_mem folded)
+    ref_s0, ref_s1, ref_ie = [f.numpy() for f in feats]
+
+    def nhwc(x):
+        return x.transpose(0, 2, 3, 1)
+
+    print(f"encoder image_embeddings corr = {corr(ours_ie, nhwc(ref_ie)):.6f}")
+    print(f"encoder feat_s1          corr = {corr(ours_s1, nhwc(ref_s1)):.6f}")
+    print(f"encoder feat_s0          corr = {corr(ours_s0, nhwc(ref_s0)):.6f}")
+
+    center = float(size // 2)
+    with torch.no_grad():
+        out = model(
+            pixel_values=chw,
+            input_points=torch.tensor([[[[center, center]]]]),
+            input_labels=torch.tensor([[[1]]]),
+            multimask_output=True,
+        )
+    ref_masks = out.pred_masks.numpy().reshape(1, -1, mg, mg)[:, -3:]
+    ref_iou = out.iou_scores.numpy().reshape(1, -1)[:, -3:]
+
+    print(f"masks corr = {corr(ours_masks, ref_masks):.6f}")
+    for i in range(3):
+        m_corr = corr(ours_masks[0, i], ref_masks[0, i])
+        a = ours_masks[0, i] > 0
+        b = ref_masks[0, i] > 0
+        iou_bin = np.logical_and(a, b).sum() / max(np.logical_or(a, b).sum(), 1)
+        print(f"  mask[{i}]: corr={m_corr:.6f} binIoU={iou_bin:.5f} "
+              f"fg_ours={int(a.sum())} fg_ref={int(b.sum())}")
+    print(f"iou_scores ours={np.round(ours_iou[0], 4).tolist()} "
+          f"ref={np.round(ref_iou[0], 4).tolist()} "
+          f"max|diff|={float(np.abs(ours_iou - ref_iou).max()):.5f}")
+    print(f"best mask ours={int(ours_iou[0].argmax())} "
+          f"ref={int(ref_iou[0].argmax())}")
+    if hasattr(out, "object_score_logits") and out.object_score_logits is not None:
+        ref_obj = float(out.object_score_logits.reshape(-1)[0])
+        print(f"object_score ours={float(ours_obj[0, 0]):.4f} ref={ref_obj:.4f}")
+
+    ok = (corr(ours_masks, ref_masks) >= 0.9999
+          and float(np.abs(ours_iou - ref_iou).max()) <= 0.002
+          and int(ours_iou[0].argmax()) == int(ref_iou[0].argmax()))
+    print("PARITY:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/BUILD
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/BUILD
@@ -1,0 +1,87 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(
+    "@litert_archive//litert/build_common:special_rule.bzl",
+    "litert_android_linkopts",
+    "litert_gpu_accelerator_prebuilts",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "sam2v_graph",
+    srcs = ["sam2v_graph.cc"],
+    hdrs = ["sam2v_graph.h"],
+    deps = [
+        "//models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_config",
+        "//models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_graph",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/strings",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+    ],
+)
+
+cc_library(
+    name = "sam2v_weights",
+    srcs = ["sam2v_weights.cc"],
+    hdrs = ["sam2v_weights.h"],
+    deps = [
+        ":sam2v_graph",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor/examples/gemma3:safetensor_loader",
+    ],
+)
+
+cc_binary(
+    name = "sam2v_main",
+    srcs = ["sam2v_main.cc"],
+    copts = ["-DGOOGLE_COMMANDLINEFLAGS_FULL_API=1"] + select({
+        "@litert_archive//litert:android": ["-DABSL_FLAGS_STRIP_NAMES=0"],
+        "//conditions:default": [],
+    }),
+    data = litert_gpu_accelerator_prebuilts(),
+    linkopts = litert_android_linkopts(),
+    deps = [
+        ":sam2v_graph",
+        ":sam2v_weights",
+        "//models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_config",
+        "//models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_graph",
+        "//models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_weights",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@litert_archive//litert/cc:litert_common",
+        "@litert_archive//litert/cc:litert_environment",
+        "@litert_archive//litert/cc:litert_options",
+        "@litert_archive//litert/cc/options:litert_gpu_options",
+        "@litert_archive//tensor",
+        "@litert_archive//tensor:arithmetic",
+        "@litert_archive//tensor:buffer",
+        "@litert_archive//tensor:datatypes",
+        "@litert_archive//tensor/backends/tflite:arithmetic_tflite",
+        "@litert_archive//tensor/backends/tflite:tflite_flatbuffer_conversion",
+        "@litert_archive//tensor/runners/litert:litert_dynamic_runner",
+    ],
+)

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/BUILD
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/BUILD
@@ -45,11 +45,10 @@ cc_library(
     hdrs = ["sam2v_weights.h"],
     deps = [
         ":sam2v_graph",
+        "//models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_weights",
         "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@litert_archive//tensor",
-        "@litert_archive//tensor/examples/gemma3:safetensor_loader",
     ],
 )
 

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.cc
@@ -1,0 +1,540 @@
+// SAM2.1 hiera-tiny video path — graph construction. See sam2v_graph.h.
+
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/log/absl_check.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "tensor/arithmetic.h"
+#include "tensor/buffer.h"
+#include "tensor/datatypes.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::sam2_video {
+
+namespace {
+
+constexpr float kTwoPi = 6.283185307179586f;
+
+TfTensor ConstScalar(float value) {
+  return TfTensor({.type = Type::kFP32,
+                   .shape = {1},
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>({value})});
+}
+
+TfTensor ConstFloats(const std::vector<float>& values,
+                     const std::vector<int>& shape,
+                     const std::string& name = "") {
+  return TfTensor({.name = name,
+                   .type = Type::kFP32,
+                   .shape = shape,
+                   .buffer = OwningCpuBuffer::Copy<Type::kFP32>(values)});
+}
+
+const TfTensor& W(const WeightMap& weights, const std::string& name) {
+  auto it = weights.find(name);
+  ABSL_CHECK(it != weights.end()) << "missing weight: " << name;
+  return it->second;
+}
+
+std::vector<float> HostFloats(const TfTensor& tensor) {
+  auto buffer = tensor.GetBuffer();
+  ABSL_CHECK(buffer.ok()) << "weight has no buffer";
+  auto lock = buffer->Lock();
+  const float* data = reinterpret_cast<const float*>(lock.data());
+  return std::vector<float>(data, data + lock.size() / sizeof(float));
+}
+
+TfTensor PadHW(const TfTensor& x, int top, int bottom, int left, int right) {
+  TfTensor paddings(
+      {.type = Type::kI32,
+       .shape = {4, 2},
+       .buffer = OwningCpuBuffer::Copy<Type::kI32>(
+           {0, 0, top, bottom, left, right, 0, 0})});
+  return Pad(x, paddings);
+}
+
+// Last-axis LayerNorm with weight+bias (covers channels-first LayerNorm2d in
+// NHWC). Raw decomposition, same form the image path verified.
+TfTensor LayerNorm(const TfTensor& x, const TfTensor& weight,
+                   const TfTensor& bias, float eps) {
+  int last = static_cast<int>(x.GetShape().size()) - 1;
+  TfTensor mean = Mean(x, {last}, /*keep_dims=*/true);
+  TfTensor centered = Sub(x, mean);
+  TfTensor var = Mean(Mul(centered, centered), {last}, /*keep_dims=*/true);
+  TfTensor normed = Mul(centered, Rsqrt(Add(var, ConstScalar(eps))));
+  return Add(Mul(normed, weight), bias);
+}
+
+// Rank-4 BNSD attention core (batch dim always kept — the rank-3 form is
+// silently mis-computed by the ML Drift delegate; image-path lesson).
+TfTensor AttentionRaw(const TfTensor& q, const TfTensor& k, const TfTensor& v,
+                      float scale) {
+  TfTensor scores = BatchMatMul(q, k, /*adj_x=*/false, /*adj_y=*/true);
+  scores = Mul(scores, ConstScalar(scale));
+  TfTensor attn = Softmax(scores);
+  return BatchMatMul(attn, v);
+}
+
+// Multi-head attention over [B,N,C] token tensors (raw path only; the video
+// decoder reuses the image decoder's verified shapes).
+TfTensor Mha(const TfTensor& q, const TfTensor& k, const TfTensor& v,
+             int heads) {
+  const auto& qs = q.GetShape();
+  const auto& ks = k.GetShape();
+  int b = qs[0];
+  int nq = qs[1];
+  int nk = ks[1];
+  int c = qs[2];
+  int hd = c / heads;
+  float scale = 1.0f / std::sqrt(static_cast<float>(hd));
+  TfTensor q4 = Transpose(Reshape(q, {b, nq, heads, hd}), {0, 2, 1, 3});
+  TfTensor k4 = Transpose(Reshape(k, {b, nk, heads, hd}), {0, 2, 1, 3});
+  TfTensor v4 = Transpose(Reshape(v, {b, nk, heads, hd}), {0, 2, 1, 3});
+  TfTensor o = Transpose(AttentionRaw(q4, k4, v4, scale), {0, 2, 1, 3});
+  return Reshape(o, {b, nq, c});
+}
+
+TfTensor SamAttention(const TfTensor& q_in, const TfTensor& k_in,
+                      const TfTensor& v_in, const std::string& prefix,
+                      const WeightMap& weights, int heads) {
+  TfTensor q = FullyConnected(q_in, W(weights, prefix + ".q_proj.weight"),
+                              W(weights, prefix + ".q_proj.bias"));
+  TfTensor k = FullyConnected(k_in, W(weights, prefix + ".k_proj.weight"),
+                              W(weights, prefix + ".k_proj.bias"));
+  TfTensor v = FullyConnected(v_in, W(weights, prefix + ".v_proj.weight"),
+                              W(weights, prefix + ".v_proj.bias"));
+  TfTensor out = Mha(q, k, v, heads);
+  return FullyConnected(out, W(weights, prefix + ".out_proj.weight"),
+                        W(weights, prefix + ".out_proj.bias"));
+}
+
+// 3-layer FeedForward (ReLU between layers; optional sigmoid).
+TfTensor SamMlp3(const TfTensor& x, const std::string& prefix,
+                 const WeightMap& weights, bool sigmoid_output) {
+  TfTensor h = FullyConnected(x, W(weights, prefix + ".layers.0.weight"),
+                              W(weights, prefix + ".layers.0.bias"), kActRelu);
+  h = FullyConnected(h, W(weights, prefix + ".layers.1.weight"),
+                     W(weights, prefix + ".layers.1.bias"), kActRelu);
+  h = FullyConnected(h, W(weights, prefix + ".layers.2.weight"),
+                     W(weights, prefix + ".layers.2.bias"));
+  return sigmoid_output ? Logistic(h) : h;
+}
+
+// 2x transposed conv k=2/s=2 (VALID) — the image path's verified form.
+TfTensor Upsample2x(const TfTensor& x, const TfTensor& weight,
+                    const TfTensor& bias, int out_h, int out_w, int out_c) {
+  return TransposeConv(weight, x, bias, {1, out_h, out_w, out_c},
+                       kPaddingValid, 2, 2);
+}
+
+// Dense positional-encoding grid [1, G*G, 256] baked from the prompt
+// encoder's Gaussian matrix (identical math to the image path).
+TfTensor BakeDensePeGrid(const std::vector<float>& gaussian, int grid) {
+  std::vector<float> out(static_cast<size_t>(grid) * grid * 256);
+  for (int y = 0; y < grid; ++y) {
+    for (int x = 0; x < grid; ++x) {
+      float cx = 2.0f * ((x + 0.5f) / grid) - 1.0f;
+      float cy = 2.0f * ((y + 0.5f) / grid) - 1.0f;
+      size_t base = (static_cast<size_t>(y) * grid + x) * 256;
+      for (int i = 0; i < 128; ++i) {
+        float phase = kTwoPi * (cx * gaussian[i] + cy * gaussian[128 + i]);
+        out[base + i] = std::sin(phase);
+        out[base + 128 + i] = std::cos(phase);
+      }
+    }
+  }
+  return ConstFloats(out, {1, grid * grid, 256}, "dense_pe_grid");
+}
+
+// rotate_half on the last axis: [-x[..., d/2:], x[..., :d/2]].
+TfTensor RotateHalf(const TfTensor& x) {
+  const auto& s = x.GetShape();
+  int d = s.back();
+  std::vector<int> begin_hi(s.size(), 0);
+  begin_hi.back() = d / 2;
+  std::vector<int> size_lo(s.begin(), s.end());
+  size_lo.back() = d / 2;
+  std::vector<int> begin_lo(s.size(), 0);
+  TfTensor hi = Slice(x, begin_hi, size_lo);
+  TfTensor lo = Slice(x, begin_lo, size_lo);
+  return Concatenation({Neg(hi), lo},
+                       /*axis=*/static_cast<int>(s.size()) - 1);
+}
+
+// Rotate-half RoPE against tables broadcast over leading dims.
+TfTensor Rope(const TfTensor& x, const TfTensor& cos, const TfTensor& sin) {
+  return Add(Mul(x, cos), Mul(RotateHalf(x), sin));
+}
+
+}  // namespace
+
+MemCondInputs MakeMemCondInputs(const Sam2VideoConfig& config, int nmm) {
+  const int hw = config.hw();
+  const int g = config.image.embed_grid();
+  MemCondInputs in;
+  in.pix_raw = TfTensor({.name = "pix_raw",
+                         .type = Type::kFP32,
+                         .shape = {1, g, g, config.hidden}});
+  in.mem_bank = TfTensor({.name = "mem_bank",
+                          .type = Type::kFP32,
+                          .shape = {1, nmm, hw, config.mem_ch}});
+  in.slot_tpe = TfTensor({.name = "slot_tpe",
+                          .type = Type::kFP32,
+                          .shape = {1, nmm, 1, config.mem_ch}});
+  in.ptr_tok = TfTensor({.name = "ptr_tok",
+                         .type = Type::kFP32,
+                         .shape = {1, 1, config.n_ptr(), config.mem_ch}});
+  in.ptr_pos = TfTensor({.name = "ptr_pos",
+                         .type = Type::kFP32,
+                         .shape = {1, 1, config.n_ptr(), config.mem_ch}});
+  in.key_mask = TfTensor({.name = "key_mask",
+                          .type = Type::kFP32,
+                          .shape = {1, 1, 1, config.mem_len(nmm)}});
+  return in;
+}
+
+VideoDecoderInputs MakeVideoDecoderInputs(const Sam2VideoConfig& config) {
+  const int g = config.image.embed_grid();
+  const int mg = config.image.mask_grid();
+  VideoDecoderInputs in;
+  in.pix_feat = TfTensor({.name = "pix_feat_in",
+                          .type = Type::kFP32,
+                          .shape = {1, g, g, config.hidden}});
+  in.feat_s1 = TfTensor({.name = "feat_s1",
+                         .type = Type::kFP32,
+                         .shape = {1, mg / 2, mg / 2, 64}});
+  in.feat_s0 = TfTensor(
+      {.name = "feat_s0", .type = Type::kFP32, .shape = {1, mg, mg, 32}});
+  in.sparse = TfTensor(
+      {.name = "sparse", .type = Type::kFP32, .shape = {1, 2, config.hidden}});
+  in.nomem = TfTensor(
+      {.name = "nomem", .type = Type::kFP32, .shape = {1, 1, 1, 1}});
+  return in;
+}
+
+MemorizeInputs MakeMemorizeInputs(const Sam2VideoConfig& config) {
+  const int g = config.image.embed_grid();
+  const int s = config.image.image_size;
+  MemorizeInputs in;
+  in.pix_raw = TfTensor({.name = "pix_raw",
+                         .type = Type::kFP32,
+                         .shape = {1, g, g, config.hidden}});
+  in.mask_for_mem = TfTensor({.name = "mask_for_mem",
+                              .type = Type::kFP32,
+                              .shape = {1, s, s, 1}});
+  in.occ = TfTensor({.name = "occ", .type = Type::kFP32, .shape = {1, 1, 1}});
+  return in;
+}
+
+TfTensor BuildMemCond(const Sam2VideoConfig& config, int nmm,
+                      const MemCondInputs& inputs, const WeightMap& weights) {
+  const int hw = config.hw();
+  const int hd = config.hidden;
+  const int mc = config.mem_ch;
+  const int np = config.n_ptr();
+  const int len = config.mem_len(nmm);
+  const float scale = 1.0f / std::sqrt(static_cast<float>(hd));
+  const float eps = config.ln_eps;
+
+  // Baked tables (per-resolution constants from the export).
+  TfTensor cos = ConstFloats(HostFloats(W(weights, "tables.rope_cos")),
+                             {1, 1, hw, hd}, "rope_cos");
+  TfTensor sin = ConstFloats(HostFloats(W(weights, "tables.rope_sin")),
+                             {1, 1, hw, hd}, "rope_sin");
+  TfTensor vpos = ConstFloats(HostFloats(W(weights, "tables.vision_pos_scaled")),
+                              {1, 1, hw, hd}, "vision_pos_scaled");
+  TfTensor mem_pos = ConstFloats(HostFloats(W(weights, "tables.mem_pos")),
+                                 {1, 1, hw, mc}, "mem_pos");
+
+  // Queries: raw features to token-major + 0.1 * vision position encoding.
+  TfTensor x = Add(Reshape(inputs.pix_raw, {1, 1, hw, hd}), vpos);
+
+  // Memory tokens and their position rows.
+  TfTensor spatial = Reshape(inputs.mem_bank, {1, 1, nmm * hw, mc});
+  TfTensor memory = Concatenation({spatial, inputs.ptr_tok}, /*axis=*/2);
+  TfTensor spatial_pos = Add(mem_pos, inputs.slot_tpe);  // [1,nmm,hw,mc]
+  TfTensor keys_pos = Concatenation(
+      {Reshape(spatial_pos, {1, 1, nmm * hw, mc}), inputs.ptr_pos},
+      /*axis=*/2);
+  TfTensor keys_in = Add(memory, keys_pos);
+
+  for (int l = 0; l < config.ma_layers; ++l) {
+    const std::string p = absl::StrCat("memory_attention.layers.", l);
+    // --- self attention (RoPE on q and k) ---
+    TfTensor h = LayerNorm(x, W(weights, p + ".norm1.weight"),
+                           W(weights, p + ".norm1.bias"), eps);
+    TfTensor q = Rope(FullyConnected(h, W(weights, p + ".self_attn.q_proj.weight"),
+                                     W(weights, p + ".self_attn.q_proj.bias")),
+                      cos, sin);
+    TfTensor k = Rope(FullyConnected(h, W(weights, p + ".self_attn.k_proj.weight"),
+                                     W(weights, p + ".self_attn.k_proj.bias")),
+                      cos, sin);
+    TfTensor v = FullyConnected(h, W(weights, p + ".self_attn.v_proj.weight"),
+                                W(weights, p + ".self_attn.v_proj.bias"));
+    TfTensor sa = AttentionRaw(q, k, v, scale);
+    sa = FullyConnected(sa, W(weights, p + ".self_attn.out_proj.weight"),
+                        W(weights, p + ".self_attn.out_proj.bias"));
+    x = Add(x, sa);
+
+    // --- cross attention to the memory (RoPE on q and spatial k only) ---
+    h = LayerNorm(x, W(weights, p + ".norm2.weight"),
+                  W(weights, p + ".norm2.bias"), eps);
+    q = Rope(FullyConnected(h, W(weights, p + ".cross_attn_image.q_proj.weight"),
+                            W(weights, p + ".cross_attn_image.q_proj.bias")),
+             cos, sin);
+    k = FullyConnected(keys_in,
+                       W(weights, p + ".cross_attn_image.k_proj.weight"),
+                       W(weights, p + ".cross_attn_image.k_proj.bias"));
+    TfTensor k_sp = Reshape(Slice(k, {0, 0, 0, 0}, {1, 1, nmm * hw, hd}),
+                            {1, nmm, hw, hd});
+    k_sp = Reshape(Rope(k_sp, cos, sin), {1, 1, nmm * hw, hd});
+    TfTensor k_ptr = Slice(k, {0, 0, nmm * hw, 0}, {1, 1, np, hd});
+    k = Concatenation({k_sp, k_ptr}, /*axis=*/2);
+    v = FullyConnected(memory, W(weights, p + ".cross_attn_image.v_proj.weight"),
+                       W(weights, p + ".cross_attn_image.v_proj.bias"));
+    TfTensor scores = BatchMatMul(q, k, /*adj_x=*/false, /*adj_y=*/true);
+    scores = Add(Mul(scores, ConstScalar(scale)), inputs.key_mask);
+    TfTensor ca = BatchMatMul(Softmax(scores), v);
+    ca = FullyConnected(ca, W(weights, p + ".cross_attn_image.out_proj.weight"),
+                        W(weights, p + ".cross_attn_image.out_proj.bias"));
+    x = Add(x, ca);
+
+    // --- MLP (ReLU) ---
+    h = LayerNorm(x, W(weights, p + ".norm3.weight"),
+                  W(weights, p + ".norm3.bias"), eps);
+    h = FullyConnected(h, W(weights, p + ".linear1.weight"),
+                       W(weights, p + ".linear1.bias"), kActRelu);
+    h = FullyConnected(h, W(weights, p + ".linear2.weight"),
+                       W(weights, p + ".linear2.bias"));
+    x = Add(x, h);
+    (void)len;
+  }
+  x = LayerNorm(x, W(weights, "memory_attention.norm.weight"),
+                W(weights, "memory_attention.norm.bias"), eps);
+  const int g = config.image.embed_grid();
+  TfTensor out = Reshape(x, {1, g, g, hd});
+  out.SetName("pix_feat");
+  return out;
+}
+
+VideoDecoderOutputs BuildVideoDecoder(const Sam2VideoConfig& config,
+                                      const VideoDecoderInputs& inputs,
+                                      const WeightMap& weights) {
+  const Sam2Config& img = config.image;
+  const int eg = img.embed_grid();
+  const int mg = img.mask_grid();
+  const int n_img = eg * eg;
+  const float eps = img.ln_eps_decoder;
+  const std::string dec = "sam_mask_decoder";
+  const std::string tr = dec + ".transformer";
+
+  // pix_feat + nomem * no_mem_embed (the conditioning-frame path).
+  TfTensor no_mem = ConstFloats(HostFloats(W(weights, "no_mem_embed")),
+                                {1, 1, 1, img.d_model}, "no_mem_row");
+  TfTensor pix = Add(inputs.pix_feat, Mul(no_mem, inputs.nomem));
+
+  // Tokens: [obj_score | iou | mask x4 | sparse x2].
+  std::vector<float> token_data;
+  for (const char* name :
+       {"sam_mask_decoder.obj_score_token.weight",
+        "sam_mask_decoder.iou_token.weight",
+        "sam_mask_decoder.mask_tokens.weight"}) {
+    std::vector<float> rows = HostFloats(W(weights, name));
+    token_data.insert(token_data.end(), rows.begin(), rows.end());
+  }
+  TfTensor output_tokens =
+      ConstFloats(token_data, {1, 6, img.d_model}, "output_tokens");
+  TfTensor tokens = Concatenation({output_tokens, inputs.sparse}, /*axis=*/1);
+
+  // Image side: += no-mask dense prompt row; flatten; baked dense PE.
+  std::vector<float> gaussian = HostFloats(W(
+      weights, "sam_prompt_encoder.pe_layer.positional_encoding_gaussian_matrix"));
+  std::vector<float> no_mask =
+      HostFloats(W(weights, "sam_prompt_encoder.no_mask_embed.weight"));
+  TfTensor src = Add(pix, ConstFloats(no_mask, {1, 1, 1, img.d_model},
+                                      "no_mask_dense"));
+  TfTensor keys = Reshape(src, {1, n_img, img.d_model});
+  TfTensor kpe = BakeDensePeGrid(gaussian, eg);
+
+  // Two-way transformer (2 blocks + final token->image attention) — the
+  // image path's verified construction, on 8 tokens.
+  TfTensor queries = tokens;
+  const TfTensor& qpe = tokens;
+  for (int l = 0; l < 2; ++l) {
+    std::string p = absl::StrCat(tr, ".layers.", l);
+    if (l == 0) {
+      queries = SamAttention(queries, queries, queries, p + ".self_attn",
+                             weights, 8);
+    } else {
+      TfTensor q = Add(queries, qpe);
+      queries = Add(queries,
+                    SamAttention(q, q, queries, p + ".self_attn", weights, 8));
+    }
+    queries = LayerNorm(queries, W(weights, p + ".norm1.weight"),
+                        W(weights, p + ".norm1.bias"), eps);
+
+    TfTensor q = Add(queries, qpe);
+    TfTensor k = Add(keys, kpe);
+    queries = Add(queries, SamAttention(q, k, keys,
+                                        p + ".cross_attn_token_to_image",
+                                        weights, 8));
+    queries = LayerNorm(queries, W(weights, p + ".norm2.weight"),
+                        W(weights, p + ".norm2.bias"), eps);
+
+    TfTensor m = FullyConnected(queries, W(weights, p + ".mlp.layers.0.weight"),
+                                W(weights, p + ".mlp.layers.0.bias"), kActRelu);
+    m = FullyConnected(m, W(weights, p + ".mlp.layers.1.weight"),
+                       W(weights, p + ".mlp.layers.1.bias"));
+    queries = LayerNorm(Add(queries, m), W(weights, p + ".norm3.weight"),
+                        W(weights, p + ".norm3.bias"), eps);
+
+    q = Add(queries, qpe);
+    k = Add(keys, kpe);
+    keys = Add(keys, SamAttention(k, q, queries,
+                                  p + ".cross_attn_image_to_token", weights,
+                                  8));
+    keys = LayerNorm(keys, W(weights, p + ".norm4.weight"),
+                     W(weights, p + ".norm4.bias"), eps);
+  }
+  TfTensor q_final = Add(queries, qpe);
+  TfTensor k_final = Add(keys, kpe);
+  queries = Add(queries, SamAttention(q_final, k_final, keys,
+                                      tr + ".final_attn_token_to_image",
+                                      weights, 8));
+  queries = LayerNorm(queries, W(weights, tr + ".norm_final_attn.weight"),
+                      W(weights, tr + ".norm_final_attn.bias"), eps);
+
+  // Mask upscaling with the high-res skips.
+  TfTensor src_img = Reshape(keys, {1, eg, eg, img.d_model});
+  TfTensor up = Upsample2x(src_img, W(weights, dec + ".output_upscaling_0.weight"),
+                           W(weights, dec + ".output_upscaling_0.bias"),
+                           2 * eg, 2 * eg, 64);
+  up = Add(up, inputs.feat_s1);
+  up = LayerNorm(up, W(weights, dec + ".output_upscaling_1.weight"),
+                 W(weights, dec + ".output_upscaling_1.bias"), img.ln_eps_2d);
+  up = Gelu(up);
+  up = Upsample2x(up, W(weights, dec + ".output_upscaling_3.weight"),
+                  W(weights, dec + ".output_upscaling_3.bias"), mg, mg, 32);
+  up = Add(up, inputs.feat_s0);
+  up = Gelu(up);  // [1, mg, mg, 32]
+
+  // Heads: ALL four mask tokens (host picks argmax iou over 1..3).
+  TfTensor obj_tok = Slice(queries, {0, 0, 0}, {1, 1, img.d_model});
+  TfTensor iou_tok = Slice(queries, {0, 1, 0}, {1, 1, img.d_model});
+  TfTensor mask_toks = Slice(queries, {0, 2, 0}, {1, 4, img.d_model});
+  std::vector<TfTensor> hyper;
+  for (int i = 0; i < 4; ++i) {
+    TfTensor tok = Slice(mask_toks, {0, i, 0}, {1, 1, img.d_model});
+    hyper.push_back(SamMlp3(
+        tok, absl::StrCat(dec, ".output_hypernetworks_mlps.", i), weights,
+        /*sigmoid_output=*/false));  // [1,1,32]
+  }
+  TfTensor hyper_all = Concatenation({hyper[0], hyper[1], hyper[2], hyper[3]},
+                                     /*axis=*/1);  // [1,4,32]
+  TfTensor up_flat = Reshape(up, {1, mg * mg, 32});
+  TfTensor masks = BatchMatMul(hyper_all, up_flat, /*adj_x=*/false,
+                               /*adj_y=*/true);  // [1,4,mg*mg]
+
+  VideoDecoderOutputs out;
+  out.masks = Reshape(masks, {1, 4, mg, mg});
+  out.masks.SetName("masks");
+  TfTensor iou4 = SamMlp3(iou_tok, dec + ".iou_prediction_head", weights,
+                          /*sigmoid_output=*/true);  // [1,1,4]
+  out.iou_scores = Reshape(iou4, {1, 4});
+  out.iou_scores.SetName("iou_scores");
+  out.obj_ptr = SamMlp3(mask_toks, "obj_ptr_proj", weights,
+                        /*sigmoid_output=*/false);  // [1,4,256]
+  out.obj_ptr.SetName("obj_ptr");
+  TfTensor obj = SamMlp3(obj_tok, dec + ".pred_obj_score_head", weights,
+                         /*sigmoid_output=*/false);
+  out.object_score = Reshape(obj, {1, 1});
+  out.object_score.SetName("object_score");
+  return out;
+}
+
+TfTensor BuildMemorize(const Sam2VideoConfig& config,
+                       const MemorizeInputs& inputs, const WeightMap& weights) {
+  const int g = config.image.embed_grid();
+  const int hw = config.hw();
+  const float eps = config.ln_eps_2d;
+  const std::string me = "memory_encoder";
+
+  // Mask downsampler: 4x [pad1 + conv k3/s2 VALID + LN + GELU] (torch p=1
+  // stride-2 sampling grid; TFLite SAME would shift it), then 1x1.
+  TfTensor m = inputs.mask_for_mem;
+  for (int i = 0; i < 4; ++i) {
+    m = Conv2D(PadHW(m, 1, 1, 1, 1),
+               W(weights, absl::StrCat(me, ".mask_downsampler.conv", i,
+                                       ".weight")),
+               W(weights, absl::StrCat(me, ".mask_downsampler.conv", i,
+                                       ".bias")),
+               /*stride_h=*/2, /*stride_w=*/2, kPaddingValid);
+    m = LayerNorm(m,
+                  W(weights, absl::StrCat(me, ".mask_downsampler.norm", i,
+                                          ".weight")),
+                  W(weights, absl::StrCat(me, ".mask_downsampler.norm", i,
+                                          ".bias")),
+                  eps);
+    m = Gelu(m);
+  }
+  m = Conv2D(m, W(weights, me + ".mask_downsampler.conv4.weight"),
+             W(weights, me + ".mask_downsampler.conv4.bias"), 1, 1,
+             kPaddingValid);
+
+  // Fuse with the projected pixel features.
+  TfTensor f = Conv2D(inputs.pix_raw, W(weights, me + ".pix_feat_proj.weight"),
+                      W(weights, me + ".pix_feat_proj.bias"), 1, 1,
+                      kPaddingValid);
+  f = Add(f, m);
+
+  // 2 ConvNeXt fuser blocks: depthwise 7x7 (pad3 + VALID), LN, pw1, GELU,
+  // pw2, gamma scale, residual. Depthwise filter repacked to [1,7,7,C].
+  for (int i = 0; i < 2; ++i) {
+    const std::string p = absl::StrCat(me, ".fuser.", i);
+    std::vector<float> dw = HostFloats(W(weights, p + ".dwconv.weight"));
+    const auto& ds = W(weights, p + ".dwconv.weight").GetShape();  // [C,7,7,1]
+    const int ch = ds[0];
+    const int kh = ds[1];
+    const int kw = ds[2];
+    std::vector<float> dwt(dw.size());
+    for (int c = 0; c < ch; ++c) {
+      for (int y = 0; y < kh; ++y) {
+        for (int xx = 0; xx < kw; ++xx) {
+          dwt[(static_cast<size_t>(y) * kw + xx) * ch + c] =
+              dw[(static_cast<size_t>(c) * kh + y) * kw + xx];
+        }
+      }
+    }
+    TfTensor t = DepthwiseConv2D(
+        PadHW(f, 3, 3, 3, 3),
+        ConstFloats(dwt, {1, kh, kw, ch}, p + ".dwconv.repacked"),
+        W(weights, p + ".dwconv.bias"), 1, 1, kPaddingValid);
+    t = LayerNorm(t, W(weights, p + ".norm.weight"),
+                  W(weights, p + ".norm.bias"), eps);
+    t = FullyConnected(t, W(weights, p + ".pwconv1.weight"),
+                       W(weights, p + ".pwconv1.bias"));
+    t = Gelu(t);
+    t = FullyConnected(t, W(weights, p + ".pwconv2.weight"),
+                       W(weights, p + ".pwconv2.bias"));
+    t = Mul(t, W(weights, p + ".gamma"));
+    f = Add(f, t);
+  }
+  f = Conv2D(f, W(weights, me + ".out_proj.weight"),
+             W(weights, me + ".out_proj.bias"), 1, 1, kPaddingValid);
+  (void)g;
+
+  // Token-major + occ * occlusion embedding.
+  TfTensor mem = Reshape(f, {1, hw, config.mem_ch});
+  TfTensor no_obj = ConstFloats(HostFloats(W(weights, "no_obj_embed_spatial")),
+                                {1, 1, config.mem_ch}, "no_obj_embed_row");
+  mem = Add(mem, Mul(no_obj, inputs.occ));
+  mem.SetName("mem");
+  return mem;
+}
+
+}  // namespace litert::tensor::examples::sam2_video

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.cc
@@ -493,27 +493,14 @@ TfTensor BuildMemorize(const Sam2VideoConfig& config,
   f = Add(f, m);
 
   // 2 ConvNeXt fuser blocks: depthwise 7x7 (pad3 + VALID), LN, pw1, GELU,
-  // pw2, gamma scale, residual. Depthwise filter repacked to [1,7,7,C].
+  // pw2, gamma scale, residual. The depthwise filter is exported in the
+  // TFLite [1,7,7,C] layout, like every other conv filter.
   for (int i = 0; i < 2; ++i) {
     const std::string p = absl::StrCat(me, ".fuser.", i);
-    std::vector<float> dw = HostFloats(W(weights, p + ".dwconv.weight"));
-    const auto& ds = W(weights, p + ".dwconv.weight").GetShape();  // [C,7,7,1]
-    const int ch = ds[0];
-    const int kh = ds[1];
-    const int kw = ds[2];
-    std::vector<float> dwt(dw.size());
-    for (int c = 0; c < ch; ++c) {
-      for (int y = 0; y < kh; ++y) {
-        for (int xx = 0; xx < kw; ++xx) {
-          dwt[(static_cast<size_t>(y) * kw + xx) * ch + c] =
-              dw[(static_cast<size_t>(c) * kh + y) * kw + xx];
-        }
-      }
-    }
-    TfTensor t = DepthwiseConv2D(
-        PadHW(f, 3, 3, 3, 3),
-        ConstFloats(dwt, {1, kh, kw, ch}, p + ".dwconv.repacked"),
-        W(weights, p + ".dwconv.bias"), 1, 1, kPaddingValid);
+    TfTensor t = DepthwiseConv2D(PadHW(f, 3, 3, 3, 3),
+                                 W(weights, p + ".dwconv.weight"),
+                                 W(weights, p + ".dwconv.bias"), 1, 1,
+                                 kPaddingValid);
     t = LayerNorm(t, W(weights, p + ".norm.weight"),
                   W(weights, p + ".norm.bias"), eps);
     t = FullyConnected(t, W(weights, p + ".pwconv1.weight"),

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h
@@ -1,0 +1,124 @@
+// SAM2.1 hiera-tiny VIDEO tracking path authored on the C++ Tensor API.
+//
+// Adds the three per-frame memory graphs of the SAM2 tracking loop to the
+// image-path encoder (reused from ../sam2_image at image_size=1024 with a
+// zeroed no_mem_embed, so its output IS the raw top-level feature map):
+//
+//   memcond{N}: memory attention over a FIXED bank of N spatial memory
+//     slots (4096 tokens x 64ch each) + 64 object-pointer tokens. Unused
+//     slots/pointers are masked with an additive key mask, which matches
+//     the reference's variable-length bank exactly. Single-head 256-dim
+//     rank-4 attention; rotate-half RoPE with the head-dim permutation
+//     baked into the checkpoint's q/k projections at export time.
+//   decode: the video mask decoder — sparse prompt as an INPUT (2x256:
+//     click row + pad, or the baked tracking row), a nomem scalar input
+//     that adds the no-memory embedding on the conditioning frame, ALL
+//     four mask tokens emitted plus iou (4, sigmoid), object pointers
+//     (4x256) and the object score. The host picks argmax iou over 1..3.
+//   memorize: the memory encoder — mask downsampler (4x stride-2 convs,
+//     torch padding = explicit pad + VALID), feature projection, 2
+//     ConvNeXt fuser blocks (depthwise 7x7), 1x1 projection to 64ch,
+//     plus occ * the occlusion embedding. Output token-major [1,4096,64].
+//
+// Layouts are NHWC / token-major end to end. The memory bank, temporal
+// position rows, pointer tokens/positions and key mask are per-frame host
+// inputs (the reference pipeline's contract); the chained-state variants
+// (in-graph DynamicUpdateSlice / odml.cache_update at a runtime slot) are
+// built on top of the same graphs.
+
+#ifndef MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_VIDEO_SAM2V_GRAPH_H_
+#define MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_VIDEO_SAM2V_GRAPH_H_
+
+#include <string>
+#include <vector>
+
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
+
+namespace litert::tensor::examples::sam2_video {
+
+using ::litert::tensor::examples::sam2::Sam2Config;
+using ::litert::tensor::examples::sam2::TfTensor;
+using ::litert::tensor::examples::sam2::WeightMap;
+
+struct Sam2VideoConfig {
+  Sam2Config image;  // image_size = 1024 for the video pipeline
+  int mem_ch = 64;   // memory channel dim
+  int hidden = 256;  // memory-attention hidden (single head)
+  int ma_layers = 4;
+  int ff_hidden = 2048;
+  int num_ptr_frames = 16;  // object-pointer frames
+  int ptr_split = 4;        // 256-dim pointer -> 4 tokens of 64
+  float ln_eps = 1e-5f;     // torch nn.LayerNorm default (memory attention)
+  float ln_eps_2d = 1e-6f;  // Sam2VideoLayerNorm (memory encoder)
+  float mask_neg = -1e9f;   // additive key-mask fill for unused slots
+
+  Sam2VideoConfig() { image.image_size = 1024; }
+
+  int hw() const {  // top-level token count (64x64 at 1024)
+    int g = image.embed_grid();
+    return g * g;
+  }
+  int n_ptr() const { return num_ptr_frames * ptr_split; }  // 64
+  int mem_len(int nmm) const { return nmm * hw() + n_ptr(); }
+};
+
+struct MemCondInputs {
+  TfTensor pix_raw;   // [1, G, G, 256] raw top-level features (NHWC)
+  TfTensor mem_bank;  // [1, N, HW, 64] spatial memories, token-major
+  TfTensor slot_tpe;  // [1, N, 1, 64] temporal position row per slot
+  TfTensor ptr_tok;   // [1, 1, 64, 64] object-pointer tokens
+  TfTensor ptr_pos;   // [1, 1, 64, 64] pointer temporal positions
+  TfTensor key_mask;  // [1, 1, 1, N*HW+64] additive (0 / mask_neg)
+  std::vector<TfTensor> AsList() const {
+    return {pix_raw, mem_bank, slot_tpe, ptr_tok, ptr_pos, key_mask};
+  }
+};
+
+struct VideoDecoderInputs {
+  TfTensor pix_feat;  // [1, G, G, 256] (memcond output, or pix_raw + nomem)
+  TfTensor feat_s1;   // [1, 4G, 4G ... see image spec] high-res skip 1
+  TfTensor feat_s0;   // high-res skip 0
+  TfTensor sparse;    // [1, 2, 256] sparse prompt rows
+  TfTensor nomem;     // [1, 1, 1, 1] 1.0 on the conditioning frame else 0.0
+  std::vector<TfTensor> AsList() const {
+    return {pix_feat, feat_s1, feat_s0, sparse, nomem};
+  }
+};
+
+struct VideoDecoderOutputs {
+  TfTensor masks;         // [1, 4, S/4, S/4] all mask tokens' logits
+  TfTensor iou_scores;    // [1, 4] (sigmoid)
+  TfTensor obj_ptr;       // [1, 4, 256] object pointer per mask token
+  TfTensor object_score;  // [1, 1]
+  std::vector<TfTensor> AsList() const {
+    return {masks, iou_scores, obj_ptr, object_score};
+  }
+};
+
+struct MemorizeInputs {
+  TfTensor pix_raw;       // [1, G, G, 256]
+  TfTensor mask_for_mem;  // [1, S, S, 1] sigmoid(hi-res)*20-10 (host-built)
+  TfTensor occ;           // [1, 1, 1] 1 - is_obj_appearing
+  std::vector<TfTensor> AsList() const {
+    return {pix_raw, mask_for_mem, occ};
+  }
+};
+
+MemCondInputs MakeMemCondInputs(const Sam2VideoConfig& config, int nmm);
+VideoDecoderInputs MakeVideoDecoderInputs(const Sam2VideoConfig& config);
+MemorizeInputs MakeMemorizeInputs(const Sam2VideoConfig& config);
+
+// pix_feat [1, G, G, 256] token-major output, named "pix_feat".
+TfTensor BuildMemCond(const Sam2VideoConfig& config, int nmm,
+                      const MemCondInputs& inputs, const WeightMap& weights);
+VideoDecoderOutputs BuildVideoDecoder(const Sam2VideoConfig& config,
+                                      const VideoDecoderInputs& inputs,
+                                      const WeightMap& weights);
+// mem [1, 4096, 64] token-major output, named "mem".
+TfTensor BuildMemorize(const Sam2VideoConfig& config,
+                       const MemorizeInputs& inputs, const WeightMap& weights);
+
+}  // namespace litert::tensor::examples::sam2_video
+
+#endif  // MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_VIDEO_SAM2V_GRAPH_H_

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h
@@ -1,8 +1,8 @@
 // SAM2.1 hiera-tiny VIDEO tracking path authored on the C++ Tensor API.
 //
 // Adds the three per-frame memory graphs of the SAM2 tracking loop to the
-// image-path encoder (reused from ../sam2_image at image_size=1024 with a
-// zeroed no_mem_embed, so its output IS the raw top-level feature map):
+// image-path encoder (reused from ../sam2_image at image_size=1024 with
+// fold_no_mem_embed cleared, so its output IS the raw top-level feature map):
 //
 //   memcond{N}: memory attention over a FIXED bank of N spatial memory
 //     slots (4096 tokens x 64ch each) + 64 object-pointer tokens. Unused

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_main.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_main.cc
@@ -1,0 +1,668 @@
+// SAM2.1 hiera-tiny video tracking — build, serialize, run the host loop,
+// verify, bench.
+//
+// Usage (from the LiteRT repo root; GPU runs need cwd =
+// litert/prebuilt/macos_arm64 so the Metal accelerator dylib resolves):
+//   bazel build --config=macos_arm64 //models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video:sam2v_main
+//   sam2v_main --weights=.../sam2_tiny_1024_video.safetensors \
+//     --frames_file=frames.f32 --frames=10 --dump_dir=out \
+//     [--accelerator=gpu --gpu_precision=fp16 --gpu_buffer_storage=buffer]
+//
+// The host loop is the numpy specification in verify/verify_video_1024.py
+// (`track`): per frame it only calls the four graphs and does the bank
+// bookkeeping, best-mask pick, no-object handling and the mask_for_mem
+// construction. --dump_dir writes per-frame outputs for the parity check
+// against the HF streaming reference.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "tensor/backends/tflite/tflite_flatbuffer_conversion.h"
+#include "tensor/datatypes.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_config.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_graph.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h"
+#include "tensor/runners/litert/litert_dynamic_runner.h"
+#include "tensor/tensor.h"
+
+ABSL_FLAG(std::string, weights, "",
+          "sam2_tiny_1024_video.safetensors path (empty = synthetic weights "
+          "for a shape/route check)");
+ABSL_FLAG(std::string, tflite_path, "/tmp/sam2_video.tflite",
+          "Where to write the serialized five-signature model");
+ABSL_FLAG(std::string, accelerator, "cpu", "cpu|gpu");
+ABSL_FLAG(std::string, gpu_precision, "fp16",
+          "fp16|fp32 — GPU calculation precision (fp16 is the delegate "
+          "default; fp32 for CPU-parity verification)");
+ABSL_FLAG(std::string, gpu_buffer_storage, "default",
+          "default|buffer|texture2d");
+ABSL_FLAG(int, nmm, 7, "Memory-bank slots used by the loop (7 or 2)");
+ABSL_FLAG(int, frames, 10, "Frames to track");
+ABSL_FLAG(std::string, frames_file, "",
+          "Raw fp32 NHWC [T,1024,1024,3] ImageNet-normalized clip (empty = "
+          "the synthetic white-disk clip is required for parity; a static "
+          "circle fixture is used as fallback for bench-only runs)");
+ABSL_FLAG(double, click_x, 400.0, "Frame-0 click x in image space");
+ABSL_FLAG(double, click_y, 512.0, "Frame-0 click y in image space");
+ABSL_FLAG(std::string, dump_dir, "",
+          "If set, write per-frame mask/obj/ptr/mem/pix_feat raw fp32");
+ABSL_FLAG(int, bench_loops, 1,
+          "Repeat the whole clip N times and report warm per-stage medians "
+          "(first pass excluded when N > 1)");
+
+namespace {
+
+using ::litert::tensor::Create;
+using ::litert::tensor::LitertDynamicRunner;
+using ::litert::tensor::ModelFactory;
+using ::litert::tensor::Type;
+namespace sam2 = ::litert::tensor::examples::sam2;
+namespace s2v = ::litert::tensor::examples::sam2_video;
+
+constexpr int kSize = 1024;
+constexpr int kGrid = 64;                 // top-level feature grid
+constexpr int kHw = kGrid * kGrid;        // 4096
+constexpr int kHidden = 256;
+constexpr int kMemCh = 64;
+constexpr int kMaskGrid = 256;            // low-res mask side
+constexpr int kPlane = kMaskGrid * kMaskGrid;
+constexpr int kNptrFrames = 16;
+constexpr int kPtrSplit = 4;
+constexpr int kNptr = kNptrFrames * kPtrSplit;  // 64
+// Additive key-mask fill. -30000 is fp16-safe on the Metal delegate (the
+// reference uses -1e9, which overflows fp16); for softmax both give exactly
+// zero weight in fp32, so parity is unaffected.
+constexpr float kMaskNeg = -30000.0f;
+constexpr float kNoObjScore = -1024.0f;
+constexpr float kMemScale = 20.0f;
+constexpr float kMemBias = -10.0f;
+constexpr float kTwoPi = 6.283185307179586f;
+
+double Median(std::vector<double> v) {
+  if (v.empty()) return 0.0;
+  std::sort(v.begin(), v.end());
+  return v[v.size() / 2];
+}
+
+absl::Status ReadFloats(LitertDynamicRunner& runner, const std::string& sig,
+                        const std::string& name, std::vector<float>& out) {
+  auto t = runner.GetOutput(sig, name);
+  if (!t.ok()) return t.status();
+  auto buffer = t->GetBuffer();
+  if (!buffer.ok()) return buffer.status();
+  auto lock = buffer->Lock();
+  const float* data = reinterpret_cast<const float*>(lock.data());
+  out.assign(data, data + lock.size() / sizeof(float));
+  return absl::OkStatus();
+}
+
+absl::Status DumpFile(const std::string& dir, const std::string& name,
+                      const std::vector<float>& data) {
+  std::ofstream out(absl::StrCat(dir, "/", name, ".f32"), std::ios::binary);
+  if (!out) return absl::InternalError(absl::StrCat("cannot write ", name));
+  out.write(reinterpret_cast<const char*>(data.data()),
+            data.size() * sizeof(float));
+  return absl::OkStatus();
+}
+
+// Host tables read once from the weight map.
+struct HostConsts {
+  std::vector<float> gaussian;      // (2,128) row-major
+  std::vector<float> point_embed1;  // (256)
+  std::vector<float> not_a_point;   // (256)
+  std::vector<float> track_sparse;  // (2,256)
+  std::vector<float> mtpe;          // (7,64)
+  std::vector<float> no_obj_ptr;    // (256)
+  std::vector<float> tpos_w;        // (64,256)
+  std::vector<float> tpos_b;        // (64)
+
+  // 2-token sparse prompt: one positive click + the not-a-point pad
+  // (matches the reference host and the HF _embed_points math).
+  std::vector<float> ClickSparse(float x, float y) const {
+    float xn = 2.0f * ((x + 0.5f) / kSize) - 1.0f;
+    float yn = 2.0f * ((y + 0.5f) / kSize) - 1.0f;
+    std::vector<float> out(2 * kHidden);
+    for (int i = 0; i < 128; ++i) {
+      float proj = kTwoPi * (xn * gaussian[i] + yn * gaussian[128 + i]);
+      out[i] = std::sin(proj) + point_embed1[i];
+      out[128 + i] = std::cos(proj) + point_embed1[128 + i];
+    }
+    for (int i = 0; i < kHidden; ++i) out[kHidden + i] = not_a_point[i];
+    return out;
+  }
+
+  // tpos_proj(get_1d_sine_pe(t_diff / 15, 256)) — double accumulation like
+  // the reference (float32 rounding only at the end).
+  std::vector<float> PtrPos(int t_diff) const {
+    double pe[kHidden];
+    const double pos = static_cast<double>(t_diff) / (kNptrFrames - 1.0);
+    for (int i = 0; i < 128; ++i) {
+      double dim_t = std::pow(10000.0, 2.0 * (i / 2) / 128.0);
+      pe[i] = std::sin(pos / dim_t);
+      pe[128 + i] = std::cos(pos / dim_t);
+    }
+    std::vector<float> out(kMemCh);
+    for (int r = 0; r < kMemCh; ++r) {
+      double acc = static_cast<double>(tpos_b[r]);
+      for (int c = 0; c < kHidden; ++c) {
+        acc += static_cast<double>(tpos_w[static_cast<size_t>(r) * kHidden + c]) *
+               pe[c];
+      }
+      out[r] = static_cast<float>(acc);
+    }
+    return out;
+  }
+};
+
+std::vector<float> HostFloatsOf(const s2v::WeightMap& weights,
+                                const std::string& name) {
+  auto it = weights.find(name);
+  if (it == weights.end()) return {};
+  auto buffer = it->second.GetBuffer();
+  if (!buffer.ok()) return {};
+  auto lock = buffer->Lock();
+  const float* data = reinterpret_cast<const float*>(lock.data());
+  return std::vector<float>(data, data + lock.size() / sizeof(float));
+}
+
+// Bilinear 256 -> 1024, align_corners=false (torch semantics).
+void Upsample1024(const float* low, std::vector<float>& high) {
+  const float scale = static_cast<float>(kMaskGrid) / kSize;  // 0.25
+  for (int y = 0; y < kSize; ++y) {
+    float sy = (y + 0.5f) * scale - 0.5f;
+    int y0 = static_cast<int>(std::floor(sy));
+    float fy = sy - y0;
+    int y0c = std::clamp(y0, 0, kMaskGrid - 1);
+    int y1c = std::clamp(y0 + 1, 0, kMaskGrid - 1);
+    for (int x = 0; x < kSize; ++x) {
+      float sx = (x + 0.5f) * scale - 0.5f;
+      int x0 = static_cast<int>(std::floor(sx));
+      float fx = sx - x0;
+      int x0c = std::clamp(x0, 0, kMaskGrid - 1);
+      int x1c = std::clamp(x0 + 1, 0, kMaskGrid - 1);
+      float v00 = low[y0c * kMaskGrid + x0c];
+      float v01 = low[y0c * kMaskGrid + x1c];
+      float v10 = low[y1c * kMaskGrid + x0c];
+      float v11 = low[y1c * kMaskGrid + x1c];
+      high[static_cast<size_t>(y) * kSize + x] =
+          (1 - fy) * ((1 - fx) * v00 + fx * v01) +
+          fy * ((1 - fx) * v10 + fx * v11);
+    }
+  }
+}
+
+// Static circle fixture (bench fallback when no clip file is given).
+std::vector<float> CircleFrame() {
+  const float mean[3] = {0.485f, 0.456f, 0.406f};
+  const float stddev[3] = {0.229f, 0.224f, 0.225f};
+  std::vector<float> out(static_cast<size_t>(kSize) * kSize * 3);
+  const int cx = kSize / 2, cy = kSize / 2, r = kSize / 4 - 8;
+  for (int y = 0; y < kSize; ++y) {
+    for (int x = 0; x < kSize; ++x) {
+      const int dx = x - cx, dy = y - cy;
+      const float value = (dx * dx + dy * dy <= r * r) ? 1.0f : 0.0f;
+      size_t base = (static_cast<size_t>(y) * kSize + x) * 3;
+      for (int ch = 0; ch < 3; ++ch) {
+        out[base + ch] = (value - mean[ch]) / stddev[ch];
+      }
+    }
+  }
+  return out;
+}
+
+struct StageTimes {
+  std::vector<double> encode, memcond, decode, memorize, host, e2e;
+};
+
+absl::Status Run() {
+  const int nmm = absl::GetFlag(FLAGS_nmm);
+  if (nmm != 7 && nmm != 2) {
+    return absl::InvalidArgumentError("--nmm must be 7 or 2");
+  }
+  const int T = absl::GetFlag(FLAGS_frames);
+
+  s2v::Sam2VideoConfig config;  // image_size = 1024
+  sam2::Sam2Config& img = config.image;
+
+  // ---- Weights: image keys + video keys from the same file. The encoder
+  // is built with a ZEROED no_mem_embed so its output is the raw feature
+  // map; the video decoder applies the real row via its nomem input. ----
+  s2v::WeightMap weights;
+  const std::string weights_path = absl::GetFlag(FLAGS_weights);
+  if (weights_path.empty()) {
+    weights = sam2::MakeSyntheticWeights(img, /*seed=*/42);
+    s2v::MakeSyntheticVideoWeights(config, /*seed=*/43, weights);
+    std::cout << "weights: synthetic — shape/route check only" << std::endl;
+  } else {
+    auto weights_or = sam2::LoadCheckpointWeights(img, weights_path);
+    if (!weights_or.ok()) return weights_or.status();
+    weights = std::move(*weights_or);
+    auto st = s2v::LoadVideoWeights(config, weights_path, weights);
+    if (!st.ok()) return st;
+    std::cout << "weights: " << weights_path << " (" << weights.size()
+              << " tensors)" << std::endl;
+  }
+
+  HostConsts consts;
+  consts.gaussian = HostFloatsOf(
+      weights,
+      "sam_prompt_encoder.pe_layer.positional_encoding_gaussian_matrix");
+  consts.point_embed1 =
+      HostFloatsOf(weights, "sam_prompt_encoder.point_embeddings.1.weight");
+  consts.not_a_point =
+      HostFloatsOf(weights, "sam_prompt_encoder.not_a_point_embed.weight");
+  consts.track_sparse = HostFloatsOf(weights, "tables.track_sparse");
+  consts.mtpe = HostFloatsOf(weights, "maskmem_tpos_enc");  // (7,1,1,64)
+  consts.no_obj_ptr = HostFloatsOf(weights, "no_obj_ptr");
+  consts.tpos_w = HostFloatsOf(weights, "obj_ptr_tpos_proj.weight");
+  consts.tpos_b = HostFloatsOf(weights, "obj_ptr_tpos_proj.bias");
+
+  // ---- Build the five signatures (shared weights, one flatbuffer). ----
+  std::vector<float> real_no_mem = HostFloatsOf(weights, "no_mem_embed");
+  {
+    std::vector<float> zeros(real_no_mem.size(), 0.0f);
+    weights["no_mem_embed"] = s2v::TfTensor(
+        {.name = "no_mem_embed",
+         .type = Type::kFP32,
+         .shape = {1, 1, img.d_model},
+         .buffer = ::litert::tensor::OwningCpuBuffer::Copy<Type::kFP32>(
+             zeros)});
+  }
+  sam2::EncoderInputs enc_in = sam2::MakeEncoderInputs(img);
+  sam2::EncoderOutputs enc_out = sam2::BuildEncoder(img, enc_in, weights);
+  enc_out.image_embeddings.SetName("pix_raw");
+  {
+    weights["no_mem_embed"] = s2v::TfTensor(
+        {.name = "no_mem_embed",
+         .type = Type::kFP32,
+         .shape = {1, 1, img.d_model},
+         .buffer = ::litert::tensor::OwningCpuBuffer::Copy<Type::kFP32>(
+             real_no_mem)});
+  }
+
+  s2v::MemCondInputs mc7_in = s2v::MakeMemCondInputs(config, 7);
+  s2v::TfTensor mc7_out = s2v::BuildMemCond(config, 7, mc7_in, weights);
+  s2v::MemCondInputs mc2_in = s2v::MakeMemCondInputs(config, 2);
+  s2v::TfTensor mc2_out = s2v::BuildMemCond(config, 2, mc2_in, weights);
+  s2v::VideoDecoderInputs dec_in = s2v::MakeVideoDecoderInputs(config);
+  s2v::VideoDecoderOutputs dec_out =
+      s2v::BuildVideoDecoder(config, dec_in, weights);
+  s2v::MemorizeInputs mem_in = s2v::MakeMemorizeInputs(config);
+  s2v::TfTensor mem_out = s2v::BuildMemorize(config, mem_in, weights);
+
+  ModelFactory factory;
+  auto add_sig = [&](std::vector<s2v::TfTensor> ins,
+                     std::vector<s2v::TfTensor> outs,
+                     const std::string& name) -> absl::Status {
+    std::vector<::litert::tensor::TensorHandle> in_handles, out_handles;
+    for (auto& t : ins) in_handles.push_back(t);
+    for (auto& t : outs) out_handles.push_back(t);
+    return factory.AddSignature(in_handles, out_handles, name);
+  };
+  auto st = add_sig(enc_in.AsList(), enc_out.AsList(), "encode");
+  if (!st.ok()) return st;
+  st = add_sig(mc7_in.AsList(), {mc7_out}, "memcond7");
+  if (!st.ok()) return st;
+  st = add_sig(mc2_in.AsList(), {mc2_out}, "memcond2");
+  if (!st.ok()) return st;
+  st = add_sig(dec_in.AsList(), dec_out.AsList(), "decode");
+  if (!st.ok()) return st;
+  st = add_sig(mem_in.AsList(), {mem_out}, "memorize");
+  if (!st.ok()) return st;
+
+  const std::string tflite_path = absl::GetFlag(FLAGS_tflite_path);
+  auto save_status = factory.Save(tflite_path);
+  if (!save_status.ok()) return save_status;
+  std::cout << "Serialized: " << tflite_path << std::endl;
+
+  // ---- Runner. ----
+  auto env = ::litert::Environment::Create({});
+  if (!env) return absl::InternalError("Environment::Create failed");
+  auto options = ::litert::Options::Create();
+  if (!options) return absl::InternalError("Options::Create failed");
+  const bool use_gpu = absl::GetFlag(FLAGS_accelerator) == "gpu";
+  options->SetHardwareAccelerators(use_gpu ? ::litert::HwAccelerators::kGpu
+                                           : ::litert::HwAccelerators::kCpu);
+  if (use_gpu) {
+    auto gpu_options = options->GetGpuOptions();
+    if (gpu_options.HasValue()) {
+      const std::string precision = absl::GetFlag(FLAGS_gpu_precision);
+      if (precision == "fp32") {
+        gpu_options->SetPrecision(::litert::GpuOptions::Precision::kFp32);
+      } else if (precision != "fp16") {
+        return absl::InvalidArgumentError("--gpu_precision must be fp16|fp32");
+      }
+      const std::string storage = absl::GetFlag(FLAGS_gpu_buffer_storage);
+      if (storage == "buffer") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kBuffer);
+      } else if (storage == "texture2d") {
+        gpu_options->SetBufferStorageType(
+            ::litert::GpuOptions::BufferStorageType::kTexture2D);
+      } else if (storage != "default") {
+        return absl::InvalidArgumentError(
+            "--gpu_buffer_storage must be default|buffer|texture2d");
+      }
+      std::cout << "gpu precision: " << precision << ", storage: " << storage
+                << std::endl;
+    }
+  }
+  auto runner_or = LitertDynamicRunner::Create(*env, tflite_path, *options);
+  if (!runner_or.ok()) return runner_or.status();
+  auto runner = std::move(*runner_or);
+
+  // ---- Clip. ----
+  const size_t frame_elems = static_cast<size_t>(kSize) * kSize * 3;
+  std::vector<float> clip;
+  const std::string frames_file = absl::GetFlag(FLAGS_frames_file);
+  if (!frames_file.empty()) {
+    clip.resize(frame_elems * T);
+    std::ifstream in(frames_file, std::ios::binary);
+    if (!in) return absl::NotFoundError("frames_file: " + frames_file);
+    in.read(reinterpret_cast<char*>(clip.data()),
+            clip.size() * sizeof(float));
+    if (static_cast<size_t>(in.gcount()) != clip.size() * sizeof(float)) {
+      return absl::InvalidArgumentError(
+          "frames_file wrong size (need T*1024*1024*3 fp32)");
+    }
+  } else {
+    std::cout << "frames_file empty: static circle fixture (bench only, no "
+                 "parity)" << std::endl;
+    std::vector<float> f = CircleFrame();
+    clip.resize(frame_elems * T);
+    for (int t = 0; t < T; ++t) {
+      std::copy(f.begin(), f.end(), clip.begin() + frame_elems * t);
+    }
+  }
+
+  const std::string dump_dir = absl::GetFlag(FLAGS_dump_dir);
+  const std::string memcond_sig = absl::StrCat("memcond", nmm);
+  const int mem_len = nmm * kHw + kNptr;
+  const int bench_loops = absl::GetFlag(FLAGS_bench_loops);
+
+  StageTimes times;
+  auto tick = [] { return std::chrono::steady_clock::now(); };
+  auto ms = [](auto a, auto b) {
+    return std::chrono::duration<double, std::milli>(b - a).count();
+  };
+
+  for (int loop = 0; loop < bench_loops; ++loop) {
+    const bool record = bench_loops == 1 || loop > 0;
+    std::map<int, std::vector<float>> spatial_bank;  // t -> (4096,64)
+    std::map<int, std::vector<float>> ptr_bank;      // t -> (256)
+    const int cond_frame = 0;
+
+    for (int t = 0; t < T; ++t) {
+      auto t_start = tick();
+      // 1. encode
+      auto st2 = runner.SetInput(
+          "encode", "pixels",
+          Create("pixels", Type::kFP32, {1, kSize, kSize, 3},
+                 std::vector<float>(clip.begin() + frame_elems * t,
+                                    clip.begin() + frame_elems * (t + 1))));
+      if (!st2.ok()) return st2;
+      auto t0 = tick();
+      st2 = runner.Run("encode");
+      if (!st2.ok()) return st2;
+      auto t1 = tick();
+      if (record) times.encode.push_back(ms(t0, t1));
+
+      const bool prompted = t == cond_frame;
+      std::vector<float> pix_feat;  // token-major (4096,256) when tracked
+      double memcond_ms = 0.0;
+      if (!prompted) {
+        // ---- assemble the fixed bank (reference `track` lines) ----
+        std::vector<float> mem(static_cast<size_t>(nmm) * kHw * kMemCh, 0.0f);
+        std::vector<float> tpe(static_cast<size_t>(nmm) * kMemCh, 0.0f);
+        std::vector<float> km(mem_len, kMaskNeg);
+        int slot = 0;
+        auto put_slot = [&](const std::vector<float>& m, const float* row) {
+          std::copy(m.begin(), m.end(),
+                    mem.begin() + static_cast<size_t>(slot) * kHw * kMemCh);
+          std::copy(row, row + kMemCh,
+                    tpe.begin() + static_cast<size_t>(slot) * kMemCh);
+          std::fill(km.begin() + static_cast<size_t>(slot) * kHw,
+                    km.begin() + static_cast<size_t>(slot + 1) * kHw, 0.0f);
+          ++slot;
+        };
+        put_slot(spatial_bank[cond_frame],
+                 consts.mtpe.data() + 6 * kMemCh);  // cond frame row
+        for (int off = nmm - 1; off >= 1; --off) {  // most distant first
+          int pf = t - off;
+          auto it = spatial_bank.find(pf);
+          if (it != spatial_bank.end() && pf != cond_frame) {
+            put_slot(it->second, consts.mtpe.data() + (off - 1) * kMemCh);
+          }
+        }
+        std::vector<float> ptr_tok(static_cast<size_t>(kNptr) * kMemCh, 0.0f);
+        std::vector<float> ptr_pos(static_cast<size_t>(kNptr) * kMemCh, 0.0f);
+        std::vector<std::pair<int, const std::vector<float>*>> ptrs;
+        ptrs.emplace_back(t - cond_frame, &ptr_bank[cond_frame]);
+        for (int td = 1; td < kNptrFrames; ++td) {
+          int pf = t - td;
+          if (pf < 0) break;
+          auto it = ptr_bank.find(pf);
+          if (it != ptr_bank.end() && pf != cond_frame) {
+            ptrs.emplace_back(td, &it->second);
+          }
+        }
+        for (size_t i = 0; i < ptrs.size(); ++i) {
+          std::vector<float> pos = consts.PtrPos(ptrs[i].first);
+          const std::vector<float>& p = *ptrs[i].second;
+          for (int j = 0; j < kPtrSplit; ++j) {
+            size_t row = i * kPtrSplit + j;
+            std::copy(p.begin() + j * kMemCh, p.begin() + (j + 1) * kMemCh,
+                      ptr_tok.begin() + row * kMemCh);
+            std::copy(pos.begin(), pos.end(), ptr_pos.begin() + row * kMemCh);
+            km[static_cast<size_t>(nmm) * kHw + row] = 0.0f;
+          }
+        }
+
+        auto rebind = runner.GetOutput("encode", "pix_raw");
+        if (!rebind.ok()) return rebind.status();
+        st2 = runner.SetInput(memcond_sig, "pix_raw", *rebind);
+        if (!st2.ok()) return st2;
+        st2 = runner.SetInput(memcond_sig, "mem_bank",
+                              Create("mem_bank", Type::kFP32,
+                                     {1, nmm, kHw, kMemCh}, std::move(mem)));
+        if (!st2.ok()) return st2;
+        st2 = runner.SetInput(memcond_sig, "slot_tpe",
+                              Create("slot_tpe", Type::kFP32,
+                                     {1, nmm, 1, kMemCh}, std::move(tpe)));
+        if (!st2.ok()) return st2;
+        st2 = runner.SetInput(memcond_sig, "ptr_tok",
+                              Create("ptr_tok", Type::kFP32,
+                                     {1, 1, kNptr, kMemCh},
+                                     std::move(ptr_tok)));
+        if (!st2.ok()) return st2;
+        st2 = runner.SetInput(memcond_sig, "ptr_pos",
+                              Create("ptr_pos", Type::kFP32,
+                                     {1, 1, kNptr, kMemCh},
+                                     std::move(ptr_pos)));
+        if (!st2.ok()) return st2;
+        st2 = runner.SetInput(memcond_sig, "key_mask",
+                              Create("key_mask", Type::kFP32,
+                                     {1, 1, 1, mem_len}, std::move(km)));
+        if (!st2.ok()) return st2;
+        auto m0 = tick();
+        st2 = runner.Run(memcond_sig);
+        if (!st2.ok()) return st2;
+        memcond_ms = ms(m0, tick());
+        if (record) times.memcond.push_back(memcond_ms);
+        st2 = ReadFloats(runner, memcond_sig, "pix_feat", pix_feat);
+        if (!st2.ok()) return st2;
+      }
+
+      // 2. decode
+      if (prompted) {
+        auto rebind = runner.GetOutput("encode", "pix_raw");
+        if (!rebind.ok()) return rebind.status();
+        st2 = runner.SetInput("decode", "pix_feat_in", *rebind);
+      } else {
+        auto rebind = runner.GetOutput(memcond_sig, "pix_feat");
+        if (!rebind.ok()) return rebind.status();
+        st2 = runner.SetInput("decode", "pix_feat_in", *rebind);
+      }
+      if (!st2.ok()) return st2;
+      for (const std::string& name :
+           {std::string("feat_s1"), std::string("feat_s0")}) {
+        auto rebind = runner.GetOutput("encode", name);
+        if (!rebind.ok()) return rebind.status();
+        st2 = runner.SetInput("decode", name, *rebind);
+        if (!st2.ok()) return st2;
+      }
+      std::vector<float> sparse =
+          prompted ? consts.ClickSparse(
+                         static_cast<float>(absl::GetFlag(FLAGS_click_x)),
+                         static_cast<float>(absl::GetFlag(FLAGS_click_y)))
+                   : consts.track_sparse;
+      st2 = runner.SetInput("decode", "sparse",
+                            Create("sparse", Type::kFP32, {1, 2, kHidden},
+                                   std::move(sparse)));
+      if (!st2.ok()) return st2;
+      st2 = runner.SetInput("decode", "nomem",
+                            Create("nomem", Type::kFP32, {1, 1, 1, 1},
+                                   std::vector<float>{prompted ? 1.0f : 0.0f}));
+      if (!st2.ok()) return st2;
+      auto d0 = tick();
+      st2 = runner.Run("decode");
+      if (!st2.ok()) return st2;
+      if (record) times.decode.push_back(ms(d0, tick()));
+
+      std::vector<float> masks, iou, ptr, obj;
+      st2 = ReadFloats(runner, "decode", "masks", masks);
+      if (!st2.ok()) return st2;
+      st2 = ReadFloats(runner, "decode", "iou_scores", iou);
+      if (!st2.ok()) return st2;
+      st2 = ReadFloats(runner, "decode", "obj_ptr", ptr);
+      if (!st2.ok()) return st2;
+      st2 = ReadFloats(runner, "decode", "object_score", obj);
+      if (!st2.ok()) return st2;
+
+      // 3. host post: best of tokens 1..3, no-object handling, mask_for_mem.
+      auto h0 = tick();
+      int best = 1;
+      for (int j = 2; j < 4; ++j) {
+        if (iou[j] > iou[best]) best = j;
+      }
+      const bool appearing = obj[0] > 0.0f;
+      std::vector<float> low(kPlane, kNoObjScore);
+      if (appearing) {
+        low.assign(masks.begin() + static_cast<size_t>(best) * kPlane,
+                   masks.begin() + static_cast<size_t>(best + 1) * kPlane);
+      }
+      std::vector<float> obj_ptr =
+          appearing ? std::vector<float>(
+                          ptr.begin() + static_cast<size_t>(best) * kHidden,
+                          ptr.begin() + static_cast<size_t>(best + 1) * kHidden)
+                    : consts.no_obj_ptr;
+      std::vector<float> high(static_cast<size_t>(kSize) * kSize);
+      Upsample1024(low.data(), high);
+      std::vector<float> mfm(high.size());
+      if (prompted) {
+        for (size_t i = 0; i < high.size(); ++i) {
+          mfm[i] = (high[i] > 0.0f ? kMemScale : 0.0f) + kMemBias;
+        }
+      } else {
+        for (size_t i = 0; i < high.size(); ++i) {
+          mfm[i] = kMemScale / (1.0f + std::exp(-high[i])) + kMemBias;
+        }
+      }
+      if (record) times.host.push_back(ms(h0, tick()));
+
+      // 4. memorize
+      auto rebind = runner.GetOutput("encode", "pix_raw");
+      if (!rebind.ok()) return rebind.status();
+      st2 = runner.SetInput("memorize", "pix_raw", *rebind);
+      if (!st2.ok()) return st2;
+      st2 = runner.SetInput("memorize", "mask_for_mem",
+                            Create("mask_for_mem", Type::kFP32,
+                                   {1, kSize, kSize, 1}, std::move(mfm)));
+      if (!st2.ok()) return st2;
+      st2 = runner.SetInput("memorize", "occ",
+                            Create("occ", Type::kFP32, {1, 1, 1},
+                                   std::vector<float>{appearing ? 0.0f : 1.0f}));
+      if (!st2.ok()) return st2;
+      auto z0 = tick();
+      st2 = runner.Run("memorize");
+      if (!st2.ok()) return st2;
+      if (record) times.memorize.push_back(ms(z0, tick()));
+      std::vector<float> mem_t;
+      st2 = ReadFloats(runner, "memorize", "mem", mem_t);
+      if (!st2.ok()) return st2;
+
+      spatial_bank[t] = std::move(mem_t);
+      ptr_bank[t] = obj_ptr;
+      if (record) times.e2e.push_back(ms(t_start, tick()));
+
+      int fg = 0;
+      for (float v : low) fg += v > 0.0f ? 1 : 0;
+      std::cout << absl::StrCat("frame ", t, ": fg=", fg, " obj=", obj[0],
+                                " best=", best, " iou_best=", iou[best],
+                                prompted ? " (prompted)" : "",
+                                !prompted && bench_loops == 1
+                                    ? absl::StrCat(" memcond_ms=", memcond_ms)
+                                    : "")
+                << std::endl;
+
+      if (!dump_dir.empty() && loop == 0) {
+        std::string p = absl::StrCat("f", t < 10 ? "0" : "", t);
+        st2 = DumpFile(dump_dir, p + "_mask", low);
+        if (!st2.ok()) return st2;
+        st2 = DumpFile(dump_dir, p + "_obj", {obj[0]});
+        if (!st2.ok()) return st2;
+        st2 = DumpFile(dump_dir, p + "_ptr", ptr_bank[t]);
+        if (!st2.ok()) return st2;
+        st2 = DumpFile(dump_dir, p + "_mem", spatial_bank[t]);
+        if (!st2.ok()) return st2;
+        if (!prompted) {
+          st2 = DumpFile(dump_dir, p + "_pixfeat", pix_feat);
+          if (!st2.ok()) return st2;
+        }
+      }
+    }
+  }
+
+  std::cout << absl::StrCat(
+      "SAM2 video · LiteRT Tensor API (",
+      use_gpu ? absl::StrCat("gpu ", absl::GetFlag(FLAGS_gpu_precision))
+              : "cpu fp32",
+      ", 1024x1024, nmm=", nmm, ", T=", T, ", loops=", bench_loops, ")\n",
+      "medians ms: encode=", Median(times.encode),
+      " memcond=", Median(times.memcond), " decode=", Median(times.decode),
+      " memorize=", Median(times.memorize), " host=", Median(times.host),
+      " e2e/frame=", Median(times.e2e), "\n");
+  if (!dump_dir.empty()) {
+    std::cout << "dumped per-frame outputs to " << dump_dir << std::endl;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  absl::Status status = Run();
+  if (!status.ok()) {
+    std::cerr << "FAIL: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_main.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_main.cc
@@ -240,10 +240,11 @@ absl::Status Run() {
 
   s2v::Sam2VideoConfig config;  // image_size = 1024
   sam2::Sam2Config& img = config.image;
+  // The encoder emits the raw top-level feature map; the video decoder adds
+  // the no-memory row itself, on the conditioning frame, via its nomem input.
+  img.fold_no_mem_embed = false;
 
-  // ---- Weights: image keys + video keys from the same file. The encoder
-  // is built with a ZEROED no_mem_embed so its output is the raw feature
-  // map; the video decoder applies the real row via its nomem input. ----
+  // ---- Weights: image keys + video keys from the same file. ----
   s2v::WeightMap weights;
   const std::string weights_path = absl::GetFlag(FLAGS_weights);
   if (weights_path.empty()) {
@@ -275,27 +276,9 @@ absl::Status Run() {
   consts.tpos_b = HostFloatsOf(weights, "obj_ptr_tpos_proj.bias");
 
   // ---- Build the five signatures (shared weights, one flatbuffer). ----
-  std::vector<float> real_no_mem = HostFloatsOf(weights, "no_mem_embed");
-  {
-    std::vector<float> zeros(real_no_mem.size(), 0.0f);
-    weights["no_mem_embed"] = s2v::TfTensor(
-        {.name = "no_mem_embed",
-         .type = Type::kFP32,
-         .shape = {1, 1, img.d_model},
-         .buffer = ::litert::tensor::OwningCpuBuffer::Copy<Type::kFP32>(
-             zeros)});
-  }
   sam2::EncoderInputs enc_in = sam2::MakeEncoderInputs(img);
   sam2::EncoderOutputs enc_out = sam2::BuildEncoder(img, enc_in, weights);
   enc_out.image_embeddings.SetName("pix_raw");
-  {
-    weights["no_mem_embed"] = s2v::TfTensor(
-        {.name = "no_mem_embed",
-         .type = Type::kFP32,
-         .shape = {1, 1, img.d_model},
-         .buffer = ::litert::tensor::OwningCpuBuffer::Copy<Type::kFP32>(
-             real_no_mem)});
-  }
 
   s2v::MemCondInputs mc7_in = s2v::MakeMemCondInputs(config, 7);
   s2v::TfTensor mc7_out = s2v::BuildMemCond(config, 7, mc7_in, weights);

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.cc
@@ -1,0 +1,191 @@
+// Video-stack weight loading. See sam2v_weights.h.
+
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"  // from @com_google_absl
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/strings/match.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/str_join.h"  // from @com_google_absl
+#include "tensor/examples/gemma3/safetensor_loader.h"
+#include "tensor/tensor.h"
+
+namespace litert::tensor::examples::sam2_video {
+
+namespace {
+
+// The gemma3 loader's Gemma-norm heuristic: +1.0 on any tensor whose name
+// contains "layernorm" or ends with "norm.weight". Three video keys match
+// (memory_attention.norm.weight, memory_encoder.fuser.{0,1}.norm.weight);
+// their loaded values are compensated back below.
+bool LoaderAddsGemmaOffset(const std::string& name) {
+  return absl::StrContains(name, "layernorm") ||
+         absl::EndsWith(name, "norm.weight");
+}
+
+}  // namespace
+
+std::vector<WeightSpec> GetVideoWeightSpecs(const Sam2VideoConfig& config) {
+  std::vector<WeightSpec> specs;
+  auto add = [&](const std::string& name, const std::vector<int>& shape,
+                 float scale = 0.02f) {
+    specs.push_back({name, shape, scale});
+  };
+  const int hd = config.hidden;   // 256
+  const int mc = config.mem_ch;   // 64
+  const int hw = config.hw();     // 4096 at 1024
+
+  for (int l = 0; l < config.ma_layers; ++l) {
+    std::string p = absl::StrCat("memory_attention.layers.", l);
+    for (const std::string& attn :
+         {std::string(".self_attn"), std::string(".cross_attn_image")}) {
+      const int kv_in = attn == ".self_attn" ? hd : mc;
+      add(p + attn + ".q_proj.weight", {hd, hd});
+      add(p + attn + ".q_proj.bias", {hd}, 0.0f);
+      add(p + attn + ".k_proj.weight", {hd, kv_in});
+      add(p + attn + ".k_proj.bias", {hd}, 0.0f);
+      add(p + attn + ".v_proj.weight", {hd, kv_in});
+      add(p + attn + ".v_proj.bias", {hd}, 0.0f);
+      add(p + attn + ".out_proj.weight", {hd, hd});
+      add(p + attn + ".out_proj.bias", {hd}, 0.0f);
+    }
+    add(p + ".linear1.weight", {config.ff_hidden, hd});
+    add(p + ".linear1.bias", {config.ff_hidden}, 0.0f);
+    add(p + ".linear2.weight", {hd, config.ff_hidden});
+    add(p + ".linear2.bias", {hd}, 0.0f);
+    for (int n = 1; n <= 3; ++n) {
+      add(absl::StrCat(p, ".norm", n, ".weight"), {hd}, 1.0f);
+      add(absl::StrCat(p, ".norm", n, ".bias"), {hd}, 0.0f);
+    }
+  }
+  add("memory_attention.norm.weight", {hd}, 1.0f);
+  add("memory_attention.norm.bias", {hd}, 0.0f);
+
+  // Memory encoder.
+  const int ds_ch[5] = {1, 4, 16, 64, 256};
+  for (int i = 0; i < 4; ++i) {
+    add(absl::StrCat("memory_encoder.mask_downsampler.conv", i, ".weight"),
+        {ds_ch[i + 1], 3, 3, ds_ch[i]});
+    add(absl::StrCat("memory_encoder.mask_downsampler.conv", i, ".bias"),
+        {ds_ch[i + 1]}, 0.0f);
+    add(absl::StrCat("memory_encoder.mask_downsampler.norm", i, ".weight"),
+        {ds_ch[i + 1]}, 1.0f);
+    add(absl::StrCat("memory_encoder.mask_downsampler.norm", i, ".bias"),
+        {ds_ch[i + 1]}, 0.0f);
+  }
+  add("memory_encoder.mask_downsampler.conv4.weight", {hd, 1, 1, hd});
+  add("memory_encoder.mask_downsampler.conv4.bias", {hd}, 0.0f);
+  add("memory_encoder.pix_feat_proj.weight", {hd, 1, 1, hd});
+  add("memory_encoder.pix_feat_proj.bias", {hd}, 0.0f);
+  for (int i = 0; i < 2; ++i) {
+    std::string p = absl::StrCat("memory_encoder.fuser.", i);
+    add(p + ".dwconv.weight", {hd, 7, 7, 1});
+    add(p + ".dwconv.bias", {hd}, 0.0f);
+    add(p + ".norm.weight", {hd}, 1.0f);
+    add(p + ".norm.bias", {hd}, 0.0f);
+    add(p + ".pwconv1.weight", {4 * hd, hd});
+    add(p + ".pwconv1.bias", {4 * hd}, 0.0f);
+    add(p + ".pwconv2.weight", {hd, 4 * hd});
+    add(p + ".pwconv2.bias", {hd}, 0.0f);
+    add(p + ".gamma", {hd}, 1.0f);
+  }
+  add("memory_encoder.out_proj.weight", {mc, 1, 1, hd});
+  add("memory_encoder.out_proj.bias", {mc}, 0.0f);
+
+  // Pointer heads and per-frame constants.
+  add("maskmem_tpos_enc", {7, 1, 1, mc});
+  add("no_obj_ptr", {1, hd});
+  add("no_obj_embed_spatial", {1, mc});
+  for (int i = 0; i < 3; ++i) {
+    add(absl::StrCat("obj_ptr_proj.layers.", i, ".weight"), {hd, hd});
+    add(absl::StrCat("obj_ptr_proj.layers.", i, ".bias"), {hd}, 0.0f);
+  }
+  add("obj_ptr_tpos_proj.weight", {mc, hd});
+  add("obj_ptr_tpos_proj.bias", {mc}, 0.0f);
+
+  // The video decoder emits all four mask tokens; the image spec only
+  // carries hypernetworks 1..3.
+  add("sam_mask_decoder.output_hypernetworks_mlps.0.layers.0.weight",
+      {hd, hd});
+  add("sam_mask_decoder.output_hypernetworks_mlps.0.layers.0.bias", {hd},
+      0.0f);
+  add("sam_mask_decoder.output_hypernetworks_mlps.0.layers.1.weight",
+      {hd, hd});
+  add("sam_mask_decoder.output_hypernetworks_mlps.0.layers.1.bias", {hd},
+      0.0f);
+  add("sam_mask_decoder.output_hypernetworks_mlps.0.layers.2.weight",
+      {32, hd});
+  add("sam_mask_decoder.output_hypernetworks_mlps.0.layers.2.bias", {32},
+      0.0f);
+
+  // Derived tables (export-time constants).
+  add("tables.rope_cos", {hw, hd}, 1.0f);
+  add("tables.rope_sin", {hw, hd}, 0.02f);
+  add("tables.vision_pos_scaled", {hw, hd}, 0.02f);
+  add("tables.mem_pos", {hw, mc}, 0.02f);
+  add("tables.track_sparse", {2, hd}, 0.02f);
+  return specs;
+}
+
+absl::Status LoadVideoWeights(const Sam2VideoConfig& config,
+                              const std::string& path, WeightMap& weights) {
+  auto loader_or = SafetensorLoader::Load(path);
+  if (!loader_or.ok()) return loader_or.status();
+  auto loader = std::move(*loader_or);
+
+  for (const WeightSpec& spec : GetVideoWeightSpecs(config)) {
+    auto handle_or = loader.LoadTensor(
+        spec.name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
+    if (!handle_or.ok()) {
+      return absl::NotFoundError(absl::StrCat("checkpoint missing ", spec.name,
+                                              ": ",
+                                              handle_or.status().message()));
+    }
+    TfTensor tensor(*handle_or);
+    const auto& loaded_shape = tensor.GetShape();
+    std::vector<int> loaded(loaded_shape.begin(), loaded_shape.end());
+    if (loaded != spec.shape) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          spec.name, ": checkpoint shape [", absl::StrJoin(loaded, ","),
+          "] != expected [", absl::StrJoin(spec.shape, ","), "]"));
+    }
+    if (LoaderAddsGemmaOffset(spec.name)) {
+      auto buffer = tensor.GetBuffer();
+      if (!buffer.ok()) return buffer.status();
+      auto lock = buffer->LockMutable();
+      float* p = reinterpret_cast<float*>(lock.data());
+      size_t count = lock.size() / sizeof(float);
+      for (size_t i = 0; i < count; ++i) p[i] -= 1.0f;
+    }
+    tensor.SetName(spec.name);
+    weights[spec.name] = std::move(tensor);
+  }
+  return absl::OkStatus();
+}
+
+void MakeSyntheticVideoWeights(const Sam2VideoConfig& config, unsigned seed,
+                               WeightMap& weights) {
+  unsigned state = seed;
+  for (const WeightSpec& spec : GetVideoWeightSpecs(config)) {
+    size_t count = 1;
+    for (int d : spec.shape) count *= static_cast<size_t>(d);
+    std::vector<float> data(count);
+    for (size_t i = 0; i < count; ++i) {
+      state = state * 1664525u + 1013904223u;
+      data[i] = spec.init_scale * (static_cast<float>(state >> 8) /
+                                       static_cast<float>(1u << 24) * 2.0f -
+                                   1.0f);
+    }
+    weights[spec.name] =
+        TfTensor({.name = spec.name,
+                  .type = Type::kFP32,
+                  .shape = spec.shape,
+                  .buffer = OwningCpuBuffer::Copy<Type::kFP32>(data)});
+  }
+}
+
+}  // namespace litert::tensor::examples::sam2_video

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.cc
@@ -3,31 +3,14 @@
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h"
 
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"  // from @com_google_absl
-#include "absl/status/statusor.h"  // from @com_google_absl
-#include "absl/strings/match.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
-#include "absl/strings/str_join.h"  // from @com_google_absl
-#include "tensor/examples/gemma3/safetensor_loader.h"
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image/sam2_weights.h"
 #include "tensor/tensor.h"
 
 namespace litert::tensor::examples::sam2_video {
-
-namespace {
-
-// The gemma3 loader's Gemma-norm heuristic: +1.0 on any tensor whose name
-// contains "layernorm" or ends with "norm.weight". Three video keys match
-// (memory_attention.norm.weight, memory_encoder.fuser.{0,1}.norm.weight);
-// their loaded values are compensated back below.
-bool LoaderAddsGemmaOffset(const std::string& name) {
-  return absl::StrContains(name, "layernorm") ||
-         absl::EndsWith(name, "norm.weight");
-}
-
-}  // namespace
 
 std::vector<WeightSpec> GetVideoWeightSpecs(const Sam2VideoConfig& config) {
   std::vector<WeightSpec> specs;
@@ -133,38 +116,7 @@ std::vector<WeightSpec> GetVideoWeightSpecs(const Sam2VideoConfig& config) {
 
 absl::Status LoadVideoWeights(const Sam2VideoConfig& config,
                               const std::string& path, WeightMap& weights) {
-  auto loader_or = SafetensorLoader::Load(path);
-  if (!loader_or.ok()) return loader_or.status();
-  auto loader = std::move(*loader_or);
-
-  for (const WeightSpec& spec : GetVideoWeightSpecs(config)) {
-    auto handle_or = loader.LoadTensor(
-        spec.name, SafetensorLoader::QuantizedLoadMode::kDequantizeToFp32);
-    if (!handle_or.ok()) {
-      return absl::NotFoundError(absl::StrCat("checkpoint missing ", spec.name,
-                                              ": ",
-                                              handle_or.status().message()));
-    }
-    TfTensor tensor(*handle_or);
-    const auto& loaded_shape = tensor.GetShape();
-    std::vector<int> loaded(loaded_shape.begin(), loaded_shape.end());
-    if (loaded != spec.shape) {
-      return absl::FailedPreconditionError(absl::StrCat(
-          spec.name, ": checkpoint shape [", absl::StrJoin(loaded, ","),
-          "] != expected [", absl::StrJoin(spec.shape, ","), "]"));
-    }
-    if (LoaderAddsGemmaOffset(spec.name)) {
-      auto buffer = tensor.GetBuffer();
-      if (!buffer.ok()) return buffer.status();
-      auto lock = buffer->LockMutable();
-      float* p = reinterpret_cast<float*>(lock.data());
-      size_t count = lock.size() / sizeof(float);
-      for (size_t i = 0; i < count; ++i) p[i] -= 1.0f;
-    }
-    tensor.SetName(spec.name);
-    weights[spec.name] = std::move(tensor);
-  }
-  return absl::OkStatus();
+  return sam2::LoadWeightSpecs(path, GetVideoWeightSpecs(config), weights);
 }
 
 void MakeSyntheticVideoWeights(const Sam2VideoConfig& config, unsigned seed,

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.cc
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.cc
@@ -66,7 +66,7 @@ std::vector<WeightSpec> GetVideoWeightSpecs(const Sam2VideoConfig& config) {
   add("memory_encoder.pix_feat_proj.bias", {hd}, 0.0f);
   for (int i = 0; i < 2; ++i) {
     std::string p = absl::StrCat("memory_encoder.fuser.", i);
-    add(p + ".dwconv.weight", {hd, 7, 7, 1});
+    add(p + ".dwconv.weight", {1, 7, 7, hd});  // TFLite depthwise layout
     add(p + ".dwconv.bias", {hd}, 0.0f);
     add(p + ".norm.weight", {hd}, 1.0f);
     add(p + ".norm.bias", {hd}, 0.0f);

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h
@@ -1,0 +1,36 @@
+// Video-stack weight loading (memory attention / memory encoder / pointer
+// heads / baked tables) for the SAM2 video example. The image-path weights
+// load through ../sam2_image's loader; this adds the video-only keys from
+// the same safetensors file into the same WeightMap.
+
+#ifndef MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_VIDEO_SAM2V_WEIGHTS_H_
+#define MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_VIDEO_SAM2V_WEIGHTS_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/status/statusor.h"  // from @com_google_absl
+#include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h"
+
+namespace litert::tensor::examples::sam2_video {
+
+using ::litert::tensor::examples::sam2::WeightSpec;
+
+// Every video-only weight the graphs consume (checkpoint naming + the
+// "tables." entries the export derives), shapes for image_size = 1024.
+std::vector<WeightSpec> GetVideoWeightSpecs(const Sam2VideoConfig& config);
+
+// Loads GetVideoWeightSpecs into `weights` (which already holds the image
+// keys). Compensates the safetensor loader's Gemma-norm +1.0 heuristic on
+// the three video keys that match its predicate.
+absl::Status LoadVideoWeights(const Sam2VideoConfig& config,
+                              const std::string& path, WeightMap& weights);
+
+// Synthetic video weights for a shape/route check (image keys come from
+// sam2_image's generator).
+void MakeSyntheticVideoWeights(const Sam2VideoConfig& config, unsigned seed,
+                               WeightMap& weights);
+
+}  // namespace litert::tensor::examples::sam2_video
+
+#endif  // MODELS_SAM2_SAM2_HIERA_TINY_VIDEO_TENSOR_API_SAM2_VIDEO_SAM2V_WEIGHTS_H_

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_weights.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/status/statusor.h"  // from @com_google_absl
+#include "absl/status/status.h"  // from @com_google_absl
 #include "models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/sam2v_graph.h"
 
 namespace litert::tensor::examples::sam2_video {
@@ -21,8 +21,8 @@ using ::litert::tensor::examples::sam2::WeightSpec;
 std::vector<WeightSpec> GetVideoWeightSpecs(const Sam2VideoConfig& config);
 
 // Loads GetVideoWeightSpecs into `weights` (which already holds the image
-// keys). Compensates the safetensor loader's Gemma-norm +1.0 heuristic on
-// the three video keys that match its predicate.
+// keys) through sam2_image's LoadWeightSpecs: values exactly as stored,
+// shape-checked, no name-based rewriting.
 absl::Status LoadVideoWeights(const Sam2VideoConfig& config,
                               const std::string& path, WeightMap& weights);
 

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/export_weights_1024.py
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/export_weights_1024.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Export facebook/sam2.1-hiera-tiny (video stack included) for the Tensor API
+video example, fp32 at the 1024x1024 native resolution.
+
+Writes ONE safetensors file whose keys follow the original SAM2 checkpoint
+naming (trunk./neck./sam_prompt_encoder./sam_mask_decoder./memory_attention./
+memory_encoder./obj_ptr_proj./...), the same convention as the 512 image-path
+file, plus derived tables under "tables.":
+
+  trunk.pos_embed_full        [1,256,256,96]  bicubic(base 7x7 -> 256) + tiled
+                              8x8 window, composed once at the 1024 grid (the
+                              network's native size, so no re-composition trick
+                              is needed -- this is what the checkpoint encodes).
+  memory_attention q/k        stored PERM-PERMUTED: the head-dim permutation
+                              [even dims | odd dims] baked into the projection
+                              rows turns SAM2's pairwise-interleaved RoPE into
+                              the rotate-half form, so q'.k' == q.k exactly.
+                              The graph must apply rotate-half RoPE with the
+                              deinterleaved tables below.
+  tables.rope_cos / rope_sin  [4096,256] deinterleaved ([c_half | c_half]) from
+                              the model's own precomputed rotary buffers.
+  tables.vision_pos_scaled    [4096,256] 0.1 * top-level vision sine position
+                              encoding, token-major (row-major 64x64 grid).
+  tables.mem_pos              [4096,64] memory-channel sine position encoding,
+                              token-major.
+  tables.track_sparse         [2,256] the sparse prompt used on non-prompted
+                              tracking frames (label -1 "no point" encoding).
+
+All conv weights are permuted to the TFLite OHWI layout (depthwise stays
+per-channel-planes [C,kh,kw,1]; transposed convs to [O,kh,kw,I]).
+
+Cross-check: every key shared with the verified 512 file (which stores the
+same weights in fp16) must round-trip: fp16(exported) == stored fp16. The two
+expected exceptions are trunk.pos_embed_full (different grid by design) and
+the permuted memory-attention q/k rows (compared after inverse permutation).
+
+Run (any venv with torch + transformers>=5 + safetensors + numpy):
+  python export_weights_1024.py --out sam2_tiny_1024_video.safetensors \
+      [--check_512 sam2_tiny_512_clean.safetensors]
+"""
+import argparse
+
+import numpy as np
+import torch
+from safetensors import safe_open
+from safetensors.numpy import save_file
+from transformers import Sam2VideoModel
+
+CKPT = "facebook/sam2.1-hiera-tiny"
+HD = 256  # memory-attention hidden (single head)
+PERM = np.concatenate([np.arange(0, HD, 2), np.arange(1, HD, 2)])
+
+
+def ohwi(w):  # torch conv OIHW -> TFLite OHWI
+    return w.permute(0, 2, 3, 1).contiguous()
+
+
+def t_ohwi(w):  # torch ConvTranspose2d IOHW -> [O,kh,kw,I]
+    return w.permute(1, 2, 3, 0).contiguous()
+
+
+def feedforward(dst, out, hf, prefix, mlx_prefix):
+    """Sam2VideoFeedForward(depth 3) -> layers.0/1/2 naming."""
+    out[f"{mlx_prefix}.layers.0.weight"] = hf[f"{prefix}.proj_in.weight"]
+    out[f"{mlx_prefix}.layers.0.bias"] = hf[f"{prefix}.proj_in.bias"]
+    out[f"{mlx_prefix}.layers.1.weight"] = hf[f"{prefix}.layers.0.weight"]
+    out[f"{mlx_prefix}.layers.1.bias"] = hf[f"{prefix}.layers.0.bias"]
+    out[f"{mlx_prefix}.layers.2.weight"] = hf[f"{prefix}.proj_out.weight"]
+    out[f"{mlx_prefix}.layers.2.bias"] = hf[f"{prefix}.proj_out.bias"]
+    del dst  # coverage bookkeeping happens on `hf` at the end
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="sam2_tiny_1024_video.safetensors")
+    ap.add_argument("--check_512", default="")
+    a = ap.parse_args()
+
+    model = Sam2VideoModel.from_pretrained(CKPT).eval()
+    hf = {k: v.detach().clone() for k, v in model.state_dict().items()}
+    used = set()
+
+    def take(key):
+        used.add(key)
+        return hf[key]
+
+    out = {}
+
+    # ---------------------------------------------------------------- trunk
+    backbone = model.vision_encoder.backbone
+    with torch.no_grad():
+        embedded = backbone.patch_embed(torch.randn(1, 3, 1024, 1024))
+        # _get_pos_embed returns a permuted VIEW; without .contiguous() the
+        # strided buffer round-trips scrambled through numpy(order='K') +
+        # safetensors (which writes the raw buffer). Found the hard way.
+        pos = backbone._get_pos_embed(embedded.shape[1:3]).detach().contiguous().clone()
+    assert pos.shape == (1, 256, 256, 96), pos.shape
+    out["trunk.pos_embed_full"] = pos
+    used.update({"vision_encoder.backbone.pos_embed",
+                 "vision_encoder.backbone.pos_embed_window"})
+    out["trunk.patch_embed.proj.weight"] = ohwi(
+        take("vision_encoder.backbone.patch_embed.projection.weight"))
+    out["trunk.patch_embed.proj.bias"] = take(
+        "vision_encoder.backbone.patch_embed.projection.bias")
+    n_blocks = sum(1 for k in hf if k.startswith("vision_encoder.backbone.blocks.")
+                   and k.endswith(".attn.qkv.weight"))
+    for i in range(n_blocks):
+        s = f"vision_encoder.backbone.blocks.{i}"
+        d = f"trunk.blocks.{i}"
+        out[f"{d}.norm1.weight"] = take(f"{s}.layer_norm1.weight")
+        out[f"{d}.norm1.bias"] = take(f"{s}.layer_norm1.bias")
+        out[f"{d}.norm2.weight"] = take(f"{s}.layer_norm2.weight")
+        out[f"{d}.norm2.bias"] = take(f"{s}.layer_norm2.bias")
+        for p in ("attn.qkv", "attn.proj"):
+            out[f"{d}.{p}.weight"] = take(f"{s}.{p}.weight")
+            out[f"{d}.{p}.bias"] = take(f"{s}.{p}.bias")
+        if f"{s}.proj.weight" in hf:
+            out[f"{d}.proj.weight"] = take(f"{s}.proj.weight")
+            out[f"{d}.proj.bias"] = take(f"{s}.proj.bias")
+        out[f"{d}.mlp.layers.0.weight"] = take(f"{s}.mlp.proj_in.weight")
+        out[f"{d}.mlp.layers.0.bias"] = take(f"{s}.mlp.proj_in.bias")
+        out[f"{d}.mlp.layers.1.weight"] = take(f"{s}.mlp.proj_out.weight")
+        out[f"{d}.mlp.layers.1.bias"] = take(f"{s}.mlp.proj_out.bias")
+
+    # ----------------------------------------------------------------- neck
+    for i in range(4):
+        out[f"neck.convs.{i}.weight"] = ohwi(
+            take(f"vision_encoder.neck.convs.{i}.weight"))
+        out[f"neck.convs.{i}.bias"] = take(f"vision_encoder.neck.convs.{i}.bias")
+    out["no_mem_embed"] = take("no_memory_embedding")
+
+    # ------------------------------------------------------- prompt encoder
+    out["sam_prompt_encoder.pe_layer.positional_encoding_gaussian_matrix"] = (
+        take("shared_image_embedding.positional_embedding"))
+    used.add("prompt_encoder.shared_embedding.positional_embedding")  # same tensor
+    point_embed = take("prompt_encoder.point_embed.weight")  # (4, 256) fused
+    for i in range(4):
+        out[f"sam_prompt_encoder.point_embeddings.{i}.weight"] = (
+            point_embed[i:i + 1].contiguous())
+    out["sam_prompt_encoder.not_a_point_embed.weight"] = take(
+        "prompt_encoder.not_a_point_embed.weight")
+    out["sam_prompt_encoder.no_mask_embed.weight"] = take(
+        "prompt_encoder.no_mask_embed.weight")
+
+    # --------------------------------------------------------- mask decoder
+    md = "mask_decoder"
+    smd = "sam_mask_decoder"
+    out[f"{smd}.conv_s0.weight"] = ohwi(take(f"{md}.conv_s0.weight"))
+    out[f"{smd}.conv_s0.bias"] = take(f"{md}.conv_s0.bias")
+    out[f"{smd}.conv_s1.weight"] = ohwi(take(f"{md}.conv_s1.weight"))
+    out[f"{smd}.conv_s1.bias"] = take(f"{md}.conv_s1.bias")
+    for tok in ("iou_token", "mask_tokens", "obj_score_token"):
+        out[f"{smd}.{tok}.weight"] = take(f"{md}.{tok}.weight")
+    for l in range(2):
+        s = f"{md}.transformer.layers.{l}"
+        d = f"{smd}.transformer.layers.{l}"
+        for attn in ("self_attn", "cross_attn_token_to_image",
+                     "cross_attn_image_to_token"):
+            for hp, p in (("q_proj", "q_proj"), ("k_proj", "k_proj"),
+                          ("v_proj", "v_proj"), ("o_proj", "out_proj")):
+                out[f"{d}.{attn}.{p}.weight"] = take(f"{s}.{attn}.{hp}.weight")
+                out[f"{d}.{attn}.{p}.bias"] = take(f"{s}.{attn}.{hp}.bias")
+        out[f"{d}.mlp.layers.0.weight"] = take(f"{s}.mlp.proj_in.weight")
+        out[f"{d}.mlp.layers.0.bias"] = take(f"{s}.mlp.proj_in.bias")
+        out[f"{d}.mlp.layers.1.weight"] = take(f"{s}.mlp.proj_out.weight")
+        out[f"{d}.mlp.layers.1.bias"] = take(f"{s}.mlp.proj_out.bias")
+        for n in range(1, 5):
+            out[f"{d}.norm{n}.weight"] = take(f"{s}.layer_norm{n}.weight")
+            out[f"{d}.norm{n}.bias"] = take(f"{s}.layer_norm{n}.bias")
+    for hp, p in (("q_proj", "q_proj"), ("k_proj", "k_proj"),
+                  ("v_proj", "v_proj"), ("o_proj", "out_proj")):
+        out[f"{smd}.transformer.final_attn_token_to_image.{p}.weight"] = take(
+            f"{md}.transformer.final_attn_token_to_image.{hp}.weight")
+        out[f"{smd}.transformer.final_attn_token_to_image.{p}.bias"] = take(
+            f"{md}.transformer.final_attn_token_to_image.{hp}.bias")
+    out[f"{smd}.transformer.norm_final_attn.weight"] = take(
+        f"{md}.transformer.layer_norm_final_attn.weight")
+    out[f"{smd}.transformer.norm_final_attn.bias"] = take(
+        f"{md}.transformer.layer_norm_final_attn.bias")
+    out[f"{smd}.output_upscaling_0.weight"] = t_ohwi(
+        take(f"{md}.upscale_conv1.weight"))
+    out[f"{smd}.output_upscaling_0.bias"] = take(f"{md}.upscale_conv1.bias")
+    out[f"{smd}.output_upscaling_1.weight"] = take(
+        f"{md}.upscale_layer_norm.weight")
+    out[f"{smd}.output_upscaling_1.bias"] = take(f"{md}.upscale_layer_norm.bias")
+    out[f"{smd}.output_upscaling_3.weight"] = t_ohwi(
+        take(f"{md}.upscale_conv2.weight"))
+    out[f"{smd}.output_upscaling_3.bias"] = take(f"{md}.upscale_conv2.bias")
+    for i in range(4):
+        feedforward(out, out, hf, f"{md}.output_hypernetworks_mlps.{i}",
+                    f"{smd}.output_hypernetworks_mlps.{i}")
+        used.update({f"{md}.output_hypernetworks_mlps.{i}.{t}" for t in
+                     ("proj_in.weight", "proj_in.bias", "layers.0.weight",
+                      "layers.0.bias", "proj_out.weight", "proj_out.bias")})
+    for head, mlx in (("iou_prediction_head", f"{smd}.iou_prediction_head"),
+                      ("pred_obj_score_head", f"{smd}.pred_obj_score_head")):
+        feedforward(out, out, hf, f"{md}.{head}", mlx)
+        used.update({f"{md}.{head}.{t}" for t in
+                     ("proj_in.weight", "proj_in.bias", "layers.0.weight",
+                      "layers.0.bias", "proj_out.weight", "proj_out.bias")})
+
+    # ----------------------------------------------------- memory attention
+    n_ma = sum(1 for k in hf if k.startswith("memory_attention.layers.")
+               and k.endswith(".self_attn.q_proj.weight"))
+    perm_t = torch.from_numpy(PERM)
+    for i in range(n_ma):
+        s = f"memory_attention.layers.{i}"
+        for attn in ("self_attn", "cross_attn_image"):
+            for p in ("q_proj", "k_proj"):  # PERM-permuted rows (RoPE bake)
+                out[f"{s}.{attn}.{p}.weight"] = take(
+                    f"{s}.{attn}.{p}.weight")[perm_t].contiguous()
+                out[f"{s}.{attn}.{p}.bias"] = take(
+                    f"{s}.{attn}.{p}.bias")[perm_t].contiguous()
+            out[f"{s}.{attn}.v_proj.weight"] = take(f"{s}.{attn}.v_proj.weight")
+            out[f"{s}.{attn}.v_proj.bias"] = take(f"{s}.{attn}.v_proj.bias")
+            out[f"{s}.{attn}.out_proj.weight"] = take(f"{s}.{attn}.o_proj.weight")
+            out[f"{s}.{attn}.out_proj.bias"] = take(f"{s}.{attn}.o_proj.bias")
+        for p in ("linear1", "linear2"):
+            out[f"{s}.{p}.weight"] = take(f"{s}.{p}.weight")
+            out[f"{s}.{p}.bias"] = take(f"{s}.{p}.bias")
+        for n in range(1, 4):
+            out[f"{s}.norm{n}.weight"] = take(f"{s}.layer_norm{n}.weight")
+            out[f"{s}.norm{n}.bias"] = take(f"{s}.layer_norm{n}.bias")
+    out["memory_attention.norm.weight"] = take("memory_attention.layer_norm.weight")
+    out["memory_attention.norm.bias"] = take("memory_attention.layer_norm.bias")
+
+    # ------------------------------------------------------- memory encoder
+    me = "memory_encoder"
+    for i in range(4):
+        out[f"{me}.mask_downsampler.conv{i}.weight"] = ohwi(
+            take(f"{me}.mask_downsampler.layers.{i}.conv.weight"))
+        out[f"{me}.mask_downsampler.conv{i}.bias"] = take(
+            f"{me}.mask_downsampler.layers.{i}.conv.bias")
+        out[f"{me}.mask_downsampler.norm{i}.weight"] = take(
+            f"{me}.mask_downsampler.layers.{i}.layer_norm.weight")
+        out[f"{me}.mask_downsampler.norm{i}.bias"] = take(
+            f"{me}.mask_downsampler.layers.{i}.layer_norm.bias")
+    out[f"{me}.mask_downsampler.conv4.weight"] = ohwi(
+        take(f"{me}.mask_downsampler.final_conv.weight"))
+    out[f"{me}.mask_downsampler.conv4.bias"] = take(
+        f"{me}.mask_downsampler.final_conv.bias")
+    out[f"{me}.pix_feat_proj.weight"] = ohwi(take(f"{me}.feature_projection.weight"))
+    out[f"{me}.pix_feat_proj.bias"] = take(f"{me}.feature_projection.bias")
+    for i in range(2):
+        s = f"{me}.memory_fuser.layers.{i}"
+        d = f"{me}.fuser.{i}"
+        out[f"{d}.dwconv.weight"] = ohwi(take(f"{s}.depthwise_conv.weight"))
+        out[f"{d}.dwconv.bias"] = take(f"{s}.depthwise_conv.bias")
+        out[f"{d}.norm.weight"] = take(f"{s}.layer_norm.weight")
+        out[f"{d}.norm.bias"] = take(f"{s}.layer_norm.bias")
+        out[f"{d}.pwconv1.weight"] = take(f"{s}.pointwise_conv1.weight")
+        out[f"{d}.pwconv1.bias"] = take(f"{s}.pointwise_conv1.bias")
+        out[f"{d}.pwconv2.weight"] = take(f"{s}.pointwise_conv2.weight")
+        out[f"{d}.pwconv2.bias"] = take(f"{s}.pointwise_conv2.bias")
+        out[f"{d}.gamma"] = take(f"{s}.scale")
+    out[f"{me}.out_proj.weight"] = ohwi(take(f"{me}.projection.weight"))
+    out[f"{me}.out_proj.bias"] = take(f"{me}.projection.bias")
+
+    # ---------------------------------------------------- video-path extras
+    out["maskmem_tpos_enc"] = take("memory_temporal_positional_encoding")
+    out["no_obj_ptr"] = take("no_object_pointer")
+    out["no_obj_embed_spatial"] = take("occlusion_spatial_embedding_parameter")
+    feedforward(out, out, hf, "object_pointer_proj", "obj_ptr_proj")
+    used.update({f"object_pointer_proj.{t}" for t in
+                 ("proj_in.weight", "proj_in.bias", "layers.0.weight",
+                  "layers.0.bias", "proj_out.weight", "proj_out.bias")})
+    out["obj_ptr_tpos_proj.weight"] = take(
+        "temporal_positional_encoding_projection_layer.weight")
+    out["obj_ptr_tpos_proj.bias"] = take(
+        "temporal_positional_encoding_projection_layer.bias")
+
+    # ---------------------------------------------------------------- tables
+    ma = model.memory_attention
+    cos = ma.rotary_emb.rope_embeddings_cos.detach().clone()  # (4096, 256)
+    sin = ma.rotary_emb.rope_embeddings_sin.detach().clone()
+    assert cos.shape == (4096, HD), cos.shape
+    assert torch.equal(cos[:, 0::2], cos[:, 1::2]), "expected pairwise-equal"
+
+    def deinterleave(c):
+        half = c[:, 0::2]
+        return torch.cat([half, half], dim=-1).contiguous()
+
+    out["tables.rope_cos"] = deinterleave(cos)
+    out["tables.rope_sin"] = deinterleave(sin)
+
+    # Sanity: permuted projections + rotate-half == original + pairwise RoPE.
+    def rotate_half(x):
+        return torch.cat([-x[..., HD // 2:], x[..., :HD // 2]], dim=-1)
+
+    def rotate_pairwise(x):
+        v = x.view(*x.shape[:-1], -1, 2)
+        return torch.stack((-v[..., 1], v[..., 0]), dim=-1).flatten(-2)
+
+    g = torch.Generator().manual_seed(0)
+    q = torch.randn(8, HD, generator=g)
+    k = torch.randn(8, HD, generator=g)
+    ref = ((q * cos[:8] + rotate_pairwise(q) * sin[:8]) @
+           (k * cos[:8] + rotate_pairwise(k) * sin[:8]).T)
+    qp, kp = q[:, PERM], k[:, PERM]
+    got = ((qp * out["tables.rope_cos"][:8] + rotate_half(qp) * out["tables.rope_sin"][:8]) @
+           (kp * out["tables.rope_cos"][:8] + rotate_half(kp) * out["tables.rope_sin"][:8]).T)
+    rope_err = (ref - got).abs().max().item()
+    assert rope_err < 1e-4, rope_err
+
+    with torch.no_grad():
+        ve = model.vision_encoder(torch.randn(1, 3, 1024, 1024), return_dict=True)
+        vision_pos = ve.fpn_position_encoding[-1].detach().clone()  # (1,256,64,64)
+        mem_pos = model.memory_encoder.position_encoding(
+            (1, 64, 64, 64), torch.device("cpu"), torch.float32).detach().clone()
+        ts, _ = model.prompt_encoder(
+            input_points=torch.zeros(1, 1, 1, 2),
+            input_labels=-torch.ones(1, 1, 1, dtype=torch.int32),
+            input_boxes=None, input_masks=None)
+    out["tables.vision_pos_scaled"] = (0.1 * vision_pos).reshape(
+        HD, 4096).T.contiguous()                       # (4096, 256) token-major
+    out["tables.mem_pos"] = mem_pos.reshape(64, 4096).T.contiguous()  # (4096,64)
+    out["tables.track_sparse"] = ts.reshape(2, HD).contiguous()
+
+    # ------------------------------------------------------- save + coverage
+    # ascontiguousarray: numpy astype(order='K') preserves permuted strides
+    # and safetensors then writes the raw buffer in the wrong order.
+    arrays = {k: np.ascontiguousarray(v.detach().numpy().astype(np.float32))
+              for k, v in out.items()}
+    for k, v in arrays.items():
+        assert v.flags["C_CONTIGUOUS"], k
+    save_file(arrays, a.out)
+    unused = sorted(k for k in hf if k not in used)
+    print(f"saved {a.out}: {len(arrays)} tensors "
+          f"({sum(v.nbytes for v in arrays.values()) / 1e6:.1f} MB fp32)")
+    print(f"rope bake check: max |q.k diff| = {rope_err:.2e}")
+    print(f"unused HF keys ({len(unused)}):")
+    for k in unused:
+        print("  ", k, tuple(hf[k].shape))
+
+    # ----------------------------------------------- cross-check vs 512 file
+    if a.check_512:
+        inv_perm = np.argsort(PERM)
+        bad, checked, skipped = [], 0, []
+        with safe_open(a.check_512, framework="np") as f:
+            keys512 = set(f.keys())
+            for key in sorted(keys512):
+                if key not in arrays:
+                    skipped.append(key)
+                    continue
+                if key == "trunk.pos_embed_full":  # different grid by design
+                    continue
+                ref16 = f.get_tensor(key)
+                mine = arrays[key]
+                if (key.startswith("memory_attention.layers.") and
+                        (".q_proj." in key or ".k_proj." in key)):
+                    mine = mine[inv_perm]  # stored permuted; undo for compare
+                if ref16.shape != mine.shape:
+                    bad.append((key, "shape", ref16.shape, mine.shape))
+                    continue
+                if not np.array_equal(mine.astype(np.float16), ref16):
+                    d = np.abs(mine - ref16.astype(np.float32)).max()
+                    bad.append((key, "value", float(d), None))
+                checked += 1
+        print(f"\n512-file cross-check: {checked} keys compared, "
+              f"{len(bad)} mismatches, {len(skipped)} keys only in 512 file")
+        for b in bad[:20]:
+            print("  MISMATCH", b)
+        for k in skipped:
+            print("  512-only:", k)
+        if bad:
+            raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/export_weights_1024.py
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/export_weights_1024.py
@@ -26,13 +26,16 @@ file, plus derived tables under "tables.":
   tables.track_sparse         [2,256] the sparse prompt used on non-prompted
                               tracking frames (label -1 "no point" encoding).
 
-All conv weights are permuted to the TFLite OHWI layout (depthwise stays
-per-channel-planes [C,kh,kw,1]; transposed convs to [O,kh,kw,I]).
+All conv weights are permuted to the TFLite filter layouts, so the C++ graphs
+consume every filter as stored: Conv2D to OHWI, depthwise (the memory-encoder
+fuser) to [1,kh,kw,C], ConvTranspose2d to [O,kh,kw,I].
 
 Cross-check: every key shared with the verified 512 file (which stores the
-same weights in fp16) must round-trip: fp16(exported) == stored fp16. The two
-expected exceptions are trunk.pos_embed_full (different grid by design) and
-the permuted memory-attention q/k rows (compared after inverse permutation).
+same weights in fp16) must round-trip: fp16(exported) == stored fp16. The
+expected exceptions are trunk.pos_embed_full (different grid by design), the
+permuted memory-attention q/k rows (compared after inverse permutation) and
+the depthwise filters (compared after transposing back to that file's
+[C,kh,kw,1]).
 
 Run (any venv with torch + transformers>=5 + safetensors + numpy):
   python export_weights_1024.py --out sam2_tiny_1024_video.safetensors \
@@ -56,6 +59,10 @@ def ohwi(w):  # torch conv OIHW -> TFLite OHWI
 
 
 def t_ohwi(w):  # torch ConvTranspose2d IOHW -> [O,kh,kw,I]
+    return w.permute(1, 2, 3, 0).contiguous()
+
+
+def dw_1hwc(w):  # torch depthwise [C,1,kh,kw] -> TFLite DepthwiseConv2D [1,kh,kw,C]
     return w.permute(1, 2, 3, 0).contiguous()
 
 
@@ -244,7 +251,7 @@ def main():
     for i in range(2):
         s = f"{me}.memory_fuser.layers.{i}"
         d = f"{me}.fuser.{i}"
-        out[f"{d}.dwconv.weight"] = ohwi(take(f"{s}.depthwise_conv.weight"))
+        out[f"{d}.dwconv.weight"] = dw_1hwc(take(f"{s}.depthwise_conv.weight"))
         out[f"{d}.dwconv.bias"] = take(f"{s}.depthwise_conv.bias")
         out[f"{d}.norm.weight"] = take(f"{s}.layer_norm.weight")
         out[f"{d}.norm.bias"] = take(f"{s}.layer_norm.bias")
@@ -349,6 +356,8 @@ def main():
                 if (key.startswith("memory_attention.layers.") and
                         (".q_proj." in key or ".k_proj." in key)):
                     mine = mine[inv_perm]  # stored permuted; undo for compare
+                if key.endswith(".dwconv.weight"):
+                    mine = mine.transpose(3, 1, 2, 0)  # [1,kh,kw,C] -> [C,kh,kw,1]
                 if ref16.shape != mine.shape:
                     bad.append((key, "shape", ref16.shape, mine.shape))
                     continue

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/mirror_encoder.py
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/mirror_encoder.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Torch mirror of sam2_graph.cc's encoder at 1024, block by block, compared
+against hooks on the HF video vision encoder. Finds WHERE the authored
+encoder diverges without rebuilding C++.
+
+  python mirror_encoder.py
+"""
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+WPATH = os.environ["SAM2V_WEIGHTS"]  # sam2_tiny_1024_video.safetensors
+CKPT = os.environ.get("SAM2_CKPT", "facebook/sam2.1-hiera-tiny")
+
+# Block specs mirroring Sam2Config::Blocks() at image_size=1024.
+STAGES = [1, 2, 7, 2]
+WINDOW_SPEC = [8, 4, 14, 7]
+GLOBAL_BLOCKS = {5, 7, 9}
+EMBED, HEADS, TOKEN_GRID = 96, 1, 256
+
+
+def block_specs():
+    ends, acc = [], 0
+    for s in STAGES:
+        acc += s
+        ends.append(acc - 1)
+    pool_blocks = {ends[i] + 1 for i in range(len(ends) - 1)}
+    specs = []
+    ed, nh, cur_stage, grid = EMBED, HEADS, 1, TOKEN_GRID
+    for i in range(sum(STAGES)):
+        dim_out = ed
+        ws = WINDOW_SPEC[cur_stage - 1]
+        if i in GLOBAL_BLOCKS:
+            ws = 0
+        if i > 0 and (i - 1) in ends:
+            dim_out, nh, cur_stage = ed * 2, nh * 2, cur_stage + 1
+        qs = 2 if i in pool_blocks else 0
+        grid_out = grid // qs if qs else grid
+        specs.append(dict(dim=ed, dim_out=dim_out, heads=nh, window=ws,
+                          q_stride=qs, grid_in=grid, grid_out=grid_out))
+        ed, grid = dim_out, grid_out
+    return specs
+
+
+class W:
+    def __init__(self, path):
+        self.f = safe_open(path, framework="pt")
+
+    def __call__(self, name):
+        return self.f.get_tensor(name).float()
+
+
+def layer_norm(x, w, b, eps=1e-6):
+    return F.layer_norm(x, (x.shape[-1],), w, b, eps)
+
+
+def window_partition(x, ws):
+    """[1,H,W,C] -> [nH*nW, ws, ws, C], split-H-then-W (my graph's form)."""
+    _, h, w, c = x.shape
+    ph, pw = (ws - h % ws) % ws, (ws - w % ws) % ws
+    if ph or pw:
+        x = F.pad(x, (0, 0, 0, pw, 0, ph))
+    hp, wp = h + ph, w + pw
+    nh, nw = hp // ws, wp // ws
+    t = x.reshape(nh, ws, wp, c).permute(0, 2, 1, 3)     # [nH, Wp, ws, C]
+    return t.reshape(nh * nw, ws, ws, c), nh, nw
+
+
+def window_unpartition(t, nh, nw, ws2, h, w, c):
+    t = t.reshape(nh, nw * ws2, ws2, c).permute(0, 2, 1, 3)
+    t = t.reshape(1, nh * ws2, nw * ws2, c)
+    return t[:, :h, :w, :]
+
+
+def mha(q, k, v, heads):
+    b, nq, c = q.shape
+    nk = k.shape[1]
+    hd = c // heads
+    q4 = q.reshape(b, nq, heads, hd).permute(0, 2, 1, 3)
+    k4 = k.reshape(b, nk, heads, hd).permute(0, 2, 1, 3)
+    v4 = v.reshape(b, nk, heads, hd).permute(0, 2, 1, 3)
+    a = torch.softmax(q4 @ k4.transpose(-1, -2) / hd**0.5, dim=-1)
+    return (a @ v4).permute(0, 2, 1, 3).reshape(b, nq, c)
+
+
+def block(x, spec, p, w):
+    dim, dim_out, h = spec["dim"], spec["dim_out"], spec["grid_in"]
+    shortcut = x
+    xn = layer_norm(x, w(p + ".norm1.weight"), w(p + ".norm1.bias"))
+    if dim != dim_out:
+        shortcut = xn @ w(p + ".proj.weight").T + w(p + ".proj.bias")
+        if spec["q_stride"]:
+            shortcut = F.max_pool2d(shortcut.permute(0, 3, 1, 2), 2).permute(
+                0, 2, 3, 1)
+    tokens, nh, nw, batch, n, win = xn, 1, 1, 1, h * h, spec["window"]
+    if win:
+        tokens, nh, nw = window_partition(tokens, win)
+        batch, n = nh * nw, win * win
+    tokens = tokens.reshape(batch, n, dim)
+    qkv = tokens @ w(p + ".attn.qkv.weight").T + w(p + ".attn.qkv.bias")
+    q, k, v = qkv[..., :dim_out], qkv[..., dim_out:2 * dim_out], qkv[..., 2 * dim_out:]
+    nq = n
+    if spec["q_stride"]:
+        side = win if win else h
+        q = q.reshape(batch, side, side, dim_out)
+        q = F.max_pool2d(q.permute(0, 3, 1, 2), 2).permute(0, 2, 3, 1)
+        side2 = side // 2
+        nq = side2 * side2
+        q = q.reshape(batch, nq, dim_out)
+    attn = mha(q, k, v, spec["heads"])
+    attn = attn @ w(p + ".attn.proj.weight").T + w(p + ".attn.proj.bias")
+    go = spec["grid_out"]
+    if win:
+        ws2 = win // 2 if spec["q_stride"] else win
+        attn = attn.reshape(batch, ws2, ws2, dim_out)
+        attn = window_unpartition(attn, nh, nw, ws2, go, go, dim_out)
+    else:
+        attn = attn.reshape(1, go, go, dim_out)
+    merged = shortcut + attn
+    m = layer_norm(merged, w(p + ".norm2.weight"), w(p + ".norm2.bias"))
+    m = F.gelu(m @ w(p + ".mlp.layers.0.weight").T + w(p + ".mlp.layers.0.bias"))
+    m = m @ w(p + ".mlp.layers.1.weight").T + w(p + ".mlp.layers.1.bias")
+    return merged + m
+
+
+def corr(a, b):
+    a = a.detach().reshape(-1).double().numpy()
+    b = b.detach().reshape(-1).double().numpy()
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def main():
+    import sys
+    sys.path.insert(0, HERE)
+    from verify_video_1024 import frame
+    from transformers import Sam2VideoModel
+
+    w = W(WPATH)
+    model = Sam2VideoModel.from_pretrained(CKPT).eval()
+    backbone = model.vision_encoder.backbone
+
+    hooks = {}
+    for i, blk in enumerate(backbone.blocks):
+        blk.register_forward_hook(
+            lambda mod, args, out, i=i: hooks.__setitem__(i, (args[0].detach(),
+                                                              out.detach())))
+    px = torch.from_numpy(frame(3))
+    with torch.no_grad():
+        ve = model.vision_encoder(px, return_dict=True)
+
+    # --- my patch embed + pos ---
+    with torch.no_grad():
+        x = F.pad(px.permute(0, 2, 3, 1), (0, 0, 3, 3, 3, 3))       # NHWC pad3
+        pw = w("trunk.patch_embed.proj.weight")                      # [96,7,7,3]
+        x = F.conv2d(x.permute(0, 3, 1, 2), pw.permute(0, 3, 1, 2),
+                     w("trunk.patch_embed.proj.bias"), stride=4)
+        x = x.permute(0, 2, 3, 1)                                    # [1,256,256,96]
+        pos = w("trunk.pos_embed_full")
+        print("block0 input corr (patch+pos vs HF):",
+              corr(x + pos, hooks[0][0]),
+              " patch-only corr:", corr(x, hooks[0][0]))
+        x = x + pos
+        specs = block_specs()
+        for i, spec in enumerate(specs):
+            x = block(x, spec, f"trunk.blocks.{i}", w)
+            ref = hooks[i][1]
+            print(f"block {i:2d} (dim{spec['dim']}->{spec['dim_out']} "
+                  f"win{spec['window']:2d} qs{spec['q_stride']} "
+                  f"grid{spec['grid_in']}->{spec['grid_out']}): "
+                  f"out corr={corr(x, ref):.6f} "
+                  f"max|d|={float((x - ref).abs().max()):.5f} "
+                  f"shapes {tuple(x.shape)} vs {tuple(ref.shape)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/probe_graphs.py
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/probe_graphs.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Per-graph isolation probe: run each Tensor API signature on inputs captured
+from the HF modules themselves, so each graph is judged independently of the
+chain. Requires the serialized model from sam2v_main (default
+/tmp/sam2_video.tflite, built with REAL weights).
+
+  python probe_graphs.py [--tflite /tmp/sam2_video.tflite] [--frame 3]
+
+Prints per-graph corr / max|d|:
+  encode    my encoder vs HF raw fpn features (pix_raw / hi0 / hi1)
+  decode    my decoder on HF's OWN pix_feat/hi-res/sparse vs HF decoder output
+  memorize  my memory encoder on HF's OWN pix_feat + mask_for_mem vs HF output
+  memcond   my memory attention on HF's OWN bank vs HF memory-attention output
+"""
+import argparse
+import os
+
+import numpy as np
+import torch
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.abspath(os.environ.get("SAM2V_OUT", HERE + "/out"))
+CKPT = os.environ.get("SAM2_CKPT", "facebook/sam2.1-hiera-tiny")
+SIZE, HW, MEMCH, HD = 1024, 4096, 64, 256
+CLICK = (400.0, 512.0)
+
+
+def corr(a, b):
+    a, b = np.ravel(a).astype(np.float64), np.ravel(b).astype(np.float64)
+    if a.std() == 0 or b.std() == 0:
+        return float("nan")
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def report(name, mine, ref):
+    mine, ref = np.asarray(mine, np.float32), np.asarray(ref, np.float32)
+    d = np.abs(mine - ref)
+    print(f"  {name:24s} corr={corr(mine, ref):.6f} max|d|={d.max():.5f} "
+          f"mean|d|={d.mean():.6f} ref_absmax={np.abs(ref).max():.3f}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tflite", default="/tmp/sam2_video.tflite")
+    ap.add_argument("--frame", type=int, default=3)
+    a = ap.parse_args()
+
+    import sys
+    sys.path.insert(0, HERE)
+    from verify_video_1024 import frame
+    from transformers import Sam2VideoModel, Sam2VideoInferenceSession
+
+    model = Sam2VideoModel.from_pretrained(CKPT).eval()
+    cap = {}
+
+    def grab(name):
+        def hook(mod, args, kwargs, out):
+            cap[name] = (args, kwargs, out)
+        return hook
+
+    model.memory_attention.register_forward_hook(grab("ma"), with_kwargs=True)
+    model.memory_encoder.register_forward_hook(grab("me"), with_kwargs=True)
+    model.mask_decoder.register_forward_hook(grab("dec"), with_kwargs=True)
+
+    sess = Sam2VideoInferenceSession(video_height=SIZE, video_width=SIZE,
+                                     dtype=torch.float32)
+    oi = sess.obj_id_to_idx(1)
+    sess.add_point_inputs(oi, 0, {
+        "point_coords": torch.tensor([[[[CLICK[0], CLICK[1]]]]]),
+        "point_labels": torch.tensor([[[1]]])})
+    sess.obj_with_new_inputs = [1]
+    with torch.no_grad():
+        for t in range(a.frame + 1):
+            model(inference_session=sess, frame=torch.from_numpy(frame(t)))
+            if t == a.frame - 1 or (a.frame == 0 and t == 0):
+                pass
+        # captures now hold frame a.frame's module calls
+
+    # Raw vision features for the probe frame.
+    with torch.no_grad():
+        img = model.get_image_features(
+            torch.from_numpy(frame(a.frame)), return_dict=True)
+        fpn = img.fpn_hidden_states  # raw, no no_mem
+    hf_pix_raw = fpn[2][:, 0, :].numpy().reshape(64, 64, HD)  # seq-first -> HWC
+    print("fpn shapes:", [tuple(f.shape) for f in fpn])
+
+    from ai_edge_litert.interpreter import Interpreter
+    interp = Interpreter(model_path=a.tflite, num_threads=8)
+    runners = {s: interp.get_signature_runner(s)
+               for s in interp.get_signature_list()}
+    print("signatures:", list(interp.get_signature_list()))
+
+    # ---------------- encode ----------------
+    px = frame(a.frame)[0].transpose(1, 2, 0)[None]  # NHWC
+    enc = runners["encode"](pixels=px.astype(np.float32))
+    # outputs by name
+    pix_raw_m = enc["pix_raw"]          # [1,64,64,256]
+    s1_m = enc["feat_s1"]               # [1,128,128,64]
+    s0_m = enc["feat_s0"]               # [1,256,256,32]
+    print(f"[encode] frame {a.frame}")
+    report("pix_raw", pix_raw_m[0], hf_pix_raw)
+    # hi-res skips: HF applies conv_s0/s1 inside... capture from decoder call
+    dec_args, dec_kwargs, dec_out = cap["dec"]
+    hf_hi = dec_kwargs["high_resolution_features"]
+    report("feat_s0", s0_m[0], hf_hi[0][0].numpy().transpose(1, 2, 0))
+    report("feat_s1", s1_m[0], hf_hi[1][0].numpy().transpose(1, 2, 0))
+
+    # ---------------- decode (HF inputs) ----------------
+    hf_img_emb = dec_kwargs["image_embeddings"]         # [1,256,64,64] = pix_feat + dense? no: raw pix_feat
+    hf_sparse = dec_kwargs["sparse_prompt_embeddings"]  # [1,1,2,256]
+    hf_dense = dec_kwargs["dense_prompt_embeddings"]
+    print("decoder input shapes:", tuple(hf_img_emb.shape), tuple(hf_sparse.shape),
+          tuple(hf_dense.shape))
+    dec_m = runners["decode"](
+        pix_feat_in=hf_img_emb[0].numpy().transpose(1, 2, 0)[None].astype(np.float32),
+        feat_s1=hf_hi[1][0].numpy().transpose(1, 2, 0)[None].astype(np.float32),
+        feat_s0=hf_hi[0][0].numpy().transpose(1, 2, 0)[None].astype(np.float32),
+        sparse=hf_sparse[0, 0].numpy()[None].astype(np.float32),
+        nomem=np.zeros((1, 1, 1, 1), np.float32))  # HF pix_feat already conditioned
+    masks_hf, iou_hf, tok_hf, obj_hf = dec_out
+    print(f"[decode] on HF inputs (multimask slice 1:)")
+    report("masks(1:4)", dec_m["masks"][0, 1:], masks_hf[0, 0].numpy())
+    report("iou(1:4)", dec_m["iou_scores"][0, 1:], iou_hf[0, 0].numpy())
+    report("object_score", dec_m["object_score"][0], obj_hf[0, 0].numpy())
+
+    # ---------------- memorize (HF inputs) ----------------
+    me_args, me_kwargs, me_out = cap["me"]
+    hf_me_pix = me_args[0] if me_args else me_kwargs["vision_features"]
+    hf_me_mask = me_args[1] if len(me_args) > 1 else me_kwargs["masks"]
+    hf_mem = me_out[0]
+    print("memorize input shapes:", tuple(hf_me_pix.shape), tuple(hf_me_mask.shape))
+    mem_m = runners["memorize"](
+        pix_raw=hf_me_pix[0].numpy().transpose(1, 2, 0)[None].astype(np.float32),
+        mask_for_mem=hf_me_mask[0].numpy().transpose(1, 2, 0)[None].astype(np.float32),
+        occ=np.zeros((1, 1, 1), np.float32))
+    print(f"[memorize] on HF inputs")
+    report("mem", mem_m["mem"][0],
+           hf_mem[0].numpy().reshape(MEMCH, HW).T)
+
+    # ---------------- memcond (HF inputs) ----------------
+    ma_args, ma_kwargs, ma_out = cap["ma"]
+    cur = ma_kwargs["current_vision_features"]        # (HW, B, C)
+    mem_in = ma_kwargs["memory"]                       # (L, B, 64)
+    mem_pos = ma_kwargs["memory_posision_embeddings"]  # (L, B, 64)
+    nptr = ma_kwargs["num_object_pointer_tokens"]
+    L = mem_in.shape[0]
+    n_spatial = (L - nptr) // HW
+    print(f"memcond: L={L} nptr={nptr} spatial_slots={n_spatial}")
+    nmm = 7
+    sig = "memcond7"
+    hw_tokens = cur[:, 0, :].numpy()                   # (HW, C)
+    mem_bank = np.zeros((1, nmm, HW, MEMCH), np.float32)
+    slot_tpe = np.zeros((1, nmm, 1, MEMCH), np.float32)
+    ptr_tok = np.zeros((1, 1, 64, MEMCH), np.float32)
+    ptr_pos = np.zeros((1, 1, 64, MEMCH), np.float32)
+    km = np.full((1, 1, 1, nmm * HW + 64), -1e9, np.float32)
+    spatial = mem_in[:L - nptr, 0, :].numpy().reshape(n_spatial, HW, MEMCH)
+    spatial_pos = mem_pos[:L - nptr, 0, :].numpy().reshape(n_spatial, HW, MEMCH)
+    # my graph adds baked mem_pos + slot_tpe; HF pos = mem_pos_grid + tpe row.
+    # Recover the per-slot tpe row: spatial_pos - baked grid (constant per slot).
+    from safetensors import safe_open
+    wpath = os.environ["SAM2V_WEIGHTS"]  # sam2_tiny_1024_video.safetensors
+    with safe_open(wpath, framework="np") as f:
+        grid = f.get_tensor("tables.mem_pos")          # (HW, 64)
+    for s in range(n_spatial):
+        mem_bank[0, s] = spatial[s]
+        tpe = spatial_pos[s] - grid
+        slot_tpe[0, s, 0] = tpe.mean(axis=0)
+        print(f"    slot {s}: tpe row std over tokens = {tpe.std(axis=0).max():.2e}")
+        km[0, 0, 0, s * HW:(s + 1) * HW] = 0
+    ptrs = mem_in[L - nptr:, 0, :].numpy()
+    ptrs_pos = mem_pos[L - nptr:, 0, :].numpy()
+    ptr_tok[0, 0, :nptr] = ptrs
+    ptr_pos[0, 0, :nptr] = ptrs_pos
+    km[0, 0, 0, nmm * HW:nmm * HW + nptr] = 0
+    mc = runners[sig](
+        pix_raw=hw_tokens.reshape(1, 64, 64, HD).astype(np.float32),
+        mem_bank=mem_bank, slot_tpe=slot_tpe, ptr_tok=ptr_tok,
+        ptr_pos=ptr_pos, key_mask=km)
+    hf_pf = ma_out[0].numpy()  # shape?
+    print("ma out shape:", tuple(ma_out.shape) if hasattr(ma_out, "shape")
+          else [tuple(o.shape) for o in ma_out])
+    pf_ref = np.asarray(hf_pf).reshape(-1)
+    pf_mine = mc["pix_feat"].reshape(-1)
+    if pf_ref.size == pf_mine.size:
+        # HF returns (HW, B, C) seq-first -> token-major already
+        report("pix_feat", pf_mine, pf_ref)
+    else:
+        print("  pix_feat size mismatch", pf_mine.size, pf_ref.size)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/verify_video_1024.py
+++ b/models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video/verify/verify_video_1024.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Parity check for the Tensor API SAM2 video path vs the HF streaming
+reference, at the model-native 1024x1024.
+
+Modes (run in this order):
+
+  python verify_video_1024.py clip                # write frames.f32 (T,1024,1024,3)
+  python verify_video_1024.py ref                 # HF streaming run -> ref_nmm{7,2}.npz
+  python verify_video_1024.py compare --dump_dir <dir> --nmm 7
+                                                  # compare sam2v_main --dump_dir output
+
+Synthetic clip: a white disk moving diagonally on black, T frames, one
+positive click on the disk in frame 0 — the same fixture as the converted-
+path reference (litert-samples #283 lineage), so results are comparable.
+
+The HF reference capture matches the graph boundary exactly:
+  mask     low-res (256,256) logits after best-mask/no-object handling
+  obj      object score logit
+  ptr      the stored object pointer (256)
+  mem      memory encoder output, token-major (4096,64), fp32 pre-bfloat16,
+           with the occlusion embedding added when obj <= 0 (HF adds it
+           outside the encoder)
+  pix_feat memory-attention output, token-major flat (4096*256), tracked
+           frames only
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.abspath(os.environ.get("SAM2V_OUT", HERE + "/out"))
+CKPT = os.environ.get("SAM2_CKPT", "facebook/sam2.1-hiera-tiny")
+T = int(os.environ.get("SAM2_T", "10"))
+SIZE = 1024
+HW, MEMCH, HD = 4096, 64, 256
+CLICK = (400.0, 512.0)
+MEAN = np.array([0.485, 0.456, 0.406])
+STD = np.array([0.229, 0.224, 0.225])
+
+
+def frame(t):
+    """Normalized NCHW float32 frame t (disk moves (+14,+6) px/frame in 512-space)."""
+    from PIL import Image, ImageDraw
+    img = Image.new("RGB", (512, 512), "black")
+    cx, cy, r = 200 + 14 * t, 256 + 6 * t, 100
+    ImageDraw.Draw(img).ellipse([cx - r, cy - r, cx + r, cy + r], fill="white")
+    arr = np.asarray(img.resize((SIZE, SIZE), Image.BILINEAR)).astype(np.float32) / 255.0
+    return ((arr - MEAN) / STD).transpose(2, 0, 1)[None].astype(np.float32)
+
+
+def write_clip():
+    frames = np.stack([frame(t)[0].transpose(1, 2, 0) for t in range(T)])  # NHWC
+    path = f"{OUT}/frames.f32"
+    frames.astype(np.float32).tofile(path)
+    print(f"wrote {path}: {frames.shape} NHWC float32")
+
+
+def reference(nmm):
+    import torch
+    from transformers import Sam2VideoModel, Sam2VideoInferenceSession
+    model = Sam2VideoModel.from_pretrained(CKPT).eval()
+    model.num_maskmem = nmm
+    cap = {}
+    model.memory_attention.register_forward_hook(
+        lambda m, a, o: cap.__setitem__("pix_feat", o.detach().clone()))
+    model.memory_encoder.register_forward_hook(
+        lambda m, a, o: cap.__setitem__("mem", o[0].detach().clone()))
+    sess = Sam2VideoInferenceSession(video_height=SIZE, video_width=SIZE,
+                                     dtype=torch.float32)
+    oi = sess.obj_id_to_idx(1)
+    sess.add_point_inputs(oi, 0, {
+        "point_coords": torch.tensor([[[[CLICK[0], CLICK[1]]]]]),
+        "point_labels": torch.tensor([[[1]]])})
+    sess.obj_with_new_inputs = [1]
+    masks, objs, ptrs, mems, pfs = [], [], [], [], []
+    with torch.no_grad():
+        for t in range(T):
+            cap.clear()
+            out = model(inference_session=sess, frame=torch.from_numpy(frame(t)))
+            masks.append(out.pred_masks.numpy().reshape(256, 256))
+            objs.append(float(out.object_score_logits.reshape(-1)[0]))
+            store = "cond_frame_outputs" if t == 0 else "non_cond_frame_outputs"
+            ptrs.append(sess.output_dict_per_obj[oi][store][t][
+                "object_pointer"].numpy().reshape(256))
+            mem_t = cap["mem"].numpy().reshape(MEMCH, HW).T.copy()
+            if objs[-1] <= 0:
+                mem_t = mem_t + model.occlusion_spatial_embedding_parameter.detach(
+                ).numpy().reshape(1, 64)
+            mems.append(mem_t)
+            pfs.append(np.zeros((HW * HD,), np.float32) if t == 0 else
+                       cap["pix_feat"].numpy().reshape(HW, HD).T.reshape(-1).copy())
+            print(f"ref nmm={nmm} frame {t}: fg={(masks[-1] > 0).sum()} "
+                  f"obj={objs[-1]:.3f}", flush=True)
+    np.savez_compressed(f"{OUT}/ref_nmm{nmm}.npz", mask=np.stack(masks),
+                        obj=np.array(objs), ptr=np.stack(ptrs),
+                        mem=np.stack(mems), pix_feat=np.stack(pfs))
+
+
+def iou(a, b):
+    u = np.logical_or(a, b).sum()
+    return float(np.logical_and(a, b).sum() / u) if u else 1.0
+
+
+def corr(a, b):
+    a, b = a.ravel().astype(np.float64), b.ravel().astype(np.float64)
+    if a.std() == 0 or b.std() == 0:
+        return float("nan")
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def compare(dump_dir, nmm, tag):
+    ref = np.load(f"{OUT}/ref_nmm{nmm}.npz")
+    n = ref["mask"].shape[0]
+    worst = dict(iou=1.0, corr=1.0, dmask=0.0, dpf=0.0, dmem=0.0, dptr=0.0)
+    lines = []
+    # HF pix_feat capture is seq-first (HW,HD) -> stored as (HD,HW) flat; the
+    # graph emits token-major (HW,HD). Compare in one common layout.
+    for t in range(n):
+        p = f"{dump_dir}/f{t:02d}"
+        m = np.fromfile(f"{p}_mask.f32", np.float32).reshape(256, 256)
+        obj = float(np.fromfile(f"{p}_obj.f32", np.float32)[0])
+        ptr = np.fromfile(f"{p}_ptr.f32", np.float32)
+        mem = np.fromfile(f"{p}_mem.f32", np.float32).reshape(HW, MEMCH)
+        rm = ref["mask"][t]
+        r = dict(iou=iou(rm > 0, m > 0), corr=corr(rm, m),
+                 dmask=float(np.abs(rm - m).max()),
+                 dobj=abs(float(ref["obj"][t]) - obj),
+                 dptr=float(np.abs(ref["ptr"][t] - ptr).max()),
+                 dmem=float(np.abs(ref["mem"][t] - mem).max()),
+                 cmem=corr(ref["mem"][t], mem))
+        if t == 0:
+            r["dpf"], r["cpf"] = 0.0, 1.0
+        else:
+            pf = np.fromfile(f"{p}_pixfeat.f32", np.float32)  # (HW,HD) token-major
+            rpf = ref["pix_feat"][t].reshape(HD, HW).T.ravel()
+            r["dpf"] = float(np.abs(rpf - pf).max())
+            r["cpf"] = corr(rpf, pf)
+        lines.append(
+            f"  f{t:02d} fg={int((m > 0).sum()):6d}/{int((rm > 0).sum()):6d} "
+            f"IoU={r['iou']:.4f} corr={r['corr']:.5f} "
+            f"max|dmask|={r['dmask']:.3f} |dobj|={r['dobj']:.3f} "
+            f"pix_feat corr={r['cpf']:.5f} max|d|={r['dpf']:.4f} "
+            f"mem corr={r['cmem']:.5f} max|d|={r['dmem']:.4f} "
+            f"|dptr|={r['dptr']:.4f}")
+        worst["iou"] = min(worst["iou"], r["iou"])
+        worst["corr"] = min(worst["corr"], r["corr"])
+        for k in ("dmask", "dpf", "dmem", "dptr"):
+            worst[k] = max(worst[k], r[k])
+    head = (f"[{tag}] nmm={nmm} T={n}: min IoU={worst['iou']:.4f} "
+            f"min corr={worst['corr']:.5f} max|dmask|={worst['dmask']:.3f} "
+            f"max|dpix_feat|={worst['dpf']:.4f} max|dmem|={worst['dmem']:.4f} "
+            f"max|dptr|={worst['dptr']:.4f}")
+    print(head)
+    print("\n".join(lines))
+    with open(f"{OUT}/parity_{tag}_nmm{nmm}.log", "w") as f:
+        f.write(head + "\n" + "\n".join(lines) + "\n")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("mode", choices=["clip", "ref", "compare"])
+    ap.add_argument("--nmm", type=int, default=7)
+    ap.add_argument("--dump_dir", default="")
+    ap.add_argument("--tag", default="tensorapi")
+    a = ap.parse_args()
+    os.makedirs(OUT, exist_ok=True)
+    if a.mode == "clip":
+        write_clip()
+    elif a.mode == "ref":
+        assert "convert_sam2_video" not in sys.modules
+        reference(a.nmm)
+    else:
+        compare(a.dump_dir, a.nmm, a.tag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Thanks, Ping, for the go-ahead in the "the C++ Tensor API" doc thread — "we could use it for some of examples and blogs". This is the SAM 2.1 Hiera-Tiny video-tracking stack authored with the C++ Tensor API, at `models/sam2/sam2_hiera_tiny_video/tensor_api/`, in the same layout as the Qwen3-TTS suite (#241). No weights are included, and nothing here is time-sensitive; happy to reshape any of it to your conventions.

**What this adds**

- `sam2_video/` — the video stack as five signatures in one flatbuffer sharing weights: `encode` (Hiera at the native 1024, raw top-level features plus the two high-res skips), `memcond7` / `memcond2` (memory attention over a fixed bank of 7 or 2 spatial memory slots + 64 object-pointer tokens, unused entries masked additively), `decode` (video mask decoder: all four mask tokens, IoU scores, object pointers, object score), `memorize` (mask downsampler + ConvNeXt fuser memory encoder). Alongside: the weight loader and the host tracking loop (`sam2v_main.cc`), which mirrors the numpy specification in `verify/verify_video_1024.py`.
- `sam2_image/` — the image-path library the video graphs build on (Hiera encoder, in-graph prompt encoder, mask decoder), plus its standalone 512 sample and PyTorch parity script.
- `sam2_video/verify/` — fp32 weight export from `facebook/sam2.1-hiera-tiny` (conv layouts pre-permuted, RoPE bake self-checked in-run), the `transformers` `Sam2VideoModel` streaming reference, per-frame compare, per-signature isolation probes, and a block-by-block encoder mirror.
- No new op class anywhere: SAM 2's pairwise-interleaved RoPE becomes the rotate-half form by permuting the q/k projection rows at weight export (q'·k' == q·k exactly), with the cos/sin tables baked as constants.

**Verification**

- Chained 10-frame clip vs the HF streaming reference: min mask-IoU 1.0000 on CPU fp32 and Metal fp32 (both bank sizes), 0.9950 at Metal fp16.
- M4 Max Metal fp16, per tracked frame end to end (host loop included): 94 ms with the 7-slot bank, 64 ms with 2 slots. Per-graph breakdown and the fp32 / CPU numbers are in the README.
- Validated at LiteRT `a19d8fa` + the PR #8796 runner change.

**Build**

BUILD files target this repository's `@litert_archive` workspace in the same form as #241 (no `litert_api_with_dynamic_runtime`). From the repo root:

```
bazel build --config=macos_arm64 //models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_video:sam2v_main
bazel build --config=macos_arm64 //models/sam2/sam2_hiera_tiny_video/tensor_api/sam2_image:sam2_main
```

The numbers above come from the same sources built as a `tensor/examples/` overlay in a LiteRT checkout. In this workspace the dependency closure of both binaries resolves under `bazel query`; a `--config=macos_arm64` build stops in analysis at the apple_support crosstool target (the `.bazelrc.user` issue noted on #241, still present on `main`), so the compile in this workspace is not exercised on my side. If anything drifts against current `main`, tell me and I will chase it.

**Relation to #283**

#283 adds the parent directory's README and the `converted/` recipe (the litert-torch export of the same four per-frame graphs). This PR adds only `tensor_api/`; the file sets are disjoint, so the two merge in either order. The README here names `converted/` as its companion.

**Provenance**

Sources are the same as [john-rocky/litert-tensor-vision-examples](https://github.com/john-rocky/litert-tensor-vision-examples) (`sam2_video/`, `sam2_image/`), adapted to this layout; the findings ledger stays there. The memory bank rides host-side as per-frame signature I/O; moving it in-graph as signature state (`odml.cache_update` + the #8796 feedback-loop runner) is the intended next step, and the README records what blocks it on Metal today.

Happy to add whatever an example or a blog post needs — a shorter walkthrough, figures, a trimmed sample — and to adjust placement or naming to whatever fits the repo best. Thanks again for the pointers through this thread; they are what let the video stack drop in cleanly.
