### PR TITLE
Add op-level GPU divergence bisect to litert_gpu_toolkit checker

### DIFF
--- a/utilities/litert_gpu_toolkit/README.md
+++ b/utilities/litert_gpu_toolkit/README.md
@@ -29,9 +29,254 @@ signature on random inputs, and compares the outputs against a CPU-compiled
 reference (`rtol`/`atol` default to 1e-2 — fp16 accumulation on GPU makes
 bit-exactness unrealistic). When GPU compilation fails, the runtime's error
 names the offending op; the patches table below maps the common ones to the
-rewrite that clears them. Use it as a gate before spending a device run — it
-exercises the host GPU, so still compare on-device output against CPU before
-shipping.
+rewrite that clears them. When compilation succeeds and the numbers are still
+wrong, nothing names an op — `bisect_gpu_divergence` does (next section).
+Use both as a gate before spending a device run — they exercise the host GPU,
+so still compare on-device output against CPU before shipping.
+
+The checker needs no torch. On any `.tflite`:
+
+```sh
+python checker.py model.tflite                 # verify every signature
+python checker.py model.tflite --bisect        # and name the first wrong op
+python checker.py model.tflite --bisect --enforce-f32 --uniform --int-high 1000 --json out.json
+```
+
+`--uniform` draws float inputs from [0, 1) instead of N(0, 1) (image models;
+the fp16 reduction overflow of #9249 only shows on non-negative input), and
+`--int-high N` gives integer inputs random ids in [0, N) instead of zeros
+(a token model fed all zeros returns the same vector on every backend, so
+the comparison is vacuous). `--inputs file.npz` runs your own arrays.
+
+## Finding the op the GPU gets wrong
+
+A GPU silent miscompute looks like this: the graph compiles, reports full
+residency, runs without error, and returns wrong numbers. The runtime has no
+diagnostic for it. Every such bug we have reported against LiteRT
+(#8593, #8599, #8619, #9249, #9272, and the LiteRT.js pair #9661/#9662) was
+found the same way by hand: promote intermediate tensors to graph outputs,
+compare GPU against CPU, walk forward until the first tensor that disagrees.
+`bisect_gpu_divergence` is that procedure, automated. When the GPU compile
+itself fails, the checker now also carries the runtime's own reason into the
+result (the rejected op, or the kernel it could not create), which the
+Python exception alone does not.
+
+**How it works.** The graph is cut after op *k*: the prefix keeps ops
+0..*k*, and every tensor still live at the cut (consumed later, or a graph
+output, or produced by op *k*) becomes a graph output. The prefix is written
+as a new `.tflite` (the flatbuffer utilities in the `ai-edge-litert` wheel;
+weights are shared, not copied), compiled on CPU and on GPU with the same
+inputs, and the live tensors are compared. Binary search over *k* finds the
+first cut whose tensors disagree; the op at that cut is the first op the GPU
+gets wrong. A 276-op graph takes 9 prefix compiles; a 1031-op graph 11.
+Weight-only ops (a `DEQUANTIZE` of a constant) are never cut points and their
+outputs are never compared.
+
+One detail keeps the method honest. A frontier tensor that an op inside the
+prefix also consumes is exposed through a same-shape `RESHAPE` copy, not
+directly: made a graph output as-is it would form the "output that is also
+consumed" pattern of #8599, which the Metal accelerator gets wrong on its own
+(an `ADD` output read by a `SUM` comes back off by 3.85 at both precisions on
+2.2.0, exact through the copy), and the bisect would report a divergence it
+had caused. Tensors that were graph outputs in the original model keep their
+native wiring, so a shipped #8599 case is still seen — as a divergence at the
+cut that appends the consumer, with the producer's tensor marked
+`context_dependent`. Both cases are pinned by tests. The difference is not
+academic: without the copy, the rank-4 SAM 2.1 mask decoder export (correct
+at fp32) reported a 100 % divergence at a `FULLY_CONNECTED` at fp16; with
+it, the same run reports 2 % fp16 noise two ops later.
+
+**What counts as wrong.** Intermediate tensors on a fp16 GPU carry errors of
+about `rtol × (partial-sum magnitude)`, and an elementwise `allclose` flags
+those on a correct kernel — efficientnet_b0's first `CONV_2D` fails
+elementwise 1e-2 on Metal while the real fault is eight ops later. So the
+default criterion is tensor-scale: a tensor diverges when its worst element
+differs by more than `atol + rtol × max|cpu|`. When the full graph returns
+NaN/Inf, the criterion switches to non-finite (`criterion="auto"`), because
+an overflow poisons every op downstream and the first NaN is the fault. Both
+can be overridden (`scale` / `nonfinite` / `elementwise`).
+
+**What the result can and cannot claim.** It names the op at which the
+divergence is *first observed*: the prefix ending one op earlier matched
+CPU. Later ops are not examined, and a graph may hold more than one wrong op
+(the SAM 2.1 mask decoder below holds three of the same kind). If the
+diverging tensor was produced by an earlier op — it was correct while it was
+the end of the graph and became wrong once op *k* consumed it — the result
+marks it `context_dependent`; that is the shape of #8599, and it points at
+how the runtime handles the pair, not at op *k*'s arithmetic. Run the bisect
+twice, at the default fp16 and with `enforce_f32=True`: a kernel bug
+reproduces at fp32 (#9272, the three entries below), fp16 accumulation loss
+does not (#9249).
+
+```python
+from litert_gpu_toolkit import check_gpu_compatibility, bisect_gpu_divergence
+
+report = check_gpu_compatibility("model.tflite", bisect=True)   # bisects every diverging signature
+r = bisect_gpu_divergence("model.tflite", signature_key="serving_default", enforce_f32=True)
+r["first_divergent_op"]   # {'index', 'name', 'version', 'inputs', 'outputs'} with shapes, dtypes, const flags
+r["diverging_tensors"]    # per tensor: max_abs_diff, scale, nonfinite, producer op, context_dependent
+r["probes"]               # every cut tried, in order
+```
+
+The report for `litert-community/efficientnet_b0` (LiteRT #9249):
+
+```
+  First divergent op: #8 SUM (v1) of 276 ops
+    inputs : float32[1, 112, 112, 32], int32[2] const
+    outputs: float32[1, 32]
+    prefix ending at op #7 matched CPU
+  Diverging tensors at that cut:
+    t189 ... float32[1, 32]: max abs diff 6.515e+01 (tensor scale 4.957e+04), 6 non-finite
+  Probes (9): #275:d, #137:d, #68:d, #33:d, #16:d, #7:c, #11:d, #9:d, #8:d
+```
+
+**Tests.** `tests/test_bisect.py` pins the bisect to three reported bugs and
+asserts it names the op the issue describes: a synthetic 5-op graph carrying
+the rank-3 `PAD` of #9272, a synthetic reduction and the public
+`efficientnet_b0` for the fp16 `SUM` overflow of #9249 (the NaN channels are
+checked to be exactly those whose CPU sum exceeds 65504), and the public
+SAM 2.1 mask decoder pair of #8619. GPU tests skip where no LiteRT GPU
+accelerator is available; the graph-analysis tests run anywhere.
+
+```sh
+pip install ai-edge-litert numpy pytest huggingface_hub   # huggingface_hub only for the public-model tests
+cd utilities && python -m pytest litert_gpu_toolkit/tests -v
+```
+
+## Results on litert-community's most-downloaded `.tflite` files
+
+<!-- sweep-results:start -->
+The 20 repositories under `litert-community` with the most downloads that
+publish a `.tflite` (Hub download counts, 2026-09-10), one file each: the
+smallest non-vendor float file, or the int8 file where the float one is over
+2 GiB, or the first transformer block of a multi-file pipeline. The four
+files the reported issues name are appended below the 20. Every file was
+run through `check_gpu_compatibility(bisect=True)` twice, at the default fp16
+GPU precision and with `enforce_f32`, on ai-edge-litert 2.2.0 (CompiledModel,
+Metal accelerator) on an Apple M4 Max, macOS 27.0. Inputs: uniform [0, 1)
+floats and random token ids in [0, 1000), seed 0; `rtol = atol = 1e-2`. Host
+GPU numbers — a phone can differ. A bisect of a 600–900 MB file takes 30–50
+minutes per precision (each probe rewrites and recompiles the prefix).
+
+Reading the two result columns: a cell that names an op is the first op
+whose GPU result differs from CPU beyond `rtol × tensor scale`; **op fp32**
+is the column that matters for a kernel fault. A file that diverges only at
+fp16 and matches at fp32 is losing fp16 precision, and the op named at fp16
+is where that loss first exceeds 1 % of the tensor's scale — `SUM` cells
+with a NaN count are the fp16 overflow of #9249.
+
+| # | model (litert-community) | file | MB | ops | GPU fp16 (default) | GPU fp32 (`enforce_f32`) |
+|---|---|---|---|---|---|---|
+| 1 | Qwen2.5-1.5B-Instruct | `Qwen2.5-1.5B-Instruct_seq128_q8_ekv1280.tflite` | 1571 | 1588 | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) |
+| 2 | DeepSeek-R1-Distill-Qwen-1.5B | `DeepSeek-R1-Distill-Qwen-1.5B_seq128_q8_ekv1280.tflite` | 1807 | 1588 | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) |
+| 3 | Phi-4-mini-instruct | `Phi-4-mini-instruct_seq128_q8_ekv1280.tflite` | 3871 |  | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) |
+| 4 | Qwen2.5-0.5B-Instruct | `Qwen2.5-0.5B-Instruct_seq128_q8_ekv1280.tflite` | 513 | 1360 | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) |
+| 5 | FLUX.2-klein-4B-LiteRT | `kc_double0.tflite` | 739 | 706 | op 56 `FULLY_CONNECTED` [1×256×3072, const 3072×3072] → 1×256×3072 (2% of scale) | op 204 `FULLY_CONNECTED` [1×256×3072, const 18432×3072] → 1×256×18432 (2% of scale) |
+| 6 | whisper-tiny | `whisper_tiny_30s_f32.tflite` | 151 | 82 | `encode`: op 14 `GELU` [1×384×1500] → 1×384×1500 (2% of scale); `decode`: op 94 `FULLY_CONNECTED` [128×384, const 384×384] → 128×384 (2% of scale) | match (max abs diff 7e-03) |
+| 7 | parakeet-tdt-0.6b-v3 | `parakeet_tdt_0.6b_v3_5s_i8.tflite` | 614 | 1790 | `encode`: op 6 `CONV_2D` [1×125×32×256, const 256×1×1×256] → 1×125×32×256 (2% of scale); `decode`: op 23 `SLICE` [64×1×2560] → 1×1×2560 (1% of scale) | `encode`: op 58 `CONV_2D` [1×63×1×1024, const 2048×1×1×1024] → 1×63×1×2048 (2% of scale); `decode`: op 79 `LOGISTIC` [1×1×640] → 1×1×640 (3% of scale) |
+| 8 | Bonsai-Image-ternary-4B | `vae_dec_fp32.tflite` | 199 | 882 | op 43 `MUL` [1×32×1×1, const 1×32×16×1] → 1×32×16×1 (100% of scale); op 35 `RESHAPE` output changes once this op is appended · some ops on CPU | match (max abs diff 2e-05) · some ops on CPU |
+| 9 | moonshine-tiny | `moonshine_tiny_5s_f32.tflite` | 109 | 358 | `encode`: op 77 `STABLEHLO_COMPOSITE` [1×207×8×40, 1×207×8×40, 1×207×8×40] → 1×207×8×40 (106% of scale); `decode`: fp16 noise only (within 1% of tensor scale) | `encode`: op 77 `STABLEHLO_COMPOSITE` [1×207×8×40, 1×207×8×40, 1×207×8×40] → 1×207×8×40 (106% of scale) |
+| 10 | Z-Image-Turbo-LiteRT | `zc_main0.tflite` | 908 | 815 | op 144 `FULLY_CONNECTED` [1×288×10240, const 3840×10240] → 1×288×3840, 2 NaN/Inf, 278 Inf where CPU exceeds fp16 range | op 139 `FULLY_CONNECTED` [1×288×3840, const 10240×3840] → 1×288×10240 (1% of scale) |
+| 11 | embeddinggemma-300m | `embeddinggemma-300M_seq256_mixed-precision.tflite` | 179 | 2265 | op 52 `SIN` [1×256×1×128] → 1×256×1×128 (12% of scale) | op 127 `MUL` [1×256×768, 1×256×1] → 1×256×768 (4% of scale) |
+| 12 | SmolLM-135M-Instruct | `SmolLM-135M-Instruct_seq128_f32_ekv1280.tflite` | 547 | 1702 | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) |
+| 13 | yolox-nano-litert | `yolox_nano.tflite` | 2 | 482 | op 18 `CONV_2D` [1×104×104×32, 16×1×1×32] → 1×104×104×16 (2% of scale) | match (max abs diff 2e-04) |
+| 14 | Gecko-110m-en | `Gecko_256_f32.tflite` | 443 | 633 | op 20 `MUL` [1×256] → 1×256, 34 NaN/Inf; Inf first at op 19 `SUM` · some ops on CPU | match (max abs diff 1e-07) · some ops on CPU |
+| 15 | Matcha-TTS | `matcha_decoder_fp16.tflite` | 23 | 1031 | op 77 `MUL` [1×8×32] → 1×8×32, 53 NaN/Inf; Inf first at op 76 `SUM` | op 161 `MUL` [512×1024, const 1×1×1024] → 1×512×1024 (93% of scale) |
+| 16 | Qwen3-TTS-12Hz-0.6B-Base | `codec_decoder_fp32.tflite` | 457 | 1023 | op 635 `GELU` [1×128×4096] → 1×128×4096 (1% of scale) · some ops on CPU | op 637 `MUL` [128×1024, const 1×1×1024] → 1×128×1024 (81% of scale) · some ops on CPU |
+| 17 | parakeet-ctc-0.6b | `parakeet_ctc_0.6b_5s_i8.tflite` | 596 | 1578 | **GPU compile failed**: kernel creation refused | **GPU compile failed**: kernel creation refused |
+| 18 | TinyLlama-1.1B-Chat-v1.0 | `TinyLlama-1.1B-Chat-v1.0_seq128_q8_ekv1280.tflite` | 1119 | 1246 | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) | **process crash** (SIGSEGV in CPU `DYNAMIC_UPDATE_SLICE` of the GPU\|CPU run) |
+| 19 | whisper-acft | `tiny/acft_whisper_tiny_30s_drq.tflite` | 61 | 322 | `decode`: op 30 `ADD` [6×128×128, const 1×1×128×128] → 1×6×128×128, 48768 Inf where CPU exceeds fp16 range; Inf first at op 30 `ADD`; `encode`: op 8 `CONV_2D` [1×1×3002×384, const 384×1×3×384] → 1×1×1500×384 (1% of scale) · some ops on CPU | `decode`: op 32 `SOFTMAX` [6×128×128] → 6×128×128 (99% of scale); `encode`: op 18 `MUL` [1×1500×384, 1×1500×384] → 1×1500×384 (1% of scale) · some ops on CPU |
+| 20 | Qwen3-ASR-0.6B | `qwen3_asr_0.6b_5s_i8.tflite` | 794 | 471 | `encode`: op 306 `STABLEHLO_COMPOSITE` [1×63×14×64, 1×63×14×64, 1×63×14×64] → 1×63×14×64, 832 NaN/Inf; `decode`: op 86 `MUL` [1×134×1024, 1×134×1] → 1×134×1024 (1% of scale) · some ops on CPU | `encode`: op 66 `FULLY_CONNECTED` [63×896, const 896×896] → 63×896 (2% of scale); `decode`: op 86 `MUL` [1×134×1024, 1×134×1] → 1×134×1024 (1% of scale) · some ops on CPU |
+| issue | efficientnet_b0 (#9249) | `efficientnet_b0.tflite` | 21 | 276 | op 8 `SUM` [1×112×112×32] → 1×32, 6 Inf where CPU exceeds fp16 range | match (max abs diff 4e-05) |
+| issue | SAM2.1-Hiera-Tiny-Mask-Decoder (#8619) | `sam2_tiny_mask_decoder_fp16.tflite` | 17 | 378 | op 41 `ADD` [4096×256, const 4096×256] → 4096×256 (92% of scale) | op 41 `ADD` [4096×256, const 4096×256] → 4096×256 (92% of scale) |
+| issue | SAM2.1-Hiera-Tiny-Mask-Decoder (#8619) | `sam2_tiny_mask_decoder_v2_fp16.tflite` | 17 | 425 | op 236 `FULLY_CONNECTED` [8×2048, 256×2048] → 8×256 (2% of scale) | match (max abs diff 6e-05) |
+| issue | PP-OCRv5-LiteRT (#9661) | `ppocr_rec_fp16.tflite` | 17 | 827 | op 310 `CONV_2D` [1×12×80×240, 240×1×1×240] → 1×12×80×240 (2% of scale) | op 705 `BATCH_MATMUL` [8×40×15, 8×15×40] → 8×40×40 (128% of scale) |
+
+What the table shows, and the controls behind each claim:
+
+- **Rank-2 activations against a constant are wrong on Metal, and it is
+  common.** Three of the files diverge at fp32 at an elementwise op whose
+  activation is rank 2 and whose other operand is a constant: the SAM 2.1
+  mask decoder v1 (`ADD([4096,256], [4096,256] const)`, three sites), the
+  Matcha-TTS decoder (`MUL([512,1024], [1,1,1024] const) -> [1,512,1024]`,
+  six sites) and the Qwen3-TTS codec decoder (same MUL shape family, two
+  sites). As single ops both forms reproduce (max abs diff 7.4 and 14 on
+  N(0,1) inputs) and the same op with the activation at rank 3 is bit-exact.
+  Reshaping the activation to `[1, N, C]` at only those sites takes each whole
+  model to CPU parity at fp32: SAM 2.1 v1 18.9 → 1.07e-4 (the rank-4 v2
+  export measures 1.07e-4), Matcha 3.9 → 1.3e-5, Qwen3-TTS codec 0.20 →
+  1.8e-6. For #8619 this means that on this backend the v1/v2 difference is
+  those three adds, not the attention rank; the Pixel 8a result in the issue
+  is not re-measured here.
+- **`BATCH_MATMUL` with output width 40 is wrong.** The PP-OCRv5 recognizer
+  (#9661's file, here on native Metal rather than WebGPU) first diverges at
+  fp32 at its attention scores `BATCH_MATMUL [8,40,15] × [8,15,40]`, and
+  moonshine-tiny's encoder at its `odml.scaled_dot_product_attention`
+  composite, whose decomposition holds `BATCH_MATMUL [8,207,207] × [8,207,40]`
+  (head dim 40). Single-op probes against numpy are wrong for N = 40 exactly
+  when M mod 64 is in 1…61 (M = 8, 40, 56, 65, 96, 207, 1000, 1025 wrong;
+  62, 63, 64, 128, 192, 256, 1024 right) and the batch is at least 2, at both
+  precisions; K does not matter (1…256), batch 1 is always right, and every
+  other N tried (4…36, 41, 44…264) is right. The mechanism is not known; the
+  extent stated is exactly the shapes probed.
+- **`SUM` overflows fp16 in three different places.** efficientnet_b0 (#9249:
+  6 of 32 channels, exactly those whose CPU sum exceeds 65504), the Matcha
+  decoder (the first `SUM` over `[1,8,32,512]`, tensor scale 6.4e4, 53 NaN in
+  the `MUL` that consumes it) and Gecko's LayerNorm variance `SUM` over
+  `[1,256,768]` (scale 6.4e4, 34 NaN in the next `MUL`) return NaN at fp16
+  and verify with `enforce_f32`. The report names the consumer and points
+  back at the `SUM` ("Inf first at op N"), because the `SUM`'s own Inf is
+  expected once the CPU total is past the fp16 range.
+- **embeddinggemma's fp16 output is all zeros; its first fp16 deviation is
+  the rotary `SIN`.** At fp16 the bisect stops at op 52, `SIN` of the
+  position angles (12 % of tensor scale), and the output ends all-zero. At fp32 the output is finite with cosine
+  0.989 against CPU and the first deviation above 1 % of tensor scale is
+  the RMSNorm `MUL` after the int4 `FULLY_CONNECTED` layers, the same
+  reference gap as the int8 files below (this export is int4/int8
+  mixed-precision) — no kernel fault is claimed. Qwen3-ASR's int8 encoder
+  behaves the same way at fp32 (first 1 % crossing at an int8
+  `FULLY_CONNECTED`), and at fp16 its `odml.scaled_dot_product_attention`
+  composite returns 832 NaN in an in-range output; the bisect does not open
+  composites.
+- **The LLM `_seq128_*_ekv1280` exports crash the process.** `Qwen2.5-1.5B-Instruct`,
+  `DeepSeek-R1-Distill-Qwen-1.5B`, `Phi-4-mini-instruct`, `Qwen2.5-0.5B-Instruct`
+  and `SmolLM-135M-Instruct` (MediaPipe-style exports, q8 and f32) do not compile GPU-only
+  (`CAST` int64, `GATHER_ND`, `GREATER_EQUAL`/`LESS_EQUAL` with const
+  inputs); the GPU|CPU compile succeeds with 57 ops on CPU, and the run then
+  segfaults in the CPU-resident `DYNAMIC_UPDATE_SLICE` on both signatures.
+  CPU-only runs of the same files pass. The bisect cannot start on them, and
+  Phi-4's 3.9 GB file is past the 2 GiB the flatbuffer writer can re-emit.
+- **On int8-weight files the CPU reference is the approximate side.** FLUX.2
+  klein (`kc_double0`) and Z-Image Turbo (`zc_main0`) first cross 1 % of
+  tensor scale at fp32 at an int8 `FULLY_CONNECTED`. Taken out as single ops
+  with their own weights (FLUX ops 56 and 204, Z-Image ops 139 and 144), the
+  GPU at fp32 is bit-identical to CPU float math on the dequantized weights
+  (max abs diff 0.0 on all four), while the CPU run of the same int8 op is
+  0.2–0.3 % off that float reference. A whole-model float-weight control was
+  not possible (the dequantized files exceed 2 GiB). At fp16 the same ops
+  are 1.2–2.9 % off float, and Z-Image's op 144
+  output reaches 6.6e4 on CPU, past the fp16 range, so its fp16 run returns
+  NaN from there. parakeet-tdt's int8 export crosses 1 % at an int8
+  `CONV_2D` in the encoder and at a `LOGISTIC`/`SLICE` fed by int8 layers in
+  the decoder, the same class. The DRQ whisper-acft file behaves the same
+  way (encoder within 3e-3 of a float-weight copy on a scale of 17 while the
+  CPU DRQ path is off by 14.6); its decoder disagrees between all three
+  references (at fp16 an unmasked attention logit differs by 74 % of scale
+  at the mask add, which its fp32 run does not show) and is not claimed.
+- **The Bonsai VAE decoder is wrong at fp16 inside its first GroupNorm.**
+  The whole decoder is off by 0.58 at fp16 and bit-exact at fp32. The bisect
+  pins it to the `[1,32,1,1]` chain that closes the first GroupNorm: the
+  per-channel mean (values 0.06–8.5, inside the fp16 range) reads back as
+  `-inf` in 26 of 32 channels and the `rsqrt(var) × gamma` product as all
+  zeros. Which op is named depends on how the mean is exposed: op 43 with
+  the RESHAPE copy, op 44 without it. No single-op repro was attempted.
+- **parakeet-ctc's int8 export is refused at kernel creation** with `Unable
+  to parse bc coord for BATCH axis ... shape {bhwc, {63, 1, 1, 1024}}`, the
+  same message as #9277 (reported on Mali). The shape matches the rank-2
+  `[63,1024]` activations of its attention projections' int8
+  `FULLY_CONNECTED` ops; the error does not name the op, so that attribution
+  is by shape. Nothing can be measured on it; the bisect cannot start.
+<!-- sweep-results:end -->
 
 ## What each patch is for
 
@@ -68,5 +313,5 @@ Two cautions that apply to all of them:
 
 ## Requirements
 
-`torch`, `litert-torch`, and `ai-edge-litert` (the checker verifies through
-the CompiledModel API).
+`torch` and `litert-torch` for the conversion patches; `numpy` and
+`ai-edge-litert` for the checker and the bisect (they run without torch).

--- a/utilities/litert_gpu_toolkit/__init__.py
+++ b/utilities/litert_gpu_toolkit/__init__.py
@@ -33,34 +33,52 @@ Opt-in patches (import from litert_gpu_toolkit.patches):
     patch_grid_sample, patch_safe_layernorm, patch_rmsnorm, patch_instance_norm,
     patch_maxpool_zeropad, patch_gelu(model, approximation="tanh"),
     pixelshuffle_to_conv_transpose.
+
+Post-conversion checks on any .tflite (no torch needed):
+    check_gpu_compatibility(path)      # GPU vs CPU, every signature
+    bisect_gpu_divergence(path)        # first op whose GPU result is wrong
 """
 
-from litert_gpu_toolkit.converter import convert_for_gpu
-from litert_gpu_toolkit.patches import (
-    SafeInstanceNorm2d,
-    SigmoidGELU,
-    TanhGELU,
-    ZeroPadMaxPool,
-    ZeroStuffConvT1d,
-    ZeroStuffConvT2d,
-    apply_all_patches,
-    hierarchical_mean,
-    patch_conv_transpose,
-    patch_gelu,
-    patch_grid_sample,
-    patch_instance_norm,
-    patch_maxpool_zeropad,
-    patch_rmsnorm,
-    patch_safe_layernorm,
-    pixelshuffle_to_conv_transpose,
-    safe_rms,
+from litert_gpu_toolkit.checker import (
+    bisect_gpu_divergence,
+    check_gpu_compatibility,
+    print_bisect_report,
+    print_report,
 )
-from litert_gpu_toolkit.checker import check_gpu_compatibility
+
+try:
+    from litert_gpu_toolkit.converter import convert_for_gpu
+    from litert_gpu_toolkit.patches import (
+        SafeInstanceNorm2d,
+        SigmoidGELU,
+        TanhGELU,
+        ZeroPadMaxPool,
+        ZeroStuffConvT1d,
+        ZeroStuffConvT2d,
+        apply_all_patches,
+        hierarchical_mean,
+        patch_conv_transpose,
+        patch_gelu,
+        patch_grid_sample,
+        patch_instance_norm,
+        patch_maxpool_zeropad,
+        patch_rmsnorm,
+        patch_safe_layernorm,
+        pixelshuffle_to_conv_transpose,
+        safe_rms,
+    )
+except ImportError:
+    # torch / litert-torch are not installed: the checker and the bisect
+    # still work on an existing .tflite (numpy + ai-edge-litert only).
+    pass
 
 __all__ = [
     "convert_for_gpu",
     "apply_all_patches",
     "check_gpu_compatibility",
+    "bisect_gpu_divergence",
+    "print_report",
+    "print_bisect_report",
     "SafeInstanceNorm2d",
     "SigmoidGELU",
     "TanhGELU",

--- a/utilities/litert_gpu_toolkit/checker.py
+++ b/utilities/litert_gpu_toolkit/checker.py
@@ -20,36 +20,90 @@ random inputs, and the outputs are compared against a CPU-compiled
 reference. When GPU compilation fails, the runtime's error message names
 the offending op — the patches table in the README maps the common ones
 to the rewrite that clears them.
+
+When compilation succeeds but the outputs disagree, nothing in the runtime
+names an op: the graph reports full residency and returns wrong numbers.
+`bisect_gpu_divergence` finds the op. It cuts the graph after op k (the
+prefix keeps ops 0..k and every tensor still live at the cut becomes a
+graph output), compiles the prefix on CPU and GPU, and binary-searches k
+for the first cut whose outputs disagree. The op at that cut is the first
+op whose result the GPU gets wrong.
+
+Command line:
+
+    python checker.py model.tflite            # verify (all signatures)
+    python checker.py model.tflite --bisect   # ... and bisect any divergence
+    python checker.py model.tflite --bisect --enforce-f32 --uniform --json out.json
+
+Only `numpy` and `ai-edge-litert` are needed to run this file directly.
 """
 
+import argparse
+import copy
+import json
 import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
 
 import numpy as np
 
 log = logging.getLogger("litert_gpu_toolkit")
 
 
+# --------------------------------------------------------------------------
+# Inputs, execution, comparison
+# --------------------------------------------------------------------------
+
 def _static_shape(shape) -> list:
     """Replace dynamic (-1/0) dims with 1 so buffers can be sized."""
     return [int(s) if int(s) > 0 else 1 for s in shape]
 
 
-def _random_inputs(input_details: dict, rng) -> dict:
+def _random_inputs(input_details: dict, rng, distribution: str = "normal",
+                   int_high: int = 0) -> dict:
     """Build random input arrays keyed by input name.
 
-    Floats get standard-normal noise; integer/bool inputs get zeros (random
-    ints could be out of range for index-like inputs).
+    Floats get standard-normal noise (or uniform [0, 1) with
+    `distribution="uniform"` — image models expect non-negative pixels, and
+    the fp16 reduction overflow of LiteRT #9249 only shows on such inputs).
+    Integer/bool inputs get zeros (random ints could be out of range for
+    index-like inputs); with `int_high > 0` integer inputs get uniform ids in
+    [0, int_high) instead, which a token-input model needs for its output to
+    depend on the computation at all.
     """
     inputs = {}
     for name, detail in input_details.items():
         shape = _static_shape(detail['shape'])
         dtype = np.dtype(detail['dtype'])
         if dtype.kind == 'f':
-            arr = rng.standard_normal(shape).astype(dtype)
+            if distribution == "uniform":
+                arr = rng.random(shape).astype(dtype)
+            else:
+                arr = rng.standard_normal(shape).astype(dtype)
+        elif dtype.kind in 'iu' and int_high > 0:
+            arr = rng.integers(0, int_high, size=shape).astype(dtype)
         else:
             arr = np.zeros(shape, dtype=dtype)
         inputs[name] = arr
     return inputs
+
+
+def _resolve_inputs(signature_key, input_details, inputs, rng, distribution,
+                    int_high: int = 0):
+    """Pick the caller's arrays for this signature, or generate random ones.
+
+    `inputs` may be `{signature_key: {name: array}}` or, for convenience,
+    a plain `{name: array}` that is used for every signature whose input
+    names it covers.
+    """
+    if inputs:
+        chosen = inputs.get(signature_key, inputs)
+        if all(name in chosen for name in input_details):
+            return {name: np.asarray(chosen[name]) for name in input_details}
+    return _random_inputs(input_details, rng, distribution, int_high)
 
 
 def _run_signature(model, signature_key: str, inputs: dict) -> dict:
@@ -74,11 +128,175 @@ def _run_signature(model, signature_key: str, inputs: dict) -> dict:
     return outputs
 
 
+def _compile(tflite_path: str, accel, enforce_f32: bool = False):
+    """Compile for an accelerator (GPU precision defaults to fp16)."""
+    from ai_edge_litert.compiled_model import CompiledModel
+    from ai_edge_litert.gpu_options import GpuOptions
+    from ai_edge_litert.options import Options
+    return CompiledModel.from_file(
+        tflite_path,
+        options=Options(hardware_accelerators=accel,
+                        gpu_options=GpuOptions(enforce_f32=enforce_f32)))
+
+
+_RUNTIME_REASON = re.compile(
+    r"(Failed to create DelegateKernel[^\n]*|Following operations are not supported[^\n]*"
+    r"|^(?!WARNING|INFO|ERROR|VERBOSE)[A-Z][A-Z_0-9]+: [^\n]*"
+    r"(not supported|Can't|Only support|Invalid|Expected|Unsupported|mismatch)[^\n]*"
+    r"|\d+ operations will run on the GPU[^\n]*)", re.M)
+
+
+class _CaptureStderr:
+    """Redirect fd 2 to a file for the block; the runtime logs there, not
+    to `sys.stderr`, and its compile-failure reason never reaches the Python
+    exception. `.reasons()` returns the lines that name ops or errors."""
+
+    def __enter__(self):
+        self.tmp = tempfile.TemporaryFile(mode="w+b")
+        sys.stderr.flush()
+        self.saved = os.dup(2)
+        os.dup2(self.tmp.fileno(), 2)
+        return self
+
+    def _read(self) -> str:
+        fd = self.tmp.fileno()
+        os.lseek(fd, 0, os.SEEK_SET)
+        chunks = []
+        while True:
+            chunk = os.read(fd, 1 << 16)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        os.lseek(fd, 0, os.SEEK_END)
+        return b"".join(chunks).decode(errors="replace")
+
+    def __exit__(self, *exc):
+        sys.stderr.flush()
+        os.dup2(self.saved, 2)
+        os.close(self.saved)
+        self.text = self._read()
+        self.tmp.close()
+        # Replay so the runtime's log stays visible when it was wanted.
+        if log.isEnabledFor(logging.DEBUG):
+            sys.stderr.write(self.text)
+        return False
+
+    def reasons(self) -> list:
+        seen = []
+        for m in _RUNTIME_REASON.finditer(self._read()):
+            line = m.group(0).strip()
+            if line not in seen:
+                seen.append(line)
+        return seen
+
+
+def _compile_gpu(tflite_path: str, enforce_f32: bool = False,
+                 allow_cpu_fallback: bool = True):
+    """GPU compile: strict GPU first, then GPU|CPU (partial delegation).
+
+    Returns (model, fallback_used, gpu_only_error). The runtime's own
+    reason (the op it rejected, the kernel it failed to create) is appended
+    to the error message and, on fallback, listed after the exception text.
+    """
+    from ai_edge_litert.hardware_accelerator import HardwareAccelerator
+    first_err = None
+    with _CaptureStderr() as cap:
+        try:
+            model = _compile(tflite_path, HardwareAccelerator.GPU, enforce_f32)
+            return model, False, None
+        except Exception as e:
+            reasons = cap.reasons()
+            first_err = RuntimeError(
+                f"{e}" + (": " + " | ".join(reasons) if reasons else ""))
+    if not allow_cpu_fallback:
+        raise first_err
+    with _CaptureStderr() as cap:
+        try:
+            model = _compile(
+                tflite_path, HardwareAccelerator.GPU | HardwareAccelerator.CPU,
+                enforce_f32)
+        except Exception as e:
+            reasons = cap.reasons()
+            raise RuntimeError(
+                f"{e}" + (": " + " | ".join(reasons) if reasons else "")) from None
+    return model, True, first_err
+
+
+FP16_MAX = 65504.0
+
+
+def _compare(ref: np.ndarray, got: np.ndarray, rtol: float, atol: float,
+             fp16_range: bool = False) -> dict:
+    """Compare a GPU tensor against its CPU reference.
+
+    Floats: `np.allclose(got, ref, rtol, atol)` with NaN==NaN, so a NaN the
+    CPU also produces is not a divergence. Integers/bools: exact equality.
+
+    `nonfinite` counts GPU NaN/Inf where the CPU value is finite. With
+    `fp16_range=True` (the GPU runs at fp16), those whose CPU value lies
+    outside the fp16 range (|x| > 65504) are expected — an additive mask of
+    -1e9 becomes -inf and a reduction past 65504 becomes inf — and only the
+    rest, `nonfinite_in_range`, fail the tensor-scale test.
+    """
+    ref = np.asarray(ref)
+    got = np.asarray(got)
+    stats = {
+        'ok': True, 'scale_ok': True, 'max_abs_diff': 0.0, 'max_rel_diff': 0.0,
+        'scale': 0.0, 'mismatch_fraction': 0.0, 'nonfinite': 0,
+        'nonfinite_in_range': 0,
+    }
+    if ref.shape != got.shape:
+        stats.update(ok=False, scale_ok=False, error=f"shape {got.shape} vs {ref.shape}")
+        return stats
+    if np.dtype(ref.dtype).kind == 'f':
+        r = ref.astype(np.float64)
+        g = got.astype(np.float64)
+        ref_finite = np.isfinite(r)
+        bad = ~np.isfinite(g) & ref_finite
+        stats['nonfinite'] = int(np.sum(bad))
+        stats['nonfinite_in_range'] = int(np.sum(bad & (np.abs(r) <= FP16_MAX))) \
+            if fp16_range else stats['nonfinite']
+        both = ref_finite & np.isfinite(g)
+        if np.any(both):
+            diff = np.abs(g[both] - r[both])
+            stats['max_abs_diff'] = float(diff.max())
+            stats['max_rel_diff'] = float(
+                (diff / np.maximum(np.abs(r[both]), 1e-12)).max())
+            stats['scale'] = float(np.abs(r[both]).max())
+        close = np.isclose(g, r, rtol=rtol, atol=atol, equal_nan=True)
+        stats['mismatch_fraction'] = float(1.0 - close.mean()) if close.size else 0.0
+        stats['ok'] = bool(close.all())
+        # Tensor-scale criterion: the worst element against the tensor's
+        # own magnitude. fp16 accumulation with cancellation leaves absolute
+        # errors of rtol x (partial-sum magnitude) on elements that end near
+        # zero, which the elementwise test flags on a correct kernel.
+        stats['scale_ok'] = bool(
+            stats['nonfinite_in_range'] == 0
+            and stats['max_abs_diff'] <= atol + rtol * stats['scale'])
+    else:
+        eq = (got == ref)
+        stats['mismatch_fraction'] = float(1.0 - eq.mean()) if eq.size else 0.0
+        stats['ok'] = bool(eq.all())
+        stats['scale_ok'] = stats['ok']
+    return stats
+
+
+# --------------------------------------------------------------------------
+# Whole-model verification
+# --------------------------------------------------------------------------
+
 def check_gpu_compatibility(
     tflite_path: str,
     rtol: float = 1e-2,
     atol: float = 1e-2,
     seed: int = 0,
+    inputs: dict = None,
+    input_distribution: str = "normal",
+    int_high: int = 0,
+    enforce_f32: bool = False,
+    bisect: bool = False,
+    bisect_criterion: str = "auto",
+    work_dir: str = None,
 ) -> dict:
     """Verify a TFLite model on the LiteRT CompiledModel GPU accelerator.
 
@@ -92,6 +310,19 @@ def check_gpu_compatibility(
         rtol/atol: Elementwise tolerances for the GPU-vs-CPU comparison
             (fp16 accumulation on GPU makes bit-exactness unrealistic).
         seed: Seed for the random inputs.
+        inputs: Optional `{signature_key: {input_name: array}}` (or a plain
+            `{input_name: array}`) to run instead of random inputs.
+        input_distribution: "normal" (default) or "uniform" for random floats.
+        int_high: When > 0, integer inputs get random ids in [0, int_high)
+            instead of zeros (token-input models).
+        enforce_f32: Ask the GPU accelerator for fp32 compute. Re-running a
+            divergent model with this on separates fp16 precision loss from
+            a wrong kernel: a kernel bug reproduces at fp32 too.
+        bisect: When a signature's outputs diverge, run
+            `bisect_gpu_divergence` on it and attach the result under
+            `result['bisect'][signature_key]`.
+        bisect_criterion: Passed to `bisect_gpu_divergence` as `criterion`.
+        work_dir: Scratch directory for the bisect's prefix models.
 
     Returns:
         dict with keys:
@@ -100,19 +331,22 @@ def check_gpu_compatibility(
             - 'gpu_compile_ok': bool
             - 'gpu_cpu_fallback': bool — GPU-only compile failed but GPU|CPU
               succeeded (some ops fell back to CPU)
+            - 'gpu_fully_accelerated': bool | None — the runtime's own
+              `is_fully_accelerated()` for the compiled model
             - 'numerics_ok': bool | None — None when the GPU run never happened
             - 'max_abs_diff': float | None — worst output element across signatures
             - 'signatures': dict of {signature_key: {'ran', 'max_abs_diff', 'error'}}
+            - 'bisect': dict of {signature_key: bisect result} (only with bisect=True)
             - 'errors': list of str
             - 'warnings': list of str
     """
-    from ai_edge_litert.compiled_model import CompiledModel
     from ai_edge_litert.hardware_accelerator import HardwareAccelerator
 
     result = {
         'compatible': False,
         'gpu_compile_ok': False,
         'gpu_cpu_fallback': False,
+        'gpu_fully_accelerated': None,
         'numerics_ok': None,
         'max_abs_diff': None,
         'signatures': {},
@@ -122,64 +356,60 @@ def check_gpu_compatibility(
 
     # CPU reference.
     try:
-        cpu_model = CompiledModel.from_file(
-            tflite_path, hardware_accel=HardwareAccelerator.CPU)
+        cpu_model = _compile(tflite_path, HardwareAccelerator.CPU)
     except Exception as e:
         result['errors'].append(f"CPU compile failed: {e}")
         log.warning(f"CPU compile failed — cannot verify: {e}")
         return result
 
     # GPU compile: strict GPU first, then GPU|CPU (partial delegation).
-    gpu_model = None
     try:
-        gpu_model = CompiledModel.from_file(
-            tflite_path, hardware_accel=HardwareAccelerator.GPU)
+        gpu_model, fallback, gpu_only_err = _compile_gpu(tflite_path, enforce_f32)
         result['gpu_compile_ok'] = True
-    except Exception as gpu_only_err:
         try:
-            gpu_model = CompiledModel.from_file(
-                tflite_path,
-                hardware_accel=HardwareAccelerator.GPU | HardwareAccelerator.CPU)
-            result['gpu_compile_ok'] = True
+            result['gpu_fully_accelerated'] = bool(gpu_model.is_fully_accelerated())
+        except Exception:
+            pass
+        if fallback:
             result['gpu_cpu_fallback'] = True
             result['warnings'].append(
                 f"GPU-only compile failed ({gpu_only_err}); "
                 f"compiled with CPU fallback instead"
             )
-        except Exception as e:
-            result['errors'].append(f"GPU compile failed: {e}")
-            log.warning(f"GPU compile failed: {e}")
-            return result
+    except Exception as e:
+        result['errors'].append(f"GPU compile failed: {e}")
+        log.warning(f"GPU compile failed: {e}")
+        return result
 
     # Run every signature on both accelerators and compare.
     rng = np.random.default_rng(seed)
     max_diff = 0.0
     all_ran = True
+    diverged = []
     for signature_key in list(cpu_model.get_signature_list()):
         sig_result = {'ran': False, 'max_abs_diff': None, 'error': None}
         try:
-            inputs = _random_inputs(
-                cpu_model.get_input_tensor_details(signature_key), rng)
-            cpu_out = _run_signature(cpu_model, signature_key, inputs)
-            gpu_out = _run_signature(gpu_model, signature_key, inputs)
+            sig_inputs = _resolve_inputs(
+                signature_key, cpu_model.get_input_tensor_details(signature_key),
+                inputs, rng, input_distribution, int_high)
+            cpu_out = _run_signature(cpu_model, signature_key, sig_inputs)
+            gpu_out = _run_signature(gpu_model, signature_key, sig_inputs)
             sig_diff = 0.0
             numerics_ok = True
+            nonfinite = 0
             for name, ref in cpu_out.items():
-                got = gpu_out[name]
-                if np.dtype(ref.dtype).kind == 'f':
-                    diff = float(np.max(np.abs(got.astype(np.float64)
-                                               - ref.astype(np.float64))))
-                    sig_diff = max(sig_diff, diff)
-                    if not np.allclose(got, ref, rtol=rtol, atol=atol):
-                        numerics_ok = False
-                elif not np.array_equal(got, ref):
-                    numerics_ok = False
-            sig_result.update(ran=True, max_abs_diff=sig_diff)
+                stats = _compare(ref, gpu_out[name], rtol, atol)
+                sig_diff = max(sig_diff, stats['max_abs_diff'])
+                nonfinite += stats['nonfinite']
+                numerics_ok = numerics_ok and stats['ok']
+            sig_result.update(ran=True, max_abs_diff=sig_diff, nonfinite=nonfinite)
             if not numerics_ok:
                 sig_result['error'] = (
-                    f"outputs diverge from CPU (max abs diff {sig_diff:.3e})")
+                    f"outputs diverge from CPU (max abs diff {sig_diff:.3e}"
+                    + (f", {nonfinite} non-finite" if nonfinite else "") + ")")
                 result['errors'].append(
                     f"Signature '{signature_key}': {sig_result['error']}")
+                diverged.append(signature_key)
             max_diff = max(max_diff, sig_diff)
         except Exception as e:
             all_ran = False
@@ -209,18 +439,31 @@ def check_gpu_compatibility(
     else:
         log.warning(f"GPU verification FAILED: {result['errors'][:3]}")
 
+    if bisect and diverged:
+        # Release the whole-model GPU compile before the prefix compiles.
+        del gpu_model, cpu_model
+        result['bisect'] = {}
+        for signature_key in diverged:
+            result['bisect'][signature_key] = bisect_gpu_divergence(
+                tflite_path, signature_key=signature_key, rtol=rtol, atol=atol,
+                seed=seed, inputs=inputs, input_distribution=input_distribution,
+                int_high=int_high, enforce_f32=enforce_f32,
+                criterion=bisect_criterion, work_dir=work_dir)
+
     return result
 
 
 def print_report(result: dict) -> None:
     """Print a human-readable GPU verification report."""
     print(f"\n{'=' * 60}")
-    print(f"  LiteRT CompiledModel GPU Verification Report")
+    print("  LiteRT CompiledModel GPU Verification Report")
     print(f"{'=' * 60}")
 
     if result['compatible']:
         residency = ("via GPU with CPU fallback" if result['gpu_cpu_fallback']
                      else "fully on GPU")
+        if result.get('gpu_fully_accelerated') is False and not result['gpu_cpu_fallback']:
+            residency = "GPU compile succeeded, runtime reports not fully accelerated"
         print(f"  Status: VERIFIED ({residency})")
         print(f"  Max abs diff vs CPU: {result['max_abs_diff']:.3e}")
     else:
@@ -229,7 +472,7 @@ def print_report(result: dict) -> None:
             print(f"    {err}")
 
     if result['signatures']:
-        print(f"\n  Signatures:")
+        print("\n  Signatures:")
         for key, sig in result['signatures'].items():
             if sig['ran'] and sig['error'] is None:
                 print(f"    {key}: OK (max abs diff {sig['max_abs_diff']:.3e})")
@@ -237,7 +480,648 @@ def print_report(result: dict) -> None:
                 print(f"    {key}: {sig['error']}")
 
     if result['warnings']:
-        print(f"\n  Warnings:")
+        print("\n  Warnings:")
         for w in result['warnings'][:10]:
             print(f"    {w}")
     print(f"{'=' * 60}\n")
+
+    for key, b in (result.get('bisect') or {}).items():
+        print_bisect_report(b)
+
+
+# --------------------------------------------------------------------------
+# Op-level bisect
+# --------------------------------------------------------------------------
+
+def _tensor_type_name(model_utils, tensor) -> str:
+    try:
+        return model_utils.type_to_name(tensor.type).lower()
+    except Exception:
+        return str(tensor.type)
+
+
+def _describe_tensor(model, sg, index: int, fu) -> dict:
+    t = sg.tensors[index]
+    name = t.name.decode(errors="replace") if isinstance(t.name, (bytes, bytearray)) else str(t.name or "")
+    buf = model.buffers[t.buffer] if t.buffer < len(model.buffers) else None
+    has_data = buf is not None and buf.data is not None and len(buf.data) > 0
+    return {
+        'index': int(index),
+        'name': name,
+        'shape': [int(d) for d in (t.shape if t.shape is not None else [])],
+        'dtype': _tensor_type_name(fu, t),
+        'constant': bool(has_data),
+    }
+
+
+def _describe_op(model, sg, op_index: int, fu) -> dict:
+    op = sg.operators[op_index]
+    code = model.operatorCodes[op.opcodeIndex]
+    name = fu.opcode_to_name(model, op.opcodeIndex)
+    return {
+        'index': int(op_index),
+        'name': name,
+        'version': int(code.version),
+        'inputs': [_describe_tensor(model, sg, t, fu) for t in op.inputs if t >= 0],
+        'outputs': [_describe_tensor(model, sg, t, fu) for t in op.outputs if t >= 0],
+    }
+
+
+def _constant_derived(model, sg) -> set:
+    """Tensors that hold weights: constants, or produced only from constants.
+
+    A weight-only quantized graph carries DEQUANTIZE ops whose input is a
+    constant; their outputs are weights too, and asking the GPU to emit a
+    weight as a graph output fails the run. They are not candidates for a
+    numerical fault either, so the bisect neither cuts at such ops nor
+    compares such tensors.
+    """
+    const = set()
+    for i, t in enumerate(sg.tensors):
+        buf = model.buffers[t.buffer] if t.buffer < len(model.buffers) else None
+        if buf is not None and buf.data is not None and len(buf.data) > 0:
+            const.add(i)
+    for op in sg.operators:
+        ins = [t for t in op.inputs if t >= 0]
+        if ins and all(t in const for t in ins):
+            const.update(t for t in op.outputs if t >= 0)
+    return const
+
+
+def _runtime_ops(sg, const: set) -> list:
+    """Indices of ops that consume at least one runtime tensor."""
+    return [i for i, op in enumerate(sg.operators)
+            if any(t >= 0 and t not in const for t in op.inputs)]
+
+
+def _frontier_tensors(sg, k: int, const: set = frozenset()) -> list:
+    """Tensors produced by ops 0..k that are still needed after the cut.
+
+    That is every tensor produced by an op at or before k which is consumed
+    by an op after k or is a graph output — plus op k's own outputs, so the
+    op at the cut is always observed. Weight-derived tensors (`const`) are
+    left out. Order follows producer order.
+    """
+    produced_by = {}
+    for i, op in enumerate(sg.operators[:k + 1]):
+        for t in op.outputs:
+            if t >= 0 and t not in const:
+                produced_by[t] = i
+    consumed_later = set()
+    for op in sg.operators[k + 1:]:
+        for t in op.inputs:
+            if t >= 0:
+                consumed_later.add(t)
+    graph_outputs = set(int(t) for t in sg.outputs)
+    cut_outputs = set(int(t) for t in sg.operators[k].outputs if t >= 0)
+    keep = [t for t in produced_by
+            if t in consumed_later or t in graph_outputs or t in cut_outputs]
+    return keep
+
+
+def _load_model(tflite_path: str):
+    from ai_edge_litert.tools import flatbuffer_utils as fu
+    return fu, fu.read_model(tflite_path)
+
+
+def _signature_subgraph(model, signature_key):
+    """Return (signature_def, subgraph_index) for a signature key."""
+    sigs = model.signatureDefs or []
+    if not sigs:
+        raise ValueError("model has no signature defs; bisect needs one")
+    if signature_key is None:
+        sd = sigs[0]
+    else:
+        wanted = signature_key.encode() if isinstance(signature_key, str) else signature_key
+        matches = [s for s in sigs if s.signatureKey == wanted]
+        if not matches:
+            raise ValueError(f"signature '{signature_key}' not in model")
+        sd = matches[0]
+    return sd, int(sd.subgraphIndex)
+
+
+def _write_prefix(fu, model, sg_index: int, sig_def, k: int, out_path: str,
+                  const: set = frozenset()) -> list:
+    """Write the model truncated after op k of `sg_index`; return frontier.
+
+    The truncated subgraph keeps ops 0..k, its inputs, and exposes every
+    frontier tensor as a graph output named `bisect_t<index>` in the
+    signature. Buffers (weights) are shared with the loaded model, not
+    copied. Returns [(tensor_index, output_name), ...].
+
+    A frontier tensor that some op inside the prefix consumes is exposed
+    through a RESHAPE copy rather than directly. Making such a tensor a
+    graph output would create the "output that is also consumed" pattern
+    of LiteRT #8599, which the Metal accelerator gets wrong on its own
+    (measured on 2.2.0: `ADD` output consumed by `SUM` reads back off by
+    3.85 at both precisions; through a same-shape RESHAPE it is exact), and
+    the bisect would then report a divergence it caused itself. Tensors
+    that were graph outputs in the original model keep their native wiring,
+    so a native #8599 case is still observed.
+    """
+    from ai_edge_litert import schema_py_generated as schema
+    sg = model.subgraphs[sg_index]
+    frontier = _frontier_tensors(sg, k, const)
+    native_outputs = set(int(t) for t in sg.outputs)
+    consumed_inside = set()
+    for op in sg.operators[:k + 1]:
+        consumed_inside.update(int(t) for t in op.inputs if t >= 0)
+
+    new_sg = copy.copy(sg)
+    new_sg.tensors = list(sg.tensors)
+    new_sg.operators = list(sg.operators[:k + 1])
+    new_buffers = list(model.buffers)
+    new_opcodes = list(model.operatorCodes)
+    reshape_code = None
+    for i, code in enumerate(new_opcodes):
+        if fu.get_builtin_code_from_operator_code(code) == schema.BuiltinOperator.RESHAPE:
+            reshape_code = i
+            break
+    outputs = []
+    named = []
+    for t in frontier:
+        t = int(t)
+        if t in consumed_inside and t not in native_outputs:
+            if reshape_code is None:
+                code = schema.OperatorCodeT()
+                code.builtinCode = schema.BuiltinOperator.RESHAPE
+                code.deprecatedBuiltinCode = schema.BuiltinOperator.RESHAPE
+                new_opcodes.append(code)
+                reshape_code = len(new_opcodes) - 1
+            src = sg.tensors[t]
+            shape = [int(d) for d in (src.shape if src.shape is not None else [])]
+            shape_buf = schema.BufferT()
+            shape_buf.data = np.frombuffer(
+                np.asarray(shape, np.int32).tobytes(), np.uint8)
+            new_buffers.append(shape_buf)
+            shape_t = schema.TensorT()
+            shape_t.name = f"bisect_shape{t}".encode()
+            shape_t.shape = [len(shape)]
+            shape_t.type = schema.TensorType.INT32
+            shape_t.buffer = len(new_buffers) - 1
+            new_sg.tensors.append(shape_t)
+            shape_idx = len(new_sg.tensors) - 1
+            copy_t = schema.TensorT()
+            copy_t.name = f"bisect_copy{t}".encode()
+            copy_t.shape = list(shape)
+            copy_t.type = src.type
+            copy_t.buffer = 0
+            copy_t.quantization = src.quantization
+            new_sg.tensors.append(copy_t)
+            copy_idx = len(new_sg.tensors) - 1
+            op = schema.OperatorT()
+            op.opcodeIndex = reshape_code
+            op.inputs = [t, shape_idx]
+            op.outputs = [copy_idx]
+            op.builtinOptionsType = schema.BuiltinOptions.ReshapeOptions
+            op.builtinOptions = schema.ReshapeOptionsT()
+            op.builtinOptions.newShape = list(shape)
+            new_sg.operators.append(op)
+            outputs.append(copy_idx)
+        else:
+            outputs.append(t)
+        tm = schema.TensorMapT()
+        tm.name = f"bisect_t{t}".encode()
+        tm.tensorIndex = outputs[-1]
+        named.append((t, f"bisect_t{t}", tm))
+    new_sg.outputs = outputs
+
+    new_sig = copy.copy(sig_def)
+    new_sig.outputs = [tm for _, _, tm in named]
+
+    new_model = copy.copy(model)
+    new_model.subgraphs = list(model.subgraphs)
+    new_model.subgraphs[sg_index] = new_sg
+    new_model.buffers = new_buffers
+    new_model.operatorCodes = new_opcodes
+    new_model.signatureDefs = [new_sig]
+    fu.write_model(new_model, out_path)
+    return [(t, name) for t, name, _ in named]
+
+
+def bisect_gpu_divergence(
+    tflite_path: str,
+    signature_key: str = None,
+    rtol: float = 1e-2,
+    atol: float = 1e-2,
+    seed: int = 0,
+    inputs: dict = None,
+    input_distribution: str = "normal",
+    int_high: int = 0,
+    enforce_f32: bool = False,
+    criterion: str = "auto",
+    work_dir: str = None,
+    max_probes: int = 64,
+) -> dict:
+    """Find the first op whose GPU result diverges from CPU.
+
+    The graph is cut after op k: the prefix keeps ops 0..k and every tensor
+    still live at the cut (consumed later, or a graph output, or produced
+    by op k) becomes a graph output. The prefix is compiled on CPU and on
+    GPU with the same inputs and the frontier tensors are compared. Binary
+    search over k finds the first cut that disagrees; the op at that cut
+    is the first op the GPU gets wrong.
+
+    Two things the result says explicitly, because they are what a bisect
+    can and cannot claim:
+
+    - The divergence is *first observed* at op k: the prefix ending one op
+      earlier matched CPU within tolerance. Later ops are not examined; a
+      graph may contain more than one wrong op.
+    - If the diverging frontier tensor was produced by an *earlier* op than
+      k — it was correct while it was the end of the graph and became wrong
+      once op k consumed it — the result marks it `context_dependent`. That
+      is the shape of LiteRT #8599 (an ADD that is both output and consumed
+      returns an operand), and it means the fault is in how the runtime
+      handles the pair, not in op k's arithmetic.
+
+    Args:
+        tflite_path: Path to the .tflite file.
+        signature_key: Signature to bisect (default: the model's first).
+        rtol/atol: Tolerances, same meaning as `check_gpu_compatibility`.
+        seed: Seed for random inputs.
+        inputs: Optional inputs, same form as `check_gpu_compatibility`.
+        input_distribution: "normal" or "uniform" random floats.
+        int_high: Random integer inputs in [0, int_high) when > 0 (else zeros).
+        enforce_f32: Ask the GPU for fp32 compute (see check_gpu_compatibility).
+        criterion: What counts as a diverging frontier tensor.
+            - "nonfinite": the GPU returns NaN/Inf where the CPU is finite.
+              Overflow bugs (LiteRT #9249) poison every op downstream, so
+              this is the symptom to chase when the final output is NaN.
+            - "scale": the worst element differs by more than
+              `atol + rtol * max|cpu|` of that tensor, or the GPU returns
+              NaN/Inf for a CPU value inside the fp16 range. This is the
+              default for finite divergences: intermediate tensors on a
+              fp16 GPU carry rtol-sized errors relative to the partial sums
+              that produced them, and an elementwise test flags those on a
+              correct kernel (efficientnet_b0's first CONV_2D fails
+              elementwise 1e-2 on Metal fp16 while the SUM eight ops later
+              is the real fault). At fp16, a GPU Inf where the CPU value is
+              itself beyond 65504 (an additive attention mask, a reduction
+              total) is recorded under `nonfinite_sightings` rather than
+              treated as the divergence, because the graph's own output was
+              finite — with `enforce_f32` every such value counts.
+            - "elementwise": `np.allclose(rtol, atol)`, the whole-model
+              check's own test. Strictest; use with enforce_f32.
+            - "auto": "nonfinite" if the full graph's GPU outputs contain
+              NaN/Inf, else "scale".
+        work_dir: Where prefix models are written (a temp dir by default,
+            removed afterwards).
+        max_probes: Safety cap on the number of prefix compiles.
+
+    Returns:
+        dict with keys:
+            - 'signature': str
+            - 'n_ops': int — ops in the signature's subgraph
+            - 'diverges': bool — the full graph's outputs differ from CPU
+            - 'first_divergent_op': dict | None — {'index', 'name', 'version',
+              'inputs', 'outputs'} of the op at the first diverging cut
+            - 'clean_prefix_end': int — last op index whose prefix matched
+              CPU (-1 if op 0 already diverges)
+            - 'diverging_tensors': list of {'tensor', 'name', 'shape', 'dtype',
+              'producer_op', 'producer_name', 'context_dependent',
+              'max_abs_diff', 'max_rel_diff', 'mismatch_fraction', 'nonfinite'}
+              at the first diverging cut
+            - 'probes': list of {'cut', 'status', 'max_abs_diff', 'nonfinite',
+              'fallback', 'fully_accelerated', 'error'} in the order run
+            - 'nonfinite_sightings': list of {'cut', 'tensor', 'producer_op',
+              'producer_name', 'nonfinite'} — frontier tensors where the GPU
+              returned NaN/Inf for CPU values beyond the fp16 range while the
+              graph's output stayed finite (fp16 runs only)
+            - 'enforce_f32': bool
+            - 'criterion': str — the criterion actually used
+            - 'errors': list of str
+    """
+    from ai_edge_litert.hardware_accelerator import HardwareAccelerator
+
+    if criterion not in ("auto", "nonfinite", "scale", "elementwise"):
+        raise ValueError(f"unknown criterion {criterion!r}")
+    result = {
+        'signature': signature_key,
+        'n_ops': None,
+        'diverges': None,
+        'first_divergent_op': None,
+        'clean_prefix_end': None,
+        'diverging_tensors': [],
+        'probes': [],
+        'nonfinite_sightings': [],
+        'enforce_f32': bool(enforce_f32),
+        'criterion': criterion,
+        'errors': [],
+    }
+
+    try:
+        fu, model = _load_model(tflite_path)
+        sig_def, sg_index = _signature_subgraph(model, signature_key)
+    except Exception as e:
+        result['errors'].append(f"cannot load model for bisect: {e}")
+        return result
+    signature_key = sig_def.signatureKey.decode()
+    result['signature'] = signature_key
+    sg = model.subgraphs[sg_index]
+    n_ops = len(sg.operators)
+    result['n_ops'] = n_ops
+    const = _constant_derived(model, sg)
+    candidates = _runtime_ops(sg, const)   # cut points, in graph order
+    if not candidates:
+        result['errors'].append("subgraph has no operators on runtime data")
+        return result
+
+    # Inputs come from the original model's signature, once.
+    try:
+        ref_model = _compile(tflite_path, HardwareAccelerator.CPU)
+        rng = np.random.default_rng(seed)
+        sig_inputs = _resolve_inputs(
+            signature_key, ref_model.get_input_tensor_details(signature_key),
+            inputs, rng, input_distribution, int_high)
+        del ref_model
+    except Exception as e:
+        result['errors'].append(f"CPU compile of the model failed: {e}")
+        return result
+
+    own_work_dir = work_dir is None
+    work_dir = work_dir or tempfile.mkdtemp(prefix="litert_bisect_")
+    os.makedirs(work_dir, exist_ok=True)
+
+    def probe(k: int) -> dict:
+        """Compile prefix 0..k on CPU and GPU, compare its frontier."""
+        rec = {'cut': int(k), 'status': None, 'max_abs_diff': 0.0,
+               'nonfinite': 0, 'fallback': False, 'fully_accelerated': None,
+               'error': None, 'tensors': []}
+        path = os.path.join(work_dir, f"prefix_{k:05d}.tflite")
+        try:
+            named = _write_prefix(fu, model, sg_index, sig_def, k, path, const)
+            cpu = _compile(path, HardwareAccelerator.CPU)
+            cpu_out = _run_signature(cpu, signature_key, sig_inputs)
+            del cpu
+            gpu, fallback, _ = _compile_gpu(path, enforce_f32)
+            rec['fallback'] = bool(fallback)
+            try:
+                rec['fully_accelerated'] = bool(gpu.is_fully_accelerated())
+            except Exception:
+                pass
+            gpu_out = _run_signature(gpu, signature_key, sig_inputs)
+            del gpu
+            diverged = False
+            for t_index, out_name in named:
+                stats = _compare(cpu_out[out_name], gpu_out[out_name], rtol, atol,
+                                 fp16_range=not enforce_f32)
+                rec['max_abs_diff'] = max(rec['max_abs_diff'], stats['max_abs_diff'])
+                rec['nonfinite'] += stats['nonfinite']
+                if (result['criterion'] == "scale"
+                        and stats['nonfinite'] > stats['nonfinite_in_range']):
+                    producer = next(
+                        (i for i, op in enumerate(sg.operators[:k + 1])
+                         if t_index in list(op.outputs)), None)
+                    result['nonfinite_sightings'].append({
+                        'cut': int(k), 'tensor': int(t_index),
+                        'producer_op': producer,
+                        'producer_name': (fu.opcode_to_name(
+                            model, sg.operators[producer].opcodeIndex)
+                            if producer is not None else None),
+                        'nonfinite': stats['nonfinite'] - stats['nonfinite_in_range']})
+                if result['criterion'] == "nonfinite":
+                    bad = stats['nonfinite'] > 0 or 'error' in stats
+                elif result['criterion'] == "elementwise":
+                    bad = not stats['ok']
+                else:
+                    bad = not stats['scale_ok']
+                if bad:
+                    diverged = True
+                    desc = _describe_tensor(model, sg, t_index, fu)
+                    producer = next(
+                        (i for i, op in enumerate(sg.operators[:k + 1])
+                         if t_index in list(op.outputs)), None)
+                    desc.update(
+                        tensor=t_index,
+                        producer_op=producer,
+                        producer_name=(fu.opcode_to_name(
+                            model, sg.operators[producer].opcodeIndex)
+                            if producer is not None else None),
+                        context_dependent=bool(producer is not None and producer != k),
+                        **{key: stats[key] for key in (
+                            'max_abs_diff', 'max_rel_diff', 'scale',
+                            'mismatch_fraction', 'nonfinite', 'nonfinite_in_range')})
+                    desc.pop('index', None)
+                    rec['tensors'].append(desc)
+            rec['status'] = 'diverged' if diverged else 'clean'
+        except Exception as e:
+            rec['status'] = 'error'
+            rec['error'] = str(e)
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+        log.info(
+            f"bisect cut {k}/{n_ops - 1} ({fu.opcode_to_name(model, sg.operators[k].opcodeIndex)}): "
+            f"{rec['status']} max abs diff {rec['max_abs_diff']:.3e}"
+            + (f" nonfinite {rec['nonfinite']}" if rec['nonfinite'] else "")
+            + (f" [{rec['error']}]" if rec['error'] else ""))
+        result['probes'].append({key: rec[key] for key in rec if key != 'tensors'})
+        return rec
+
+    def probe_near(pos: int, lo_pos: int, hi_pos: int):
+        """Probe candidates[pos]; on a compile/run error walk outward.
+
+        A prefix can fail to compile on the GPU for reasons of its own (the
+        Metal backend rejects some cuts with a shader type error), and such
+        cuts come in bands, so the walk doubles its step: +-1, +-2, +-4 ...
+        """
+        rec = probe(candidates[pos])
+        step = 1
+        while rec['status'] == 'error' and len(result['probes']) < max_probes:
+            near = [c for c in (pos + step, pos - step) if lo_pos < c < hi_pos]
+            if not near:
+                return rec
+            for c in near:
+                rec = probe(candidates[c])
+                if rec['status'] != 'error':
+                    break
+            step *= 2
+        return rec
+
+    try:
+        # The full graph must diverge, else there is nothing to bisect.
+        if criterion == "auto":
+            result['criterion'] = "scale"      # decided after the first probe
+        full = probe(candidates[-1])
+        if full['status'] == 'error':
+            result['errors'].append(f"full-graph probe failed: {full['error']}")
+            if os.path.getsize(tflite_path) >= 2 ** 31:
+                result['errors'].append(
+                    "the model is over 2 GiB: its weights use the buffer-offset "
+                    "layout, which the wheel's flatbuffer writer does not emit, so "
+                    "prefix models cannot be written")
+            return result
+        if criterion == "auto" and full['nonfinite'] > 0:
+            result['criterion'] = "nonfinite"
+            full['status'] = 'diverged'
+        result['diverges'] = full['status'] == 'diverged'
+        if not result['diverges']:
+            result['errors'].append(
+                f"full-graph frontier matches CPU under the '{result['criterion']}' "
+                f"criterion (max abs diff {full['max_abs_diff']:.3e}); nothing to bisect. "
+                "If check_gpu_compatibility reported a divergence, the elementwise "
+                "mismatch is within rtol of the tensor's scale — fp16 noise, not a "
+                "wrong kernel; confirm with enforce_f32=True or criterion='elementwise'.")
+            return result
+
+        # Binary search over positions in `candidates`:
+        # lo_pos is clean (or -1 = the empty prefix), hi_pos diverged.
+        lo_pos, hi_pos = -1, len(candidates) - 1
+        hi_rec = full
+        while hi_pos - lo_pos > 1 and len(result['probes']) < max_probes:
+            rec = probe_near((lo_pos + hi_pos) // 2, lo_pos, hi_pos)
+            if rec['status'] == 'error':
+                result['errors'].append(
+                    f"could not run any prefix between ops {candidates[lo_pos]} "
+                    f"and {candidates[hi_pos]}: {rec['error']}")
+                break
+            pos = candidates.index(rec['cut'])
+            if rec['status'] == 'diverged':
+                hi_pos, hi_rec = pos, rec
+            else:
+                lo_pos = pos
+
+        hi = candidates[hi_pos]
+        result['clean_prefix_end'] = candidates[lo_pos] if lo_pos >= 0 else -1
+        result['first_divergent_op'] = _describe_op(model, sg, hi, fu)
+        result['diverging_tensors'] = hi_rec['tensors']
+        failed = [p for p in result['probes'] if p['status'] == 'error']
+        if failed:
+            result['errors'].append(
+                f"{len(failed)} prefix cut(s) could not be compiled or run on the GPU "
+                f"(ops {min(p['cut'] for p in failed)}..{max(p['cut'] for p in failed)}; "
+                f"first error: {failed[0]['error'][:200]})")
+        if hi_pos - lo_pos > 1:
+            result['errors'].append(
+                f"bisect stopped early: ops {candidates[lo_pos + 1]}..{candidates[hi_pos - 1]} "
+                "were not probed")
+    finally:
+        if own_work_dir:
+            shutil.rmtree(work_dir, ignore_errors=True)
+    return result
+
+
+def print_bisect_report(result: dict) -> None:
+    """Print a human-readable bisect report."""
+    print(f"\n{'-' * 60}")
+    print(f"  GPU divergence bisect — signature '{result['signature']}'"
+          f" ({'fp32' if result.get('enforce_f32') else 'fp16'} GPU compute,"
+          f" criterion: {result.get('criterion')})")
+    print(f"{'-' * 60}")
+    op = result.get('first_divergent_op')
+    if op is None:
+        print("  No op isolated.")
+        for err in result['errors']:
+            print(f"    {err}")
+        print(f"{'-' * 60}\n")
+        return
+
+    def fmt(t):
+        c = " const" if t.get('constant') else ""
+        return f"{t['dtype']}{t['shape']}{c}"
+
+    print(f"  First divergent op: #{op['index']} {op['name']} (v{op['version']})"
+          f" of {result['n_ops']} ops")
+    print("    inputs : " + ", ".join(fmt(t) for t in op['inputs']))
+    print("    outputs: " + ", ".join(fmt(t) for t in op['outputs']))
+    print(f"    prefix ending at op #{result['clean_prefix_end']} matched CPU")
+    print("  Diverging tensors at that cut:")
+    for t in result['diverging_tensors']:
+        ctx = (f"  (produced by op #{t['producer_op']} {t['producer_name']};"
+               f" was correct before op #{op['index']} was appended)"
+               if t.get('context_dependent') else "")
+        nf_in = t.get('nonfinite_in_range', t.get('nonfinite', 0))
+        nf_out = t.get('nonfinite', 0) - nf_in
+        nf = (f", {nf_in} non-finite" if nf_in else "") + (
+            f", {nf_out} non-finite where CPU exceeds the fp16 range" if nf_out else "")
+        name = (t['name'] or '')[:60]
+        print(f"    t{t['tensor']} {name} {fmt(t)}: "
+              f"max abs diff {t['max_abs_diff']:.3e} (tensor scale {t.get('scale', 0):.3e}), "
+              f"{t['mismatch_fraction'] * 100:.1f}% outside elementwise tolerance{nf}{ctx}")
+    if any(p['fallback'] for p in result['probes']):
+        print("  Note: some prefixes needed CPU fallback to compile; the op at "
+              "those cuts may have run on CPU.")
+    sightings = result.get('nonfinite_sightings') or []
+    if sightings:
+        first = min(sightings, key=lambda x: x['cut'])
+        print(f"  Note: GPU NaN/Inf for CPU values beyond the fp16 range, first at "
+              f"op #{first['producer_op']} {first['producer_name']} "
+              f"({first['nonfinite']} values, cut #{first['cut']}); the graph output "
+              f"stayed finite. If the output is wrong from there, that op's fp16 "
+              f"accumulation is the cause (LiteRT #9249) — confirm with enforce_f32.")
+    print(f"  Probes ({len(result['probes'])}): " + ", ".join(
+        f"#{p['cut']}:{p['status'][0]}" for p in result['probes']))
+    for err in result['errors']:
+        print(f"    {err}")
+    print(f"{'-' * 60}\n")
+
+
+# --------------------------------------------------------------------------
+# Command line
+# --------------------------------------------------------------------------
+
+def _main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify a .tflite on the LiteRT CompiledModel GPU accelerator "
+                    "against CPU, and bisect the first divergent op.")
+    parser.add_argument("tflite")
+    parser.add_argument("--bisect", action="store_true",
+                        help="on divergence, isolate the first op whose GPU result differs")
+    parser.add_argument("--signature", default=None,
+                        help="bisect only this signature (default: every diverging one)")
+    parser.add_argument("--rtol", type=float, default=1e-2)
+    parser.add_argument("--atol", type=float, default=1e-2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--uniform", action="store_true",
+                        help="uniform [0,1) random float inputs instead of standard normal")
+    parser.add_argument("--int-high", type=int, default=0,
+                        help="random integer inputs in [0, N) instead of zeros (token ids)")
+    parser.add_argument("--inputs", default=None,
+                        help=".npz of input arrays keyed by input name")
+    parser.add_argument("--enforce-f32", action="store_true",
+                        help="ask the GPU accelerator for fp32 compute")
+    parser.add_argument("--criterion", default="auto",
+                        choices=["auto", "nonfinite", "scale", "elementwise"],
+                        help="what counts as a diverging tensor during the bisect")
+    parser.add_argument("--work-dir", default=None,
+                        help="keep prefix models here instead of a temp dir")
+    parser.add_argument("--json", default=None, help="write the result dict here")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
+                        format="%(name)s: %(message)s")
+    inputs = None
+    if args.inputs:
+        with np.load(args.inputs) as npz:
+            inputs = {k: npz[k] for k in npz.files}
+    distribution = "uniform" if args.uniform else "normal"
+
+    if args.bisect and args.signature:
+        result = bisect_gpu_divergence(
+            args.tflite, signature_key=args.signature, rtol=args.rtol, atol=args.atol,
+            seed=args.seed, inputs=inputs, input_distribution=distribution,
+            int_high=args.int_high, enforce_f32=args.enforce_f32,
+            criterion=args.criterion, work_dir=args.work_dir)
+        print_bisect_report(result)
+        ok = result.get('first_divergent_op') is None and result.get('diverges') is False
+    else:
+        result = check_gpu_compatibility(
+            args.tflite, rtol=args.rtol, atol=args.atol, seed=args.seed,
+            inputs=inputs, input_distribution=distribution, int_high=args.int_high,
+            enforce_f32=args.enforce_f32, bisect=args.bisect,
+            bisect_criterion=args.criterion, work_dir=args.work_dir)
+        print_report(result)
+        ok = result['compatible']
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(result, f, indent=1, default=str)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/utilities/litert_gpu_toolkit/tests/conftest.py
+++ b/utilities/litert_gpu_toolkit/tests/conftest.py
@@ -1,0 +1,57 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Test fixtures: put `utilities/` on the path, detect the GPU, fetch models."""
+
+import os
+import sys
+
+import pytest
+
+_UTILITIES = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _UTILITIES not in sys.path:
+    sys.path.insert(0, _UTILITIES)
+
+
+@pytest.fixture(scope="session")
+def gpu():
+    """Skip when the LiteRT GPU accelerator cannot compile a trivial graph."""
+    pytest.importorskip("ai_edge_litert")
+    from litert_gpu_toolkit.checker import _compile_gpu
+    from litert_gpu_toolkit.tests.graphs import GraphBuilder
+    import tempfile
+    g = GraphBuilder()
+    x = g.input("x", [1, 4])
+    g.outputs = [g.add(x, g.const("one", [1.0]), "y", [1, 4])]
+    path = os.path.join(tempfile.mkdtemp(), "probe.tflite")
+    g.build(path)
+    try:
+        _compile_gpu(path, allow_cpu_fallback=False)
+    except Exception as e:  # pragma: no cover - environment dependent
+        pytest.skip(f"no LiteRT GPU accelerator here: {e}")
+    return True
+
+
+@pytest.fixture(scope="session")
+def public_model():
+    """Download a litert-community file (skips when offline / no hub client)."""
+    hub = pytest.importorskip("huggingface_hub")
+
+    def fetch(repo: str, filename: str) -> str:
+        try:
+            return hub.hf_hub_download(f"litert-community/{repo}", filename)
+        except Exception as e:  # pragma: no cover - network dependent
+            pytest.skip(f"could not fetch {repo}/{filename}: {e}")
+
+    return fetch

--- a/utilities/litert_gpu_toolkit/tests/graphs.py
+++ b/utilities/litert_gpu_toolkit/tests/graphs.py
@@ -1,0 +1,216 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Small .tflite graphs written straight from the schema, no converter.
+
+The bisect tests need graphs whose faulty op is known in advance. Building
+them from the flatbuffer schema that ships in the ai-edge-litert wheel keeps
+the converter out of the loop, so a result cannot be a converter artifact.
+"""
+
+import numpy as np
+import flatbuffers
+from ai_edge_litert import schema_py_generated as tfl
+
+
+class GraphBuilder:
+    """Append tensors and ops; `build` writes a single-signature model."""
+
+    def __init__(self):
+        self.tensors = []
+        self.buffers = [tfl.BufferT()]      # buffer 0 is the empty buffer
+        self.ops = []
+        self.opcodes = []
+        self.inputs = []
+        self.outputs = []
+
+    def tensor(self, name, shape, ttype=tfl.TensorType.FLOAT32, data=None):
+        t = tfl.TensorT()
+        t.name = name.encode()
+        t.shape = list(shape)
+        t.type = ttype
+        if data is not None:
+            b = tfl.BufferT()
+            b.data = np.frombuffer(np.ascontiguousarray(data).tobytes(), np.uint8)
+            self.buffers.append(b)
+            t.buffer = len(self.buffers) - 1
+        else:
+            t.buffer = 0
+        self.tensors.append(t)
+        return len(self.tensors) - 1
+
+    def input(self, name, shape):
+        i = self.tensor(name, shape)
+        self.inputs.append(i)
+        return i
+
+    def const(self, name, array):
+        array = np.asarray(array, np.float32)
+        return self.tensor(name, array.shape, data=array)
+
+    def _opcode(self, builtin):
+        for i, c in enumerate(self.opcodes):
+            if c.builtinCode == builtin:
+                return i
+        c = tfl.OperatorCodeT()
+        c.builtinCode = builtin
+        c.deprecatedBuiltinCode = min(builtin, 127)
+        self.opcodes.append(c)
+        return len(self.opcodes) - 1
+
+    def op(self, builtin, inputs, out_name, out_shape, opts_type=None, opts=None):
+        o = self.tensor(out_name, out_shape)
+        op = tfl.OperatorT()
+        op.opcodeIndex = self._opcode(builtin)
+        op.inputs = list(inputs)
+        op.outputs = [o]
+        if opts_type is not None:
+            op.builtinOptionsType = opts_type
+            op.builtinOptions = opts
+        self.ops.append(op)
+        return o
+
+    def add(self, a, b, name, shape):
+        return self.op(tfl.BuiltinOperator.ADD, [a, b], name, shape,
+                       tfl.BuiltinOptions.AddOptions, tfl.AddOptionsT())
+
+    def mul(self, a, b, name, shape):
+        return self.op(tfl.BuiltinOperator.MUL, [a, b], name, shape,
+                       tfl.BuiltinOptions.MulOptions, tfl.MulOptionsT())
+
+    def pad(self, x, pads, name):
+        shape = self.tensors[x].shape
+        out = [d + before + after for d, (before, after) in zip(shape, pads)]
+        p = self.tensor(name + "_paddings", [len(shape), 2], tfl.TensorType.INT32,
+                        np.asarray(pads, np.int32))
+        return self.op(tfl.BuiltinOperator.PAD, [x, p], name, out,
+                       tfl.BuiltinOptions.PadOptions, tfl.PadOptionsT())
+
+    def sum(self, x, axes, name, keep_dims=False):
+        shape = self.tensors[x].shape
+        if keep_dims:
+            out = [1 if i in axes else d for i, d in enumerate(shape)]
+        else:
+            out = [d for i, d in enumerate(shape) if i not in axes]
+        a = self.tensor(name + "_axes", [len(axes)], tfl.TensorType.INT32,
+                        np.asarray(axes, np.int32))
+        o = tfl.ReducerOptionsT()
+        o.keepDims = keep_dims
+        return self.op(tfl.BuiltinOperator.SUM, [x, a], name, out,
+                       tfl.BuiltinOptions.ReducerOptions, o)
+
+    def sub(self, a, b, name, shape):
+        return self.op(tfl.BuiltinOperator.SUB, [a, b], name, shape,
+                       tfl.BuiltinOptions.SubOptions, tfl.SubOptionsT())
+
+    def build(self, path, signature="main"):
+        sub = tfl.SubGraphT()
+        sub.name = b"main"
+        sub.tensors = self.tensors
+        sub.inputs = self.inputs
+        sub.outputs = self.outputs
+        sub.operators = self.ops
+
+        def tensor_map(i):
+            m = tfl.TensorMapT()
+            m.name = self.tensors[i].name
+            m.tensorIndex = i
+            return m
+
+        sd = tfl.SignatureDefT()
+        sd.signatureKey = signature.encode()
+        sd.subgraphIndex = 0
+        sd.inputs = [tensor_map(i) for i in self.inputs]
+        sd.outputs = [tensor_map(i) for i in self.outputs]
+
+        m = tfl.ModelT()
+        m.version = 3
+        m.operatorCodes = self.opcodes
+        m.subgraphs = [sub]
+        m.buffers = self.buffers
+        m.signatureDefs = [sd]
+        m.description = b"litert_gpu_toolkit test graph"
+        b = flatbuffers.Builder(1024)
+        b.Finish(m.Pack(b), b"TFL3")
+        with open(path, "wb") as f:
+            f.write(b.Output())
+        return path
+
+
+def pad_rank3_graph(path):
+    """ADD, MUL, PAD(rank 3, middle axis), ADD, MUL — LiteRT #9272 at op 2.
+
+    The PAD pads a non-innermost axis of a rank-3 tensor, the exact shape
+    of the issue's self-contained repro (`[16, 32, 1] -> [16, 64, 1]`),
+    surrounded by elementwise ops that are correct on their own.
+    """
+    g = GraphBuilder()
+    x = g.input("x", [16, 32, 1])
+    one = g.const("one", [1.0])
+    two = g.const("two", [2.0])
+    a = g.add(x, one, "add1", [16, 32, 1])
+    m = g.mul(a, two, "mul1", [16, 32, 1])
+    p = g.pad(m, [(0, 0), (0, 32), (0, 0)], "pad_mid")
+    a2 = g.add(p, one, "add2", [16, 64, 1])
+    g.outputs = [g.mul(a2, two, "mul2", [16, 64, 1])]
+    return g.build(path)
+
+
+def sum_overflow_graph(path):
+    """MUL, SUM over HxW of [1,112,112,32], MUL — LiteRT #9249 at op 1.
+
+    With uniform [0, 1) input scaled by 40 the per-channel total is about
+    2.5e5, past the fp16 maximum of 65504, so a SUM that accumulates in
+    fp16 returns Inf and the graph output is NaN.
+    """
+    g = GraphBuilder()
+    x = g.input("x", [1, 112, 112, 32])
+    m = g.mul(x, g.const("gain", [40.0]), "mul1", [1, 112, 112, 32])
+    s = g.sum(m, [1, 2], "sum_hw")
+    g.outputs = [g.mul(s, g.const("scale", [0.001]), "scale", [1, 32])]
+    return g.build(path)
+
+
+def aliased_add_then_pad_graph(path):
+    """ADD, SUM(keep dims), SUB, PAD(rank 3, middle axis) — the PAD is the
+    only wrong op, at index 3.
+
+    The ADD output is consumed by the SUM and by the SUB, so the bisect's
+    cut after the SUM has to expose it while the SUM also reads it. Exposed
+    directly, that is the "output that is also consumed" pattern of LiteRT
+    #8599, which the Metal accelerator gets wrong by itself; the bisect
+    copies such tensors through a RESHAPE, so it must still name the PAD.
+    """
+    g = GraphBuilder()
+    x = g.input("x", [16, 32, 8])
+    y = g.input("y", [16, 32, 8])
+    t = g.add(x, y, "t", [16, 32, 8])
+    s = g.sum(t, [2], "s", keep_dims=True)
+    z = g.sub(t, s, "z", [16, 32, 8])
+    g.outputs = [g.pad(z, [(0, 0), (0, 32), (0, 0)], "pad_mid")]
+    return g.build(path)
+
+
+def native_aliased_add_graph(path):
+    """ADD whose output is a graph output *and* consumed by a SUM — LiteRT
+    #8599 as shipped in a model, at op 0. The bisect must report the ADD's
+    output as wrong once the SUM is appended, marked context_dependent.
+    """
+    g = GraphBuilder()
+    x = g.input("x", [1, 8, 256])
+    y = g.input("y", [1, 8, 256])
+    t = g.add(x, y, "t", [1, 8, 256])
+    s = g.sum(t, [2], "s")
+    g.outputs = [t, s]
+    return g.build(path)

--- a/utilities/litert_gpu_toolkit/tests/test_bisect.py
+++ b/utilities/litert_gpu_toolkit/tests/test_bisect.py
@@ -1,0 +1,223 @@
+# Copyright 2026 The Google AI Edge Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The bisect must name the op each reference issue describes.
+
+Three reproductions, each a GPU silent miscompute reported against LiteRT:
+
+- google-ai-edge/LiteRT#9272: a rank-3 PAD on a non-innermost axis returns
+  row-shifted data (precision is not a factor).
+- google-ai-edge/LiteRT#9249: SUM accumulates in fp16, so a reduction whose
+  total exceeds 65504 returns NaN — efficientnet_b0's first squeeze-excite
+  SUM over [1,112,112,32].
+- google-ai-edge/LiteRT#8619: the SAM 2.1 Hiera-Tiny mask decoder exported
+  with rank-2/rank-3 tensors miscomputes while the rank-4 export of the
+  same weights is correct.
+
+The first two run on synthetic graphs (no download) and, when the network
+allows, on the public models. Every GPU test skips where the LiteRT GPU
+accelerator is unavailable; the graph-analysis tests run anywhere.
+
+Run:  cd utilities && python -m pytest litert_gpu_toolkit/tests -v
+"""
+
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+pytest.importorskip("ai_edge_litert")
+
+from litert_gpu_toolkit import checker  # noqa: E402
+from litert_gpu_toolkit.tests.graphs import (  # noqa: E402
+    GraphBuilder, aliased_add_then_pad_graph, native_aliased_add_graph,
+    pad_rank3_graph, sum_overflow_graph)
+
+
+@pytest.fixture
+def tmp_tflite():
+    d = tempfile.mkdtemp(prefix="litert_bisect_test_")
+    return lambda name: os.path.join(d, name)
+
+
+# ---------------------------------------------------------------- graph analysis
+
+def test_frontier_and_constant_analysis(tmp_tflite):
+    """Cut bookkeeping on the PAD graph, no accelerator involved."""
+    fu, model = checker._load_model(pad_rank3_graph(tmp_tflite("pad.tflite")))
+    sg = model.subgraphs[0]
+    const = checker._constant_derived(model, sg)
+    names = lambda ts: [sg.tensors[t].name.decode() for t in ts]
+    assert "one" in names(const) and "pad_mid_paddings" in names(const)
+    assert checker._runtime_ops(sg, const) == [0, 1, 2, 3, 4]
+    # After op 1 only mul1's output is live; after op 2 only the PAD output.
+    assert names(checker._frontier_tensors(sg, 1, const)) == ["mul1"]
+    assert names(checker._frontier_tensors(sg, 2, const)) == ["pad_mid"]
+    # The final cut exposes the graph output.
+    assert names(checker._frontier_tensors(sg, 4, const)) == ["mul2"]
+
+
+def test_weight_only_ops_are_not_cut_points(tmp_tflite):
+    """A DEQUANTIZE of a constant is weight handling, not a candidate op."""
+    from ai_edge_litert import schema_py_generated as tfl
+    g = GraphBuilder()
+    x = g.input("x", [1, 4])
+    w16 = g.tensor("w16", [4, 4], tfl.TensorType.FLOAT16,
+                   np.eye(4, dtype=np.float16))
+    w = g.op(tfl.BuiltinOperator.DEQUANTIZE, [w16], "w", [4, 4],
+             tfl.BuiltinOptions.DequantizeOptions, tfl.DequantizeOptionsT())
+    fc = tfl.FullyConnectedOptionsT()
+    y = g.op(tfl.BuiltinOperator.FULLY_CONNECTED, [x, w, -1], "y", [1, 4],
+             tfl.BuiltinOptions.FullyConnectedOptions, fc)
+    g.outputs = [y]
+    fu, model = checker._load_model(g.build(tmp_tflite("wo.tflite")))
+    sg = model.subgraphs[0]
+    const = checker._constant_derived(model, sg)
+    assert w in const                      # dequantized weight is still a weight
+    assert checker._runtime_ops(sg, const) == [1]
+
+
+# ---------------------------------------------------------------- LiteRT #9272
+
+def test_pad_rank3_bisect_names_the_pad(gpu, tmp_tflite):
+    path = pad_rank3_graph(tmp_tflite("pad.tflite"))
+    for enforce_f32 in (False, True):      # "precision is not a factor"
+        r = checker.bisect_gpu_divergence(path, enforce_f32=enforce_f32)
+        assert r['diverges'] is True, r['errors']
+        op = r['first_divergent_op']
+        assert op['name'] == 'PAD' and op['index'] == 2
+        assert op['inputs'][0]['shape'] == [16, 32, 1]
+        assert op['outputs'][0]['shape'] == [16, 64, 1]
+        assert r['clean_prefix_end'] == 1
+        assert [t['tensor'] for t in r['diverging_tensors']] == [op['outputs'][0]['index']]
+        assert not r['diverging_tensors'][0]['context_dependent']
+
+
+def test_promoted_tensors_do_not_induce_issue_8599(gpu, tmp_tflite):
+    """A cut that exposes a tensor the prefix also consumes goes through a
+    RESHAPE copy; the bisect must name the PAD at op 3, not the SUM at op 1."""
+    path = aliased_add_then_pad_graph(tmp_tflite("alias_pad.tflite"))
+    fu, model = checker._load_model(path)
+    # The cut after the SUM exposes t (consumed by SUM and SUB) and s.
+    out = tmp_tflite("prefix1.tflite")
+    named = checker._write_prefix(fu, model, 0, model.signatureDefs[0], 1, out)
+    fu2, prefix = checker._load_model(out)
+    psg = prefix.subgraphs[0]
+    assert len(psg.operators) == 3                     # ADD, SUM, + one RESHAPE copy
+    assert fu2.opcode_to_name(prefix, psg.operators[-1].opcodeIndex) == "RESHAPE"
+    assert len(named) == 2                             # t and s
+    for enforce_f32 in (False, True):
+        r = checker.bisect_gpu_divergence(path, enforce_f32=enforce_f32)
+        assert r['diverges'] is True, r['errors']
+        assert r['first_divergent_op']['name'] == 'PAD'
+        assert r['first_divergent_op']['index'] == 3
+        assert r['clean_prefix_end'] == 2
+
+
+def test_native_output_also_consumed_is_context_dependent(gpu, tmp_tflite):
+    """LiteRT #8599 as shipped: the ADD output is a graph output and the SUM
+    reads it. On the Metal accelerator the output reads back wrong; the
+    bisect attributes it to the SUM being appended, with the ADD's tensor
+    marked context_dependent."""
+    path = native_aliased_add_graph(tmp_tflite("native_alias.tflite"))
+    r = checker.bisect_gpu_divergence(path, enforce_f32=True)
+    if not r['diverges']:
+        pytest.skip("this accelerator does not reproduce LiteRT #8599")
+    assert r['first_divergent_op']['name'] == 'SUM'
+    bad = r['diverging_tensors'][0]
+    assert bad['producer_name'] == 'ADD' and bad['context_dependent'] is True
+
+
+# ---------------------------------------------------------------- LiteRT #9249
+
+def test_sum_fp16_overflow_bisect_names_the_sum(gpu, tmp_tflite):
+    path = sum_overflow_graph(tmp_tflite("sum.tflite"))
+    r = checker.bisect_gpu_divergence(path, input_distribution="uniform")
+    assert r['diverges'] is True, r['errors']
+    assert r['criterion'] == 'nonfinite'
+    op = r['first_divergent_op']
+    assert op['name'] == 'SUM' and op['index'] == 1
+    assert op['inputs'][0]['shape'] == [1, 112, 112, 32]
+    assert op['outputs'][0]['shape'] == [1, 32]
+    assert r['diverging_tensors'][0]['nonfinite'] > 0
+    # The issue asks for fp32 accumulation; fp32 compute is the control.
+    ok = checker.check_gpu_compatibility(path, input_distribution="uniform",
+                                         enforce_f32=True)
+    assert ok['compatible'], ok['errors']
+
+
+def test_efficientnet_b0_issue_9249(gpu, public_model):
+    """The public model: the first SE SUM over [1,112,112,32] -> [1,32]."""
+    path = public_model("efficientnet_b0", "efficientnet_b0.tflite")
+    r = checker.check_gpu_compatibility(path, input_distribution="uniform",
+                                        bisect=True)
+    assert not r['compatible']
+    b = r['bisect']['serving_default']
+    op = b['first_divergent_op']
+    assert op['name'] == 'SUM'
+    assert op['inputs'][0]['shape'] == [1, 112, 112, 32]
+    assert op['outputs'][0]['shape'] == [1, 32]
+    bad = b['diverging_tensors'][0]
+    assert bad['nonfinite'] > 0
+
+    # The issue's claim: the NaN channels are exactly those whose true sum
+    # exceeds the fp16 maximum. Read that SUM on the CPU interpreter.
+    from ai_edge_litert.interpreter import Interpreter
+    itp = Interpreter(model_path=path, experimental_preserve_all_tensors=True)
+    itp.allocate_tensors()
+    inp = itp.get_input_details()[0]
+    rng = np.random.default_rng(0)
+    x = checker._random_inputs({inp['name']: inp}, rng, "uniform")[inp['name']]
+    itp.set_tensor(inp['index'], x)
+    itp.invoke()
+    cpu_sum = itp.get_tensor(op['outputs'][0]['index']).reshape(-1)
+    assert int((cpu_sum > 65504).sum()) == bad['nonfinite']
+
+
+# ---------------------------------------------------------------- LiteRT #8619
+
+def test_sam2_mask_decoder_issue_8619(gpu, public_model):
+    """v1 (rank-2/3 export) diverges, v2 (rank-4 export) does not.
+
+    On the macOS Metal accelerator the first wrong op in v1 is the ADD that
+    sums the flattened image embedding with its positional encoding at rank
+    2 (`[4096, 256] + const [4096, 256]`); v2 carries the same add at rank 3
+    and is correct. Both exports share weights and I/O.
+    """
+    v1 = public_model("SAM2.1-Hiera-Tiny-Mask-Decoder", "sam2_tiny_mask_decoder_fp16.tflite")
+    v2 = public_model("SAM2.1-Hiera-Tiny-Mask-Decoder", "sam2_tiny_mask_decoder_v2_fp16.tflite")
+    good = checker.check_gpu_compatibility(v2, enforce_f32=True)
+    assert good['compatible'], good['errors']
+
+    r = checker.check_gpu_compatibility(v1, enforce_f32=True, bisect=True)
+    assert not r['compatible']
+    op = r['bisect']['serving_default']['first_divergent_op']
+    assert op['name'] == 'ADD'
+    shapes = [tuple(t['shape']) for t in op['inputs']]
+    assert shapes == [(4096, 256), (4096, 256)]
+    assert [t['constant'] for t in op['inputs']] == [False, True]
+
+
+# ---------------------------------------------------------------- CLI
+
+def test_cli_json(gpu, tmp_tflite):
+    path = pad_rank3_graph(tmp_tflite("pad.tflite"))
+    out = tmp_tflite("report.json")
+    rc = checker._main([path, "--bisect", "--json", out])
+    assert rc == 1
+    with open(out) as f:
+        report = json.load(f)
+    assert report['bisect']['main']['first_divergent_op']['name'] == 'PAD'


### PR DESCRIPTION
## Op-level bisect for GPU silent miscomputes in `litert_gpu_toolkit`

I convert models for litert-community and ship them with the GPU accelerator on. The failure I keep hitting is a graph that compiles, reports full residency, and returns wrong numbers. Eight LiteRT reports of mine have that shape (#8593, #8599, #8619, #9249, #9272, #9523, #9661, #9662), and every one was located by hand: promote intermediate tensors to outputs, compare GPU against CPU, walk to the first tensor that disagrees. This PR makes that one command.

### What it adds

- `bisect_gpu_divergence()` in `checker.py`: cuts the graph after op *k*, exposes the tensors still live at the cut, compiles the prefix on CPU and GPU, and binary-searches *k*. It returns the first op whose GPU result is wrong, with shapes, dtypes and every probe. A 276-op graph needs 9 prefix compiles.
- `check_gpu_compatibility(bisect=True)` and `python checker.py model.tflite --bisect [--enforce-f32]`. The checker no longer needs torch.
- Tests that pin the bisect to reported bugs: it must name the rank-3 PAD of #9272, the fp16 SUM of #9249 (on `efficientnet_b0` too), and the ADD the SAM 2.1 mask decoder of #8619 gets wrong. Two more tests cover a trap the method itself sets: exposing a tensor the prefix also consumes creates the #8599 pattern, which Metal gets wrong on its own, so such tensors go through a RESHAPE copy.

### What it found

The README has the table: the 20 most-downloaded litert-community `.tflite` files on ai-edge-litert 2.2.0 / Metal, at fp16 and fp32, with a single-op and a whole-model control behind each claim. Three findings are new:

- SAM 2.1 mask decoder (#8619): the first wrong op is a rank-2 `ADD` of the flattened image embedding and its positional encoding. Lifting the three such adds to rank 3 takes the v1 export from 18.9 to 1.07e-4 vs CPU, the v2 figure. On Metal the v1/v2 difference is those adds, not the attention rank; the Pixel 8a result is not re-measured.
- `BATCH_MATMUL` with output width 40 is wrong when M mod 64 is in 1..61 and batch ≥ 2, at both precisions (the PP-OCRv5 recognizer of #9661 and moonshine-tiny hit it).
- `MUL` of a rank-2 activation by a `[1,1,C]` constant is wrong (the Matcha-TTS decoder of #9662, Qwen3-TTS); reshaping the activation to rank 3 restores CPU parity.

The table also says where the tool stops: on int8-weight files the single-op control puts the deviation on the CPU side (the GPU at fp32 is bit-exact to float math on the dequantized weights; the CPU run of the same int8 op is 0.2–0.3 % off), the MediaPipe-style LLM exports segfault in a CPU `DYNAMIC_UPDATE_SLICE` before any number is read, and files over 2 GiB cannot be rewritten by the wheel's flatbuffer utilities.

Host-GPU numbers only. If a different place for the tests or the table suits the repo better, I'll move them. Thanks for taking a look.

CI note: Python only, under `utilities/litert_gpu_toolkit/`; the Bazel C++ CI does not build it. `cd utilities && python -m pytest litert_gpu_toolkit/tests`, skipping without a GPU accelerator.
